### PR TITLE
Support for titles on individual stacks via .title

### DIFF
--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -198,7 +198,7 @@ dc.lineChart = function (parent, chartGroup) {
                         hideDot(dot);
                         hideRefLines(g);
                     })
-                    .append("title").text(dc.pluck('data',_chart.title()));
+                    .append("title").text(dc.pluck('data', _chart.getTitleByIndex(layerIndex)));
 
                 dots.attr("cx", function (d) {
                         return dc.utils.safeNumber(_chart.x()(d.x));
@@ -206,7 +206,7 @@ dc.lineChart = function (parent, chartGroup) {
                     .attr("cy", function (d) {
                         return dc.utils.safeNumber(_chart.y()(d.y + d.y0));
                     })
-                    .select("title").text(dc.pluck('data',_chart.title()));
+                    .select("title").text(dc.pluck('data', _chart.getTitleByIndex(layerIndex)));
 
                 dots.exit().remove();
             });

--- a/src/stackable-chart.js
+++ b/src/stackable-chart.js
@@ -229,6 +229,57 @@ dc.stackableChart = function (_chart) {
         return _chart._keyAccessor(_);
     });
 
+    /**
+     #### .title([stackName], [titleFunction])
+     Set or get the title function. Chart class will use this function to render svg title (usually interpreted by browser
+     as tooltips) for each child element in the chart, i.e. a slice in a pie chart or a bubble in a bubble chart. Almost
+     every chart supports title function however in grid coordinate chart you need to turn off brush in order to use title
+     otherwise the brush layer will block tooltip trigger.
+
+     If the first argument is a stack name, the title function will get or set the title for that stack. If stackName
+     is not provided, the first stack is implied.
+     ```js
+     // set a title function on "first stack"
+     chart.title("first stack", function(d) { return d.key + ": " + d.value; });
+     // get a title function from "second stack"
+     var secondTitleFunction = chart.title("second stack");
+    });
+     ```
+
+     **/
+    dc.override(_chart, "title", function (stackName, titleAccessor) {
+        if (!stackName) return _chart._title();
+
+        var firstStack = _chart.group() && stackName === _chart._getGroupName(_chart.group());
+
+        if (typeof stackName === 'function') {
+            return _chart._title(stackName);
+        }
+        else if (!titleAccessor) {
+            if (firstStack)
+                return _chart._title();
+            else
+                return _groupStack.getTitle(stackName);
+        }
+
+        if (firstStack)
+            return _chart._title(titleAccessor);
+        else
+            _groupStack.setTitle(stackName, titleAccessor);
+
+        return _chart;
+    });
+
+    _chart.getTitleByIndex = function (index) {
+        if (index === 0) {
+            return _chart.title();
+        }
+        else {
+            var stackTitle = _chart.title(_groupStack.getNameByIndex(index - 1));
+            return stackTitle || _chart.title();
+        }
+    };
+
     _chart.stackLayout = function (stack) {
         if (!arguments.length) return _stackLayout;
         _stackLayout = stack;

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,6 +135,10 @@ dc.utils.GroupStack = function () {
         return _groups[index][1];
     };
 
+    this.getNameByIndex = function (index) {
+        return _groups[index].name;
+    };
+
     this.size = function () {
         return _groups.length;
     };
@@ -170,6 +174,20 @@ dc.utils.GroupStack = function () {
         for (var i = 0; i < _groups.length; ++i) {
             if (_groups[i].name === name)
                 _groups[i].hidden = value;
+        }
+    };
+
+    this.setTitle = function(name, titleAccessor) {
+        for (var i = 0; i < _groups.length; ++i) {
+            if (_groups[i].name === name)
+                _groups[i].title = titleAccessor;
+        }
+    };
+
+    this.getTitle = function(name) {
+        for (var i = 0; i < _groups.length; ++i) {
+            if (_groups[i].name === name)
+                return _groups[i].title;
         }
     };
 

--- a/test/line-chart-test.js
+++ b/test/line-chart-test.js
@@ -275,7 +275,9 @@ suite.addBatch({'stacked area chart': {
         chart.dimension(dateDimension)
             .brushOn(false)
             .group(dateIdSumGroup, "stack 0")
+            .title("stack 0", function (d) { return "stack 0: " + d.value; })
             .stack(dateValueSumGroup, "stack 1")
+            .title("stack 1", function (d) { return "stack 1: " + d.value; })
             .stack(dateValueSumGroup, "stack 2")
             .elasticY(true)
             .renderArea(true);
@@ -325,6 +327,24 @@ suite.addBatch({'stacked area chart': {
         chart.render();
         assert.equal(d3.select("#stacked-area-chart g._1 path.line").attr("d"), "M58.62068965517241,134L222.75862068965515,119L246.20689655172413,75L492.41379310344826,133L597.9310344827586,120L961.3793103448276,109");
         assert.equal(d3.selectAll("#stacked-area-chart path.line")[0].length, 3);
+    },
+    'stacks have their own titles accessors': function (chart) {
+        assert.equal(chart.title()({value: 1}), "stack 0: 1");
+        assert.equal(chart.title("stack 0")({value: 2}), "stack 0: 2");
+        assert.equal(chart.title("stack 1")({value: 3}), "stack 1: 3");
+    },
+    'stacks should have titles rendered to their individual stacks': function (chart) {
+        chart.selectAll("#stacked-area-chart g._0 circle.dot").each(function (d) {
+            assert.equal(d3.select(this).select("title").text(), "stack 0: " + d.data.value);
+        });
+        chart.selectAll("#stacked-area-chart g._1 circle.dot").each(function (d) {
+            assert.equal(d3.select(this).select("title").text(), "stack 1: " + d.data.value);
+        });
+    },
+    'stack titles should default to the first stack title, even for unnamed stacks': function (chart) {
+        chart.selectAll("#stacked-area-chart g._2 circle.dot").each(function (d) {
+            assert.equal(d3.select(this).select("title").text(), "stack 0: " + d.data.value);
+        });
     },
     'tooltip dots should always be drawn on top of paths': function(chart) {
         var list = d3.select("#stacked-area-chart").selectAll("circle.dot, path.line, path.area");

--- a/test/stackable-chart-test.js
+++ b/test/stackable-chart-test.js
@@ -81,6 +81,26 @@ suite.addBatch({
             var index = stack.addGroup({});
             assert.equal(stack.getAccessorByIndex(index), retriever);
             stack.clear();
+        },
+        'should be able to get stack names by index': function (stack) {
+            stack.addNamedGroup({}, "first group");
+            stack.addNamedGroup({}, "second group");
+            assert.equal(stack.getNameByIndex(0),"first group");
+            assert.equal(stack.getNameByIndex(1),"second group");
+        },
+        'should be able to get and set title accessor functions by name': function(stack) {
+            var firstTitle = function() {};
+            var secondTitle = function() {};
+            stack.addNamedGroup({}, "first group");
+            stack.addNamedGroup({}, "second group");
+
+            stack.setTitle("first group", firstTitle);
+            stack.setTitle("second group", secondTitle);
+
+            assert.equal(stack.getTitle("first group"), firstTitle);
+            assert.equal(stack.getTitle("second group"), secondTitle);
+
+            stack.clear();
         }
     }
 });


### PR DESCRIPTION
We preserved all former title behavior. Stacks that are not provided with a title will get the primary title.
