### PR TITLE
No more flooding of global namespace. Now dc should be the only global variable added.

### DIFF
--- a/dc.js
+++ b/dc.js
@@ -28,7 +28,7 @@ dc = {
     _renderlet : null
 };
 
-dc.chartRegistry = function() {
+dc.chartRegistry = new function() {
     // chartGroup:string => charts:array
     var _chartMap = {};
 


### PR DESCRIPTION
Without using `new`, the `this` context is the global context
