### PR TITLE
Use RangeBands for Ordinal Coordinate Grid Charts

### DIFF
--- a/src/coordinate-grid-chart.js
+++ b/src/coordinate-grid-chart.js
@@ -56,9 +56,11 @@ dc.coordinateGridChart = function (_chart) {
     var _mouseZoomable = false;
     var _clipPadding = 0;
 
+    var _outerRangeBandPadding = 0.5;
+    var _rangeBandPadding = 0;
+
     _chart.rescale = function () {
         _unitCount = undefined;
-        _chart.xUnitCount();
     };
 
     /**
@@ -271,19 +273,6 @@ dc.coordinateGridChart = function (_chart) {
         return _chart.xUnits() === dc.units.ordinal;
     };
 
-    _chart.prepareOrdinalXAxis = function (count) {
-        if (!count)
-            count = _chart.xUnitCount();
-        var range = [];
-        var increment = _chart.xAxisLength() / (count + 1);
-        var currentPosition = increment/2;
-        for (var i = 0; i < count; i++) {
-            range[i] = currentPosition;
-            currentPosition += increment;
-        }
-        _x.range(range);
-    };
-
     function prepareXAxis(g) {
         if (_chart.elasticX() && !_chart.isOrdinal()) {
             _x.domain([_chart.xAxisMin(), _chart.xAxisMax()]);
@@ -294,7 +283,7 @@ dc.coordinateGridChart = function (_chart) {
         }
 
         if (_chart.isOrdinal()) {
-            _chart.prepareOrdinalXAxis();
+            _x.rangeBands([0,_chart.xAxisLength()],_rangeBandPadding,_outerRangeBandPadding);
         } else {
             _x.range([0, _chart.xAxisLength()]);
         }
@@ -315,7 +304,7 @@ dc.coordinateGridChart = function (_chart) {
         var axisXLab = g.selectAll("text."+X_AXIS_LABEL_CLASS);
         if (axisXLab.empty() && _chart.xAxisLabel())
             axisXLab = g.append('text')
-                .attr("transform", "translate(" + _chart.xAxisLength() / 2 + "," + (_chart.height() - _xAxisLabelPadding) + ")")
+                .attr("transform", "translate(" + (_chart.margins().left + _chart.xAxisLength() / 2) + "," + (_chart.height() - _xAxisLabelPadding) + ")")
                 .attr('class', X_AXIS_LABEL_CLASS)
                 .attr('text-anchor', 'middle')
                 .text(_chart.xAxisLabel());
@@ -413,7 +402,7 @@ dc.coordinateGridChart = function (_chart) {
         var axisYLab = g.selectAll("text."+Y_AXIS_LABEL_CLASS);
         if (axisYLab.empty() && _chart.yAxisLabel())
             axisYLab = g.append('text')
-                .attr("transform", "translate(" + _yAxisLabelPadding + "," + _chart.yAxisHeight()/2 + "),rotate(-90)")
+                .attr("transform", "translate(" + _yAxisLabelPadding + "," + (_chart.margins().top + _chart.yAxisHeight()/2) + "),rotate(-90)")
                 .attr('class', Y_AXIS_LABEL_CLASS)
                 .attr('text-anchor', 'middle')
                 .text(_chart.yAxisLabel());
@@ -570,22 +559,20 @@ dc.coordinateGridChart = function (_chart) {
         var min = d3.min(_chart.data(), function (e) {
             return _chart.valueAccessor()(e);
         });
-        min = dc.utils.subtract(min, _yAxisPadding);
-        return min;
+        return dc.utils.subtract(min, _yAxisPadding);
     };
 
     _chart.yAxisMax = function () {
         var max = d3.max(_chart.data(), function (e) {
             return _chart.valueAccessor()(e);
         });
-        max = dc.utils.add(max, _yAxisPadding);
-        return max;
+        return dc.utils.add(max, _yAxisPadding);
     };
 
     /**
     #### .yAxisPadding([padding])
-    Set or get y axis padding when elastic y axis is turned on. The padding will be added to the top of the y axis if and only
     if elasticY is turned on otherwise it will be simply ignored.
+    Set or get y axis padding when elastic y axis is turned on. The padding will be added to the top of the y axis if and only
 
     * padding - could be integer or percentage in string (e.g. "10%"). Padding can be applied to number or date.
     When padding with date, integer represents number of days being padded while percentage string will be treated
@@ -616,6 +603,18 @@ dc.coordinateGridChart = function (_chart) {
     _chart.round = function (_) {
         if (!arguments.length) return _round;
         _round = _;
+        return _chart;
+    };
+
+    _chart._rangeBandPadding = function (_) {
+        if (!arguments.length) return _rangeBandPadding;
+        _rangeBandPadding = _;
+        return _chart;
+    };
+
+    _chart._outerRangeBandPadding = function (_) {
+        if (!arguments.length) return _outerRangeBandPadding;
+        _outerRangeBandPadding = _;
         return _chart;
     };
 

--- a/test/bar-chart-test.js
+++ b/test/bar-chart-test.js
@@ -39,6 +39,8 @@ function buildOrdinalChart(id, xdomain) {
     chart.dimension(stateDimension).group(stateGroup)
         .width(width).height(height)
         .x(xscale)
+        .barPadding(0)
+        .outerPadding(0.1)
         .transitionDuration(0)
         .xUnits(dc.units.ordinal);
     chart.render();
@@ -568,12 +570,12 @@ suite.addBatch({'ordinal bar chart': {
         assert.lengthOf(chart.selectAll("rect.bar")[0], 6);
     },
     'should auto size bar width': function (chart) {
-        assert.equal(chart.select("rect.bar").attr("width"), "144");
+        assert.equal(chart.select("rect.bar").attr("width"), 164);
     },
     'should position bars based on ordinal range': function (chart) {
-        assert.match(d3.select(chart.selectAll("rect.bar")[0][0]).attr("x"), /0\.\d+/);
-        assert.match(d3.select(chart.selectAll("rect.bar")[0][3]).attr("x"), /583\.\d+/);
-        assert.match(d3.select(chart.selectAll("rect.bar")[0][5]).attr("x"), /438\.\d+/);
+        assert.match(d3.select(chart.selectAll("rect.bar")[0][0]).attr("x"), /16(\.\d+)?/);
+        assert.match(d3.select(chart.selectAll("rect.bar")[0][3]).attr("x"), /674(\.\d+)?/);
+        assert.match(d3.select(chart.selectAll("rect.bar")[0][5]).attr("x"), /509(\.\d+)?/);
     },
     'should respect specified domain order': function (chart) {
         // note bar chart works differently from pie chart in that the bars objects don't

--- a/test/boxplot-test.js
+++ b/test/boxplot-test.js
@@ -17,6 +17,7 @@ function buildChart(id) {
         .width(width)
         .height(height)
         .margins({top: 0, right: 0, bottom: 0, left: 0})
+        .boxPadding(0)
         .x(d3.scale.ordinal())
         .xUnits(dc.units.ordinal);
 
@@ -41,8 +42,8 @@ suite.addBatch({
         },
 
         'should create an offset box for each dimension in the group': function (chart) {
-            assert.equal(chart.selectAll("g.box:nth-of-type(1)").attr("transform"), "translate(0,0)");
-            assert.equal(chart.selectAll("g.box:nth-of-type(2)").attr("transform"), "translate(100,0)");
+            assert.equal(chart.selectAll("g.box:nth-of-type(1)").attr("transform"), "translate(50,0)");
+            assert.equal(chart.selectAll("g.box:nth-of-type(2)").attr("transform"), "translate(150,0)");
         },
 
         'should correctly place median line': function (chart) {

--- a/test/line-chart-test.js
+++ b/test/line-chart-test.js
@@ -561,7 +561,7 @@ suite.addBatch({'ordinal line chart': {
         assert.isFalse(chart.brushOn());
     },
     'should generate correct line path': function (chart) {
-        assert.match(chart.select("path.line").attr("d"), /M72.\d+,0L218.\d+,107L364.\d+,107L510.\d+,53L655.\d+,107L801.\d+,53/);
+        assert.match(chart.select("path.line").attr("d"), /M72.\d+,0L218.\d+,107L364.\d+,107L510(\.\d+)?,53L655.\d+,107L801.\d+,53/);
     },
     teardown: function (topic) {
         resetAllFilters();

--- a/web/examples/box-plot.html
+++ b/web/examples/box-plot.html
@@ -44,8 +44,6 @@ d3.csv("morley.csv", function(error, experiments) {
     .margins({top: 10, right: 50, bottom: 30, left: 50})
     .dimension(experimentDimension)
     .group(speedArrayGroup)
-    .x(d3.scale.ordinal())
-    .xUnits(dc.units.ordinal)
     .elasticY(true);
 
   chart.render();

--- a/web/examples/ord.html
+++ b/web/examples/ord.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>dc.js - Ordinal Bar Chart Example</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="../css/dc.css"/>
+</head>
+<body>
+
+<div id="test"></div>
+
+<script type="text/javascript" src="../js/d3.js"></script>
+<script type="text/javascript" src="../js/crossfilter.js"></script>
+<script type="text/javascript" src="../js/dc.js"></script>
+<script type="text/javascript">
+
+var chart = dc.barChart("#test");
+
+var counts = [
+  {name: "apple", cnt: 10},
+  {name: "orange", cnt: 15},
+  {name: "banana", cnt: 12},
+  {name: "grapefruit", cnt: 2},
+  {name: "grapefruit", cnt: 4}
+];
+
+var ndx            = crossfilter(counts),
+    fruitDimension = ndx.dimension(function(d) {return d.name;}),
+    sumGroup       = fruitDimension.group().reduceSum(function(d) {return d.cnt;});
+
+chart
+  .width(768)
+  .height(380)
+  .x(d3.scale.ordinal())
+  .xUnits(dc.units.ordinal)
+  .brushOn(false)
+  .xAxisLabel("Fruit")
+  .yAxisLabel("Quantity Sold")
+  .dimension(fruitDimension)
+  .barPadding(0.1)
+  .outerPadding(0.05)
+  .group(sumGroup);
+
+chart.render();
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #311. We use rangeBands, but keep the gap logic for bar charts and xUnits. So we have full backwards compatibility at the moment. 

This patch also
- fixes the location of axis labels to take into account margins
- adds an ordinal bar chart example
- cleans up the boxplot just a bit.
- extends the xAxis along the full length of the chart, as per many user requests
- adds `.barPadding` and `.outerPadding` to configure rangeBands
