### PR TITLE
[#77] Extended brushing logic to check for empty extent

### DIFF
--- a/src/coordinate-grid-chart.js
+++ b/src/coordinate-grid-chart.js
@@ -353,7 +353,7 @@ dc.coordinateGridChart = function(_chart) {
 
         _chart.redrawBrush(_g);
 
-        if(_brush.empty()){
+        if(_brush.empty() || !extent || extent[1] <= extent[0]){
             dc.events.trigger(function() {
                 _chart.filter(null);
                 dc.redrawAll(_chart.chartGroup());


### PR DESCRIPTION
I looked at the behavior of #77 in the debugger; it seems that the brush extent is set to a range where the start and end are equal, e.g. [0.2, 0.2].  I believe this commit fixes the issue.
