### PR TITLE
Move the functions printSingleValue and isNegligible into the dc.utils namespace

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,18 +7,18 @@ dc.printers.filter = function (filter) {
     if (filter) {
         if (filter instanceof Array) {
             if (filter.length >= 2)
-                s = "[" + printSingleValue(filter[0]) + " -> " + printSingleValue(filter[1]) + "]";
+                s = "[" + dc.utils.printSingleValue(filter[0]) + " -> " + dc.utils.printSingleValue(filter[1]) + "]";
             else if (filter.length >= 1)
-                s = printSingleValue(filter[0]);
+                s = dc.utils.printSingleValue(filter[0]);
         } else {
-            s = printSingleValue(filter)
+            s = dc.utils.printSingleValue(filter)
         }
     }
 
     return s;
 };
 
-function printSingleValue(filter) {
+dc.utils.printSingleValue(filter) {
     var s = "" + filter;
 
     if (filter instanceof Date)
@@ -122,7 +122,7 @@ dc.utils.GroupStack = function () {
     };
 };
 
-function isNegligible(max) {
+dc.utils.isNegligible = function(max) {
     return max === undefined || (max < dc.constants.NEGLIGIBLE_NUMBER && max > -dc.constants.NEGLIGIBLE_NUMBER);
 }
 
@@ -130,7 +130,7 @@ dc.utils.groupMax = function (group, accessor) {
     var max = d3.max(group.all(), function (e) {
         return accessor(e);
     });
-    if (isNegligible(max)) max = 0;
+    if (dc.utils.isNegligible(max)) max = 0;
     return max;
 };
 
@@ -138,7 +138,7 @@ dc.utils.groupMin = function (group, accessor) {
     var min = d3.min(group.all(), function (e) {
         return accessor(e);
     });
-    if (isNegligible(min)) min = 0;
+    if (dc.utils.isNegligible(min)) min = 0;
     return min;
 };
 


### PR DESCRIPTION
...pace

Move the functions printSingleValue and isNegligible into the dc.utils namespace (don't pollute the global namespace).
