### PR TITLE
added option to include an additional right aligned title label to rowChart. _chart.renderTitleLabel.  Fixed minor typo in API documentation.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Stephen Cassidy <stephen.cassidy@gmail.com>
 Jon von Gillern <jvongillern@gmail.com>
 Olivier Mornard <olivier@mornard-o.nom.fr>
 Stephen Levine <stephen.levine@gmail.com>
+Jeffrey Steinmetz <jeffrey.steinmetz@gmail.com>

--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -29,10 +29,13 @@ dc.rowChart = function (parent, chartGroup) {
 
     var _labelOffsetX = 10;
     var _labelOffsetY = 15;
+    var _titleLabelOffsetX = 2;
 
     var _gap = 5;
 
     var _rowCssClass = "row";
+    var _titleRowCssClass = "titlerow";
+    var _renderTitleLabel = false;
 
     var _chart = dc.capMixin(dc.marginMixin(dc.colorMixin(dc.baseMixin({}))));
 
@@ -181,6 +184,11 @@ dc.rowChart = function (parent, chartGroup) {
             rowEnter.append("text")
                 .on("click", onClick);
         }
+        if (_chart.renderTitleLabel()) {
+            rowEnter.append("text")
+                .attr("class", _titleRowCssClass)
+                .on("click", onClick);
+        }
     }
 
     function updateLabels(rows) {
@@ -198,6 +206,32 @@ dc.rowChart = function (parent, chartGroup) {
             dc.transition(lab, _chart.transitionDuration())
                 .attr("transform", translateX);
         }
+        if (_chart.renderTitleLabel()) {
+            var titlelab = rows.select("." + _titleRowCssClass)
+                    .attr("x", _chart.effectiveWidth() - _titleLabelOffsetX)
+                    .attr("y", _labelOffsetY)
+                    .attr("text-anchor", "end")
+                    .on("click", onClick)
+                    .attr("class", function (d, i) {
+                        return _titleRowCssClass + " _" + i ;
+                    })
+                    .text(function (d) {
+                        return _chart.title()(d);
+                    });
+            dc.transition(titlelab, _chart.transitionDuration())
+                .attr("transform", translateX);
+            }
+    }
+
+    /**
+    #### .renderTitleLabel(boolean)
+    Turn on/off Title label rendering (values) using SVG style of text-anchor 'end'
+
+    **/
+    _chart.renderTitleLabel = function (_) {
+        if (!arguments.length) return _renderTitleLabel;
+        _renderTitleLabel = _;
+        return _chart;
     }
 
     function onClick(d) {
@@ -256,12 +290,23 @@ dc.rowChart = function (parent, chartGroup) {
 
     /**
     #### .labelOffsetY([y])
-    Get of set the y offset (vertical space to the top left corner of a row) for labels on a particular row chart. Default y offset is 15px;
+    Get or set the y offset (vertical space to the top left corner of a row) for labels on a particular row chart. Default y offset is 15px;
 
     **/
     _chart.labelOffsetY = function (o) {
         if (!arguments.length) return _labelOffsetY;
         _labelOffsetY = o;
+        return _chart;
+    };
+
+    /**
+    #### .titleLabelOffsetx([x])
+    Get of set the x offset (horizontal space between right edge of row and right edge or text.   Default x offset is 2px;
+
+    **/
+    _chart.titleLabelOffsetX = function (o) {
+        if (!arguments.length) return _titleLabelOffsetX;
+        _titleLabelOffsetX = o;
         return _chart;
     };
 

--- a/web/docs/api-latest.md
+++ b/web/docs/api-latest.md
@@ -1297,17 +1297,23 @@ var chart2 = dc.rowChart("#chart-container2", "chartGroupA");
 ```
 
 #### .gap([gap])
-Get or set the vertical gap space between rows on a particular row chart instance. Default gap is 5px;
+Get or set the vertical gap space between rows on a particular row chart instance. Default gap is 5px.
 
 #### .elasticX([boolean])
 Get or set the elasticity on x axis. If this attribute is set to true, then the x axis will rescle to auto-fit the data
 range when filtered.
 
 #### .labelOffsetX([x])
-Get or set the x offset (horizontal space to the top left corner of a row) for labels on a particular row chart. Default x offset is 10px;
+Get or set the x offset (horizontal space to the top left corner of a row) for labels on a particular row chart. Default x offset is 10px.
 
 #### .labelOffsetY([y])
-Get of set the y offset (vertical space to the top left corner of a row) for labels on a particular row chart. Default y offset is 15px;
+Get or set the y offset (vertical space to the top left corner of a row) for labels on a particular row chart. Default y offset is 15px.
+
+#### .renderTitleLabel(boolean)
+Turn on/off Title label rendering within each row.  This adds an additional label using an SVG style of text-anchor 'end'.  Useful for adding titles (often values) to the right side of row bars. 
+
+#### .titleLabelOffsetX([y])
+Get of set the x offset (horizontal space between right edge of row and right edge or text.)   Default x offset is 2px;
 
 ## Legend
 Legend is a attachable widget that can be added to other dc charts to render horizontal legend labels.


### PR DESCRIPTION
This is an alternative (or can be used in addition to) the tooltip rendering for "title" .

example here:
http://jsfiddle.net/jeffsteinmetz/49WYd/

below is an example usage of renderTitleLabel and titleLabelOffsetX:

```
sampleRowChart.width(200)
        .height(275)
        .margins({top: 0, right: 10, bottom: 0, left: 10})
        .dimension(yourDim)
        .group(yourGroup)
        .label(function (d) {
            return d.key;
        })
        .title(function (d) {
            return d.value;
        })
        .renderTitleLabel(true)  // show titles (values) with text-anchor 'end'
        .titleLabelOffsetX(3);
```
