### PR TITLE
Support for merged coverage reports via grunt coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ node_modules
 
 # jasmine spec runner
 web/jasmine-runner.html
-
-# test coverage reports
-coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,9 +82,6 @@ module.exports = function (grunt) {
                                 options: {
                                     dir: 'coverage/jasmine'
                                 }
-                            },
-                            {
-                                type: 'text-summary'
                             }
                         ]
                     }
@@ -152,7 +149,13 @@ module.exports = function (grunt) {
                 options: { stdout: true, failOnError: true }
             },
             vows_coverage: {
-                command: "istanbul cover --dir coverage/vows node_modules/vows/bin/vows",
+                command: "istanbul cover --print none --dir coverage/vows node_modules/vows/bin/vows",
+                options: {
+                  stdout: true
+                }
+            },
+            merge_coverage: {
+                command: "cd coverage && node merge_coverage.js",
                 options: {
                   stdout: true
                 }
@@ -198,7 +201,7 @@ module.exports = function (grunt) {
     grunt.registerTask('web', ['docs', 'gh-pages']);
     grunt.registerTask('test', ['docs', 'vows:tests', 'jasmine:specs']);
     grunt.registerTask('vows:coverage', ['shell:vows_coverage']);
-    grunt.registerTask('coverage', ['vows:coverage', 'jasmine:coverage']);
+    grunt.registerTask('coverage', ['vows:coverage', 'jasmine:coverage', 'shell:merge_coverage']);
     grunt.registerTask('lint', ['build', 'jshint']);
     grunt.registerTask('default', ['build']);
 };

--- a/coverage/merge_coverage.js
+++ b/coverage/merge_coverage.js
@@ -1,0 +1,32 @@
+// Merge jasmine and vows coverage objects
+
+var istanbul = require('istanbul');
+
+var jasmineCoverageJSON = './jasmine/coverage.json';
+var vowsCoverageJSON = './vows/coverage.json';
+var mergedOutputDir = './merged';
+
+
+var jasmineFileCoverage = getDCFileCoverage(require(jasmineCoverageJSON));
+var vowsFileCoverage = getDCFileCoverage(require(vowsCoverageJSON));
+
+var mergedFileCoverage = istanbul.utils.mergeFileCoverage(jasmineFileCoverage, vowsFileCoverage);
+mergedFileCoverage.path = '../dc.js';
+var mergedCoverage = { './dc.js/dc.js': mergedFileCoverage };
+
+var collector = new istanbul.Collector();
+collector.add(mergedCoverage);
+
+var htmlReport = istanbul.Report.create('html', { dir: mergedOutputDir });
+htmlReport.writeReport(collector, false);
+
+var textSummaryReport = istanbul.Report.create('text-summary');
+textSummaryReport.writeReport(collector, false);
+
+function getDCFileCoverage(coverage) {
+    return coverage[
+        Object.keys(coverage).filter(function(k) {
+            return /dc\.js$/.test(k);
+        })[0]
+    ];
+}


### PR DESCRIPTION
This requires istanbul to be in $NODE_PATH.
Use `grunt coverage` to generate both the text summary and html report :)
