### PR TITLE
Add min height and width

### DIFF
--- a/src/base-chart.js
+++ b/src/base-chart.js
@@ -14,13 +14,17 @@ dc.baseChart = function (_chart) {
     var _root;
     var _svg;
 
+    var _minWidth = 200;
     var _default_width = function (element) {
-        return element && element.getBoundingClientRect && element.getBoundingClientRect().width || 200;
+        var width = element && element.getBoundingClientRect && element.getBoundingClientRect().width;
+        return (width && width > _minWidth) ? width : _minWidth;
     };
     var _width = _default_width;
 
+    var _minHeight = 200;
     var _default_height = function (element) {
-        return element && element.getBoundingClientRect && element.getBoundingClientRect().height || 200;
+        var height = element && element.getBoundingClientRect && element.getBoundingClientRect().height;
+        return (height && height > _minHeight) ? height : _minHeight;
     };
     var _height = _default_height;
 
@@ -112,6 +116,28 @@ dc.baseChart = function (_chart) {
     _chart.height = function (h) {
         if (!arguments.length) return _height(_root.node());
         _height = d3.functor(h || _default_height);
+        return _chart;
+    };
+
+    /**
+    #### .minWidth([value])
+    Set or get minimum width attribute of a chart. This only applicable if the width is calculated by DC.
+
+    **/
+    _chart.minWidth = function (w) {
+        if (!arguments.length) return _minWidth;
+        _minWidth = w;
+        return _chart;
+    };
+
+    /**
+    #### .minHeight([value])
+    Set or get minimum height attribute of a chart. This only applicable if the height is calculated by DC.
+
+    **/
+    _chart.minHeight = function (w) {
+        if (!arguments.length) return _minHeight;
+        _minHeight = w;
         return _chart;
     };
 

--- a/test/base-chart-test.js
+++ b/test/base-chart-test.js
@@ -195,7 +195,8 @@ suite.addBatch({
     'calculation of dimensions': {
         topic: function () {
             d3.select("body").append("div").attr("id", "ele");
-            return dc.baseChart({}).anchor('#ele').dimension(valueDimension).group(valueGroup);
+            chart = dc.baseChart({}).anchor('#ele');
+            return chart.dimension(valueDimension).group(valueGroup).minWidth(100);
         },
 
         'set automatically': function (chart) {
@@ -203,7 +204,7 @@ suite.addBatch({
             chart.width(null);
             chart.render();
             assert.equal(chart.height(), 200);
-            assert.equal(chart.width(), 200);
+            assert.equal(chart.width(), 100);
         },
 
         'set to a specific number': function (chart) {


### PR DESCRIPTION
When omitting the height or width to have dc auto-size the charts, you have sizes that are smaller than the margins. This will result in negative lengths passed to d3 attribute calls, which in turn fail. We already have a default case when the sizes are 0, to use 200 instead. This patch extends that notion, such that any value less than the minimum is raised to the min and exposes the getter/setters.  
