### PR TITLE
Fix coordinate grids hijacking mouse scroll

### DIFF
--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -332,6 +332,32 @@ describe('dc.coordinateGridChart', function() {
             });
         });
 
+        describe("rendering for the first time with mouse zoom disabled when it wasn't previously enabled", function () {
+            beforeEach(function () {
+                chart.mouseZoomable(false);
+                spyOn(chart, "_disableMouseZoom");
+                chart.render();
+            });
+
+            it("should not explicitly disable mouse zooming", function () {
+                expect(chart._disableMouseZoom).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("rendering with mouse zoom disabled after it was previously enabled", function () {
+            beforeEach(function () {
+                chart.mouseZoomable(true);
+                chart.render();
+                chart.mouseZoomable(false);
+                spyOn(chart, "_disableMouseZoom");
+                chart.render();
+            });
+
+            it("should explicitly disable mouse zooming", function () {
+                expect(chart._disableMouseZoom).toHaveBeenCalled();
+            });
+        });
+
         describe("with mouse zoom disabled", function () {
             beforeEach(function () {
                 chart.mouseZoomable(false);

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -55,6 +55,7 @@ dc.coordinateGridMixin = function (_chart) {
 
     var _zoom = d3.behavior.zoom().on("zoom", zoomHandler);
     var _nullZoom = d3.behavior.zoom().on("zoom", null);
+    var _hasBeenMouseZoomable = false;
 
     var _rangeChart;
     var _focusChart;
@@ -880,13 +881,16 @@ dc.coordinateGridMixin = function (_chart) {
     }
 
     function configureMouseZoom () {
-        if (_mouseZoomable)
+        if (_mouseZoomable) {
             _chart._enableMouseZoom();
-        else
+        }
+        else if (_hasBeenMouseZoomable) {
             _chart._disableMouseZoom();
+        }
     }
 
     _chart._enableMouseZoom = function () {
+        _hasBeenMouseZoomable = true;
         _zoom.x(_chart.x())
             .scaleExtent(_zoomScale)
             .size([_chart.width(),_chart.height()]);


### PR DESCRIPTION
This mostly fixes #427. Now the mouse scroll hijacking issue will only occur if you disable zoom after it was previously enabled. Still looking for a more elegant solution, but wanted to submit a fix ASAP since #427 is a regression.
