### PR TITLE
fixes spelling in css strok -> stroke

### DIFF
--- a/dc.css
+++ b/dc.css
@@ -43,7 +43,7 @@
 }
 
 .dc-chart .deselected path {
-    strok: none;
+    stroke: none;
     fill-opacity: .5;
     fill: #ccc;
 }
@@ -122,7 +122,7 @@
 }
 
 .dc-chart .deselected circle {
-    strok: none;
+    stroke: none;
     fill-opacity: .5;
     fill: #ccc;
 }

--- a/web/css/dc.css
+++ b/web/css/dc.css
@@ -43,7 +43,7 @@
 }
 
 .dc-chart .deselected path {
-    strok: none;
+    stroke: none;
     fill-opacity: .5;
     fill: #ccc;
 }
@@ -122,7 +122,7 @@
 }
 
 .dc-chart .deselected circle {
-    strok: none;
+    stroke: none;
     fill-opacity: .5;
     fill: #ccc;
 }


### PR DESCRIPTION
Same spelling mistake as issue 255, strok when it should have been stroke.  
Fixed in both src and css for web example.
