### PR TITLE
support for elements as anchors

### DIFF
--- a/src/base-chart.js
+++ b/src/base-chart.js
@@ -125,6 +125,11 @@ dc.baseChart = function (_chart) {
         return _chart;
     };
 
+    _chart.anchorName = function () {
+        var anchor = this.anchor();
+        return _.isObject(anchor) ? anchor.id : _chart.anchor().replace('#', '');
+    };
+
     _chart.root = function (r) {
         if (!arguments.length) return _root;
         _root = r;
@@ -181,12 +186,12 @@ dc.baseChart = function (_chart) {
         _listeners.preRender(_chart);
 
         if (_dimension == null)
-            throw new dc.errors.InvalidStateException("Mandatory attribute chart.dimension is missing on chart["
-                + _chart.anchor() + "]");
+            throw new dc.errors.InvalidStateException("Mandatory attribute chart.dimension is missing on chart[#"
+                + _chart.anchorName() + "]");
 
         if (_group == null)
-            throw new dc.errors.InvalidStateException("Mandatory attribute chart.group is missing on chart["
-                + _chart.anchor() + "]");
+            throw new dc.errors.InvalidStateException("Mandatory attribute chart.group is missing on chart[#"
+                + _chart.anchorName() + "]");
 
         var result = _chart.doRender();
 

--- a/src/coordinate-grid-chart.js
+++ b/src/coordinate-grid-chart.js
@@ -510,7 +510,7 @@ dc.coordinateGridChart = function (_chart) {
     };
 
     function getClipPathId() {
-        return _chart.anchor().replace('#', '') + "-clip";
+        return _chart.anchorName() + "-clip";
     }
 
     _chart.clipPadding = function (p) {
@@ -533,8 +533,8 @@ dc.coordinateGridChart = function (_chart) {
 
     _chart.doRender = function () {
         if (_x == null)
-            throw new dc.errors.InvalidStateException("Mandatory attribute chart.x is missing on chart["
-                + _chart.anchor() + "]");
+            throw new dc.errors.InvalidStateException("Mandatory attribute chart.x is missing on chart[#"
+                + _chart.anchorName() + "]");
 
         _chart.resetSvg();
 


### PR DESCRIPTION
jQuery is okay with an element object being used as a selector.  This patch allows dc.js to work with elements as well as '#id' selectors, instead of assuming that the selector is a string.

This in turn allows one to create dc.js plots "offscreen" and then add them to the document DOM once they are complete.  We are successfully using this patch (against 1.4) in cscheid/rcloud.

I am not sure if there is a performance gain but it is helpful when creating visualizations dynamically to build up the dc plot and then paste it in whole, rather than having to create the div, wait for it to be rendered, and then attach it to dc.js.

Cheers,
Gordon
