### PR TITLE
deregisterAllCharts with an optional group (like filterAll and renderAll...)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -80,8 +80,12 @@ dc.chartRegistry = function() {
             _chartMap[group].push(chart);
         },
 
-        clear: function() {
-            _chartMap = {};
+        clear: function(group) {
+            if (group) {
+                delete _chartMap[group];
+            } else {
+                _chartMap = {};
+            }
         },
 
         list: function(group) {
@@ -99,8 +103,8 @@ dc.hasChart = function(chart) {
     return dc.chartRegistry.has(chart);
 };
 
-dc.deregisterAllCharts = function() {
-    dc.chartRegistry.clear();
+dc.deregisterAllCharts = function(group) {
+    dc.chartRegistry.clear(group);
 };
 
 /**


### PR DESCRIPTION
As for the default group, one user does not need to specify the group.
It will deregister really all charts but that should be fine if the user is not aware of what is a group.

I only changed this file and it should be changed also for the big dc file and the big minified file.
