### PR TITLE
Legend items show with dashed lines of the appropriate stroke-dasharray

### DIFF
--- a/src/legend.js
+++ b/src/legend.js
@@ -70,11 +70,23 @@ dc.legend = function () {
                 }
             });
 
-        itemEnter
-            .append("rect")
+        if (_parent.legendables().some(function (legendItem) { return legendItem.dashstyle })) {
+            itemEnter
+                .append("line")
+                .attr("x1", 0)
+                .attr("y1", _itemHeight / 2)
+                .attr("x2", _itemHeight)
+                .attr("y2", _itemHeight / 2)
+                .attr("stroke-width", 2)
+                .attr("stroke-dasharray", function(d){return d.dashstyle;})
+                .attr("stroke", function(d){return d.color;});
+        } else {
+            itemEnter
+                .append("rect")
                 .attr("width", _itemHeight)
                 .attr("height", _itemHeight)
                 .attr("fill", function(d){return d.color;});
+        }
 
         itemEnter.append("text")
                 .text(function(d){return d.name;})

--- a/src/utils.js
+++ b/src/utils.js
@@ -268,7 +268,7 @@ dc.utils.appendOrSelect = function (parent, name) {
 dc.utils.createLegendable = function (chart, group, accessor, color) {
     var legendable = {name: chart._getGroupName(group, accessor), data: group};
     if (color) legendable.color = color;
-    //(typeof chart.dashStyle === 'function') ? legendable.dashstyle = chart.dashStyle() : [];
+    if (chart.dashStyle && chart.dashStyle()) legendable.dashstyle = chart.dashStyle();
     return legendable;
 };
 

--- a/test/legend-test.js
+++ b/test/legend-test.js
@@ -20,12 +20,40 @@ function buildLineChart(id) {
     return chart;
 }
 
+function buildComposedDashedLineChart(id) {
+    d3.select("body").append("div").attr("id", id);
+    var chart1 = dc.lineChart();
+    chart1
+        .dimension(dateDimension)
+        .group(dateIdSumGroup, "Id Sum")
+        .dashStyle([10,1])
+
+    var chart2 = dc.lineChart();
+    chart2
+        .dimension(dateDimension)
+        .group(dateValueSumGroup, "Value Sum")
+        .dashStyle([2,1])
+
+    var composite = dc.compositeChart("#" + id);
+    composite
+        .x(d3.scale.linear().domain([0,20]))
+        .legend(dc.legend().x(400).y(10).itemHeight(13).gap(5))
+        .compose([chart1, chart2])
+        .render();
+
+    return composite;
+}
+
 function legend(chart) {
     return chart.select("g.dc-legend");
 }
 
 function legendItems(chart) {
     return legend(chart).selectAll('g.dc-legend-item');
+}
+
+function legendLine(chart) {
+    return legend(chart).selectAll("line");
 }
 
 function legendIcon(chart) {
@@ -35,6 +63,18 @@ function legendIcon(chart) {
 function legendLabels(chart) {
     return chart.selectAll("g.dc-legend-item text");
 }
+
+suite.addBatch({
+    'renderDashedLine': {
+        topic: function () {
+            return buildComposedDashedLineChart("legend-chart");
+        },
+        'should style legend line correctly': function (chart) {
+            assert.equal(d3.select(legendLine(chart)[0][0]).attr("stroke-dasharray"), [10,1]);
+            assert.equal(d3.select(legendLine(chart)[0][1]).attr("stroke-dasharray"), [2,1]);
+        }
+    }
+});
 
 suite.addBatch({
     'render': {

--- a/web/examples/composite.html
+++ b/web/examples/composite.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>dc.js - Composite Chart Example</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="../css/dc.css"/>
+</head>
+<body>
+
+<div id="test_composed"></div>
+
+<script type="text/javascript" src="../js/d3.js"></script>
+<script type="text/javascript" src="../js/crossfilter.js"></script>
+<script type="text/javascript" src="../js/dc.js"></script>
+<script type="text/javascript">
+
+    var chart1 = dc.lineChart();
+    var chart2 = dc.lineChart();
+
+    var chartsLoaded = 0;
+
+    function chartLoaded() {
+        chartsLoaded++;
+        if (chartsLoaded < 2) return;
+
+        var composite = dc.compositeChart("#test_composed");
+        composite
+                .width(768)
+                .height(480)
+                .x(d3.scale.linear().domain([0,20]))
+                .yAxisLabel("The Y Axis")
+                .legend(dc.legend().x(80).y(20).itemHeight(13).gap(5))
+                .compose([chart1, chart2])
+                .render();
+    }
+
+    d3.csv("morley.csv", function(error, experiments) {
+        experiments.forEach(function(x) {
+            x.Speed = +x.Speed;
+        });
+
+        var ndx                 = crossfilter(experiments),
+            runDimension        = ndx.dimension(function(d) {return +d.Run;})
+        speedSumGroup       = runDimension.group().reduceSum(function(d) {return d.Speed * d.Run / 1000;});
+        chart1
+                .dimension(runDimension)
+                .colors(['red'])
+                .group(speedSumGroup, "Top Line")
+                .dashStyle([2,2]);
+
+        chartLoaded();
+    });
+
+    d3.csv("morley2.csv", function(error, experiments) {
+        experiments.forEach(function(x) {
+            x.Speed = +x.Speed;
+        });
+
+        var ndx                 = crossfilter(experiments),
+                runDimension        = ndx.dimension(function(d) {return +d.Run;})
+        speedSumGroup       = runDimension.group().reduceSum(function(d) {return d.Speed * d.Run / 1000;});
+
+        chart2
+                .dimension(runDimension)
+                .colors(['blue'])
+                .group(speedSumGroup, "Bottom Line")
+                .dashStyle([5,5]);
+
+        chartLoaded();
+    });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This makes the most sense for a composite chart with several line charts that have different dash styles.

If any of the legend items have a stroke-dasharray property, all the legend items will show as lines.

Added an example with a composite chart that has different dash styles for each line graph.

This does one part of issue #387
