### PR TITLE
makes svg text non-selectable

### DIFF
--- a/test/dc.css
+++ b/test/dc.css
@@ -2,6 +2,17 @@
     float: left;
 }
 
+.dc-chart g text {
+	/* Makes it so the user can't accidentally click and select text that is meant as a label only */
+	-webkit-user-select: none; /* Chrome/Safari */        
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE10+ */
+	-o-user-select: none;
+    user-select: none;
+
+    pointer-events: none;
+}
+
 .dc-chart rect.bar {
     stroke: none;
     fill: steelblue;


### PR DESCRIPTION
A common pet peeve of mine with d3 is that when clicking around a chart, you'll often unintentionally select svg text, when really there is no need. So... I added some css so you can't actually click/select chart text. 

I'm going to see what I can do about getting mbostock on board with changing some of his examples, but I thought this was a good first step.

This especially improves usability on the rowchart, as you have to click on the actual bar and not the label in order to filter on it.
