### PR TITLE
Composite chart legend names bugfix

### DIFF
--- a/src/base-chart.js
+++ b/src/base-chart.js
@@ -162,7 +162,7 @@ dc.baseChart = function (_chart) {
     //    chart (in referenced by multiple charts) ->
     //        array of accessors, array of names
     function groupName(chart, g, accessor) {
-        var c = chart.anchor(),
+        var c = chart.chartID(),
             k = '__names__';
         if (!accessor || accessor == chart.valueAccessor())
             accessor = "default";

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -34,7 +34,8 @@ dc.compositeChart = function (parent, chartGroup) {
     var _chart = dc.coordinateGridChart({});
     var _children = [];
 
-    var _shareColors = false;
+    var _shareColors = false,
+        _shareTitle = true;
 
     _chart._mandatoryAttributes([]);
     _chart.transitionDuration(500);
@@ -126,7 +127,10 @@ dc.compositeChart = function (parent, chartGroup) {
             child.height(_chart.height());
             child.width(_chart.width());
             child.margins(_chart.margins());
-            child.title(_chart.title());
+
+            if (_shareTitle) {
+                child.title(_chart.title());
+            }
 
             if (_shareColors && child.colorAccessor() === child._layerColorAccessor)
                 child.colorCalculator(function() {return child.colors()(i);});
@@ -149,6 +153,17 @@ dc.compositeChart = function (parent, chartGroup) {
     _chart.shareColors = function (_) {
         if (!arguments.length) return _shareColors;
         _shareColors = _;
+        return _chart;
+    };
+
+    /**
+     #### .shareTitle([[boolean])
+     Get or set title sharing for the chart. If set, the `.title()` value from this chart
+     will be shared with composed children. Default value is true.
+     **/
+    _chart.shareTitle = function (_) {
+        if (!arguments.length) return _shareTitle;
+        _shareTitle = _;
         return _chart;
     };
 

--- a/test/legend-test.js
+++ b/test/legend-test.js
@@ -37,6 +37,43 @@ function buildLineChart(id, xdomain) {
     return chart;
 }
 
+function buildCompositeChart(id, xdomain) {
+    if(xdomain === undefined)
+        xdomain = [new Date(2012, 0, 1), new Date(2012, 11, 31)];
+
+    var dimension = statusGroup;
+    var group = statusMultiGroup;
+
+    d3.select("body").append("div").attr("id", id);
+    var chart = dc.compositeChart("#" + id);
+    chart
+        .dimension(dimension)
+        .width(500)
+        .height(180)
+        .x(d3.time.scale().domain(xdomain))
+        .transitionDuration(0)
+        .xUnits(d3.time.days)
+
+        .legend(dc.legend().x(400).y(10).itemHeight(13).gap(5))
+        .brushOn(false)
+
+        .compose([
+            dc.lineChart(chart)
+                .group(group, "Series 1")
+                .valueAccessor(function (d) {
+                    return d.value.count;
+                }),
+            dc.lineChart(chart)
+                .group(group, "Series 2")
+                .valueAccessor(function (d) {
+                    return d.value.value;
+                })
+        ]);
+
+    chart.render();
+    return chart;
+}
+
 function legend(chart) {
     return chart.select("g.dc-legend");
 }
@@ -93,6 +130,22 @@ suite.addBatch({
             assert.equal("Id Sum", d3.select(legendLabels(chart)[0][0]).text());
             assert.equal("Value Sum", d3.select(legendLabels(chart)[0][1]).text());
             assert.equal("Fixed", d3.select(legendLabels(chart)[0][2]).text());
+        },
+        teardown: function (topic) {
+            resetAllFilters();
+            resetBody();
+        }
+    }
+});
+
+suite.addBatch({
+    'composite chart legend when one crossfilter group is shared between 2+ sub charts': {
+        topic: function () {
+            return buildCompositeChart("legend-composite-chart");
+        },
+        'should generate legend labels correctly': function (chart) {
+            assert.equal("Series 1", d3.select(legendLabels(chart)[0][0]).text());
+            assert.equal("Series 2", d3.select(legendLabels(chart)[0][1]).text());
         },
         teardown: function (topic) {
             resetAllFilters();


### PR DESCRIPTION
Hi, Nick!
You're doing a great job making such a cool library!
I found a little bug in composite chart legend behaviour.
When one crossfilter group is shared between 2+ sub charts with custom valueAccessor, title of only one series will be displayed on the legend and undefined values in the sub charts tooltip.

Code with problem before fix: http://jsfiddle.net/68BUX/1/
Code after fix: http://jsfiddle.net/7j2vc/2/
