### PR TITLE
Add a grunt merge task

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "uglify-js": "2.4.x",
     "vows": "0.7.x",
     "grunt-docco2": "~0.1.5",
-    "grunt-cli": "~0.1.9"
+    "grunt-cli": "~0.1.9",
+    "grunt-shell": "~0.5.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Fixes #345 

@NickQiZhu @gordonwoodhull Does this work for you guys?

Sadly, I don't think we can bootstrap the merge of this feature.

To run: `grunt merge:PR#` like `grunt merge:356`
