### PR TITLE
Extract method refactor of onClick

### DIFF
--- a/src/single-selection-chart.js
+++ b/src/single-selection-chart.js
@@ -41,17 +41,14 @@ dc.singleSelectionChart = function(_chart) {
 
     _chart.onClick = function(d) {
         var toFilter = _chart.keyAccessor()(d);
-        if (toFilter == _chart.filter()) {
-            dc.events.trigger(function() {
-                _chart.filter(null);
-                dc.redrawAll(_chart.chartGroup());
-            });
-        } else {
-            dc.events.trigger(function() {
-                _chart.filter(toFilter);
-                dc.redrawAll(_chart.chartGroup());
-            });
-        }
+        dc.events.trigger(function() {
+            _chart.filterTo(toFilter == _chart.filter() ? null : toFilter);
+        });
+    };
+
+    _chart.filterTo = function(toFilter) {
+        _chart.filter(toFilter);
+        dc.redrawAll(_chart.chartGroup());
     };
 
     return _chart;


### PR DESCRIPTION
The implementation of the two portions of the `if` statement were the same.  This pulls that into a common function that can be used directly to in case someone needs to programmatically set the filter values.

Note, `onClick` did not have any direct tests, so I wasn't sure how I should proceed with that.  All current tests still pass, so assuming they have adequate indirect coverage of `onClick`, this should be ok.
