### PR TITLE
Fix for issue #250 ordinal bar chart does not render when first two bars are empty

### DIFF
--- a/dc.js
+++ b/dc.js
@@ -1804,7 +1804,7 @@ dc.stackableChart = function (_chart) {
 
             _chart.stackLayers().forEach(function (e) {
                 e.points.forEach(function (p) {
-                    if (p.x >= xDomain[0] && p.x <= xDomain[1])
+                    if (p.x >= xDomain[0] && p.x <= xDomain[xDomain.length-1])
                         all.push(p);
                 });
             });

--- a/src/stackable-chart.js
+++ b/src/stackable-chart.js
@@ -95,7 +95,7 @@ dc.stackableChart = function (_chart) {
 
             _chart.stackLayers().forEach(function (e) {
                 e.points.forEach(function (p) {
-                    if (p.x >= xDomain[0] && p.x <= xDomain[1])
+                    if (p.x >= xDomain[0] && p.x <= xDomain[xDomain.length-1])
                         all.push(p);
                 });
             });


### PR DESCRIPTION
Change to flattenStack() function, to use first and last value of domain instead of assuming that domain array only contains two items.

See issue #250
