### PR TITLE
Add a pre-commit hook for jshint + moved coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules
 
 # jasmine spec runner
 web/jasmine-runner.html
+
+# coverage reports
+coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,10 +181,14 @@ module.exports = function (grunt) {
                 }
             },
             merge_coverage: {
-                command: "cd coverage && node merge_coverage.js",
+                command: "NODE_PATH=`npm -g root` node scripts/merge_coverage.js",
                 options: {
                   stdout: true
                 }
+            },
+            hooks: {
+                command: 'cp -n scripts/pre-commit.sh .git/hooks/pre-commit' +
+                    ' || echo "Cowardly refusing to overwrite your existing git pre-commit hook."'
             }
         }
     });
@@ -241,7 +245,7 @@ module.exports = function (grunt) {
     grunt.registerTask('build', ['concat', 'uglify', 'sed']);
     grunt.registerTask('docs', ['build', 'copy', 'emu', 'toc', 'markdown', 'docco']);
     grunt.registerTask('web', ['docs', 'gh-pages']);
-    grunt.registerTask('test', ['docs', 'vows:tests', 'jasmine:specs']);
+    grunt.registerTask('test', ['docs', 'vows:tests', 'jasmine:specs', 'shell:hooks']);
     grunt.registerTask('vows:coverage', ['shell:vows_coverage']);
     grunt.registerTask('coverage', ['vows:coverage', 'jasmine:coverage', 'shell:merge_coverage']);
     grunt.registerTask('lint', ['build', 'jshint']);

--- a/scripts/merge_coverage.js
+++ b/scripts/merge_coverage.js
@@ -2,16 +2,16 @@
 
 var istanbul = require('istanbul');
 
-var jasmineCoverageJSON = './jasmine/coverage.json';
-var vowsCoverageJSON = './vows/coverage.json';
-var mergedOutputDir = './merged';
+var jasmineCoverageJSON = '../coverage/jasmine/coverage.json';
+var vowsCoverageJSON = '../coverage/vows/coverage.json';
+var mergedOutputDir = './coverage/merged';
 
 
 var jasmineFileCoverage = getDCFileCoverage(require(jasmineCoverageJSON));
 var vowsFileCoverage = getDCFileCoverage(require(vowsCoverageJSON));
 
 var mergedFileCoverage = istanbul.utils.mergeFileCoverage(jasmineFileCoverage, vowsFileCoverage);
-mergedFileCoverage.path = '../dc.js';
+mergedFileCoverage.path = './dc.js';
 var mergedCoverage = { './dc.js/dc.js': mergedFileCoverage };
 
 var collector = new istanbul.Collector();

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+grunt jshint


### PR DESCRIPTION
We noticed a lot of commits on master that were just running `grunt jshint` and fixing the resulting issues. It seems like it would be nice to use a pre-commit hook to ensure that commits are clean before they are pushed and a pull request is sent.

As part of this, we created a /scripts directory, and it seemed like a good idea to move the coverage merging script in there. The coverage directory is now gitignore'd.
