### PR TITLE
PieChart sort on key is broken

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -19,7 +19,17 @@ dc.pieChart = function (parent, chartGroup) {
 
     function assemblePieData() {
         if (_slicesCap == Infinity) {
-            return _chart.orderedGroup().top(_slicesCap); // ordered by keys
+            var rows = _chart.group().all();
+            var sortedArray = [];
+            for(var i = 0; i<rows.length; i++) {
+                sortedArray.push(rows[i]);
+            }
+            sortedArray.sort(function(a,b) {
+               if(typeof a.key == "object") {
+                   return a.key.valueOf() > b.key.valueOf();
+               }
+               return a.key > b.key;
+            });
         } else {
             var topRows = _chart.group().top(_slicesCap); // ordered by value
             var topRowsSum = d3.sum(topRows, _chart.valueAccessor());


### PR DESCRIPTION
As the official demo shows it, the pie chart does not sort correctly its part by the key. "Q1" < "Q2" < "Q3" < "Q4" but not according to the chart.

The main reason is the call of the orderedGroup function, which assumes that the key value is provided when sorting a group, which is not the case.

Here is an attempt to correct it. A better version would include a way for the user to specify the sort function.
