### PR TITLE
bubbleChart: set opacity on circles during render instead of <g> element

### DIFF
--- a/src/bubble-chart.js
+++ b/src/bubble-chart.js
@@ -85,6 +85,7 @@ dc.bubbleChart = function(parent, chartGroup) {
             .attr("fill", _chart.getColor)
             .attr("r", 0);
         dc.transition(bubbleG, _chart.transitionDuration())
+            .selectAll("circle." + _chart.BUBBLE_CLASS)
             .attr("r", function(d) {
                 return _chart.bubbleR(d);
             })

--- a/test/bubble-chart-test.js
+++ b/test/bubble-chart-test.js
@@ -154,6 +154,12 @@ suite.addBatch({
                         assert.equal(d3.select(this).attr("transform"), "translate(541.2,155)");
                 });
             },
+            'should generate opaque groups and circles for each bubble': function (chart) {
+                chart.selectAll("g.node").each(function (d, i) {
+                    assert.equal(d3.select(this).attr("opacity"), null);
+                    assert.equal(d3.select(this).select('circle').attr("opacity"), '1');
+                });
+            },
             'should calculate right r for each bubble': function (chart) {
                 chart.selectAll("circle.bubble").each(function (d, i) {
                     if (i === 0)


### PR DESCRIPTION
I noticed a small bug where r/opacity attributes were being set on the <g> element instead of the circles themselves and I thought it was worth contributing back.  I didn't see any bubbleChart tests in /spec, so I just added a simple vows test instead - hope that's okay.  Please let me know if I need to do anything else, and thanks for a great library!
