### PR TITLE
Linechart area rendered at the zero line

### DIFF
--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -9,6 +9,7 @@ dc.lineChart = function(parent, chartGroup) {
     var _chart = dc.stackableChart(dc.coordinateGridChart({}));
     var _renderArea = false;
     var _dotRadius = DEFAULT_DOT_RADIUS;
+    var _areaZeroLine = false;
 
     _chart.transitionDuration(500);
 
@@ -98,7 +99,13 @@ dc.lineChart = function(parent, chartGroup) {
             .y1(line.y())
             .y0(function(d, dataIndex) {
                 var groupIndex = this[dc.constants.GROUP_INDEX_NAME];
-                if (groupIndex == 0) return _chart.xAxisY() - AREA_BOTTOM_PADDING;
+                if (groupIndex == 0) {
+			if (_areaZeroLine) {
+				var chartDomain=_chart.y().domain(); 
+				return _chart.xAxisY()+chartDomain[0]*(_chart.xAxisY()-_chart.margins().top)/(chartDomain[1]-chartDomain[0]) + 1 - AREA_BOTTOM_PADDING;		
+			} else
+				return _chart.xAxisY() - AREA_BOTTOM_PADDING;
+		}
                 return _chart.getChartStack().getDataPoint(--groupIndex, dataIndex) - AREA_BOTTOM_PADDING;
             });
 
@@ -113,6 +120,12 @@ dc.lineChart = function(parent, chartGroup) {
         _renderArea = _;
         return _chart;
     };
+
+    _chart.renderAreaAtZeroLine = function(_) {
+        if (!arguments.length) return _areaZeroLine;
+        _areaZeroLine = _;
+        return _chart;
+    };	
 
     function drawDots(parentG, groupIndex) {
         var g = parentG.select("g." + TOOLTIP_G_CLASS);


### PR DESCRIPTION
Add an option in lineChart that allows drawing the area at the zero line instead from the bottom of the chart. Suitable for linecharts with negative values.
Before:
![a2](https://f.cloud.github.com/assets/952085/121807/207be188-6dfd-11e2-8efb-921d22423028.png)
After:
![a1](https://f.cloud.github.com/assets/952085/121808/2450062c-6dfd-11e2-95fc-14061df19c62.png)
