### PR TITLE
Box plots with no data no longer attempt to draw with NaN values at the top of the graph

### DIFF
--- a/spec/box-plot-spec.js
+++ b/spec/box-plot-spec.js
@@ -130,8 +130,24 @@ describe('dc.boxPlot', function() {
                 expect(chart.selectAll('g.box').size()).toBe(1);
             });
 
-            it('should not represent the box in the chart domain', function() {
-                expect(chart.selectAll(".axis.x .tick").size()).toBe(1);
+            describe("with elasticX enabled", function() {
+                beforeEach(function() {
+                    chart.elasticX(true).render();
+                });
+
+                it('should not represent the box in the chart domain', function() {
+                    expect(chart.selectAll(".axis.x .tick").size()).toBe(1);
+                });
+            });
+
+            describe("when elasticX is disabled", function() {
+                beforeEach(function() {
+                    chart.elasticX(false).render();
+                });
+
+                it('should represent the box in the chart domain', function() {
+                    expect(chart.selectAll(".axis.x .tick").size()).toBe(2);
+                });
             });
         });
     });

--- a/src/box-plot.js
+++ b/src/box-plot.js
@@ -50,11 +50,15 @@ dc.boxPlot = function (parent, chartGroup) {
     _chart.xUnits(dc.units.ordinal);
 
     // valueAccessor should return an array of values that can be coerced into numbers
-    //  or if data is overloaded for a static array of arrays, it should be `Number`
+    // or if data is overloaded for a static array of arrays, it should be `Number`.
+    // Empty arrays are not included.
     _chart.data(function(group) {
         return group.all().map(function (d) {
             d.map = function(accessor) { return accessor.call(d,d); };
             return d;
+        }).filter(function (d) {
+            var values = _chart.valueAccessor()(d);
+            return values.length !== 0;
         });
     });
 
@@ -97,17 +101,11 @@ dc.boxPlot = function (parent, chartGroup) {
         return "translate(" + xOffset + ",0)";
     };
 
-    dc.override(_chart, 'data', function(_) {
-        return _chart._data().filter(function (d) {
-            var values = _chart.valueAccessor()(d);
-            return values.length !== 0;
-        });
-    });
-
-    _chart.elasticX(true);
-    _chart.on('preRedraw', function () {
-        _chart.x().domain([]);
-    });
+    _chart._preprocessData = function () {
+        if (_chart.elasticX()) {
+            _chart.x().domain([]);
+        }
+    };
 
     _chart.plotData = function () {
         var _calculatedBoxWidth = _boxWidth(_chart.effectiveWidth(), _chart.xUnitCount());

--- a/web/examples/box-plot.html
+++ b/web/examples/box-plot.html
@@ -47,7 +47,8 @@ d3.csv("morley.csv", function(error, experiments) {
     .margins({top: 10, right: 50, bottom: 30, left: 50})
     .dimension(experimentDimension)
     .group(speedArrayGroup)
-    .elasticY(true);
+    .elasticY(true)
+    .elasticX(true);
 
   pie
     .width(140)


### PR DESCRIPTION
This also makes elasticX true by default for box plots. Otherwise the animations for a box plot that is filtered out are confusing (as that box will jump to the box after it). It also seems strange to have an entirely blank portion of the graph.

We also noticed that boxplot modifies the underlying data by adding a map function to each data point. You pointed out earlier that this was undesirable. Should this be changed?
