### PR TITLE
Added horizontal gridlines from right or left y-axis to composite/series charts

### DIFF
--- a/spec/composite-chart-spec.js
+++ b/spec/composite-chart-spec.js
@@ -155,11 +155,6 @@ describe('dc.compositeChart', function() {
             expect(d3.select(chart.selectAll('g.sub')[0][1]).attr('class')).toBe('sub _1');
         });
 
-        it('should only render a left y axis', function () {
-            expect(chart.selectAll('.axis.y').empty()).toBeFalsy();
-            expect(chart.selectAll('.axis.yr').empty()).toBeTruthy();
-        });
-
         it('should generate sub line chart paths', function () {
             expect(chart.selectAll('g.sub path.line').size()).not.toBe(0);
             chart.selectAll('g.sub path.line').each(function(d, i) {
@@ -420,63 +415,111 @@ describe('dc.compositeChart', function() {
         });
     });
 
-    describe('when using a right y-axis', function () {
-        var rightChart;
+    describe('the y-axes', function() {
+        describe('when composing charts with both left and right y-axes', function () {
+            var rightChart;
 
-        beforeEach(function () {
-            chart
-                .compose([
-                    dc.barChart(chart)
-                        .group(dateValueSumGroup, 'Date Value Group'),
-                    rightChart = dc.lineChart(chart)
-                        .group(dateIdSumGroup, 'Date ID Group')
-                        .stack(dateValueSumGroup, 'Date Value Group')
-                        .stack(dateValueSumGroup, 'Date Value Group')
-                        .useRightYAxis(true)
-                ])
-                .render();
-        });
-
-        it('should render two y-axes', function () {
-            expect(chart.selectAll('.axis').size()).toBe(3);
-        });
-
-        it('should render a right and a left label', function () {
-            chart.yAxisLabel("Left Label").rightYAxisLabel("Right Label").render();
-
-            expect(chart.selectAll('.y-axis-label').size()).toBe(2);
-            expect(chart.selectAll('.y-axis-label.y-label').empty()).toBeFalsy();
-            expect(chart.selectAll('.y-axis-label.yr-label').empty()).toBeFalsy();
-        });
-
-        it('should scale "right" charts according to the right y-axis' , function () {
-            expect(rightChart.y()).toBe(chart.rightY());
-        });
-
-        it('should set the domain of the right axis', function () {
-            expect(rightChart.yAxisMin()).toBe(0);
-            expect(rightChart.yAxisMax()).toBe(281);
-        });
-
-        it('domain', function () {
-            expect(chart.rightY().domain()).toEqual([0, 281]);
-            expect(chart.y().domain()).toEqual([0, 132]);
-        });
-
-        it('should set "right" chart y-axes to the composite chart right y-axis', function () {
-            expect(rightChart.yAxis()).toBe(chart.rightYAxis());
-        });
-
-        describe('when only right y-axis sub charts are present', function () {
             beforeEach(function () {
-                chart.compose([rightChart]).render();
+                chart
+                    .compose([
+                        dc.barChart(chart)
+                            .group(dateValueSumGroup, 'Date Value Group'),
+                        rightChart = dc.lineChart(chart)
+                            .group(dateIdSumGroup, 'Date ID Group')
+                            .stack(dateValueSumGroup, 'Date Value Group')
+                            .stack(dateValueSumGroup, 'Date Value Group')
+                            .useRightYAxis(true)
+                    ])
+                    .render();
+            });
+
+            it('should render two y-axes', function () {
+                expect(chart.selectAll('.axis').size()).toBe(3);
+            });
+
+            it('should render a right and a left label', function () {
+                chart.yAxisLabel("Left Label").rightYAxisLabel("Right Label").render();
+
+                expect(chart.selectAll('.y-axis-label').size()).toBe(2);
+                expect(chart.selectAll('.y-axis-label.y-label').empty()).toBeFalsy();
+                expect(chart.selectAll('.y-axis-label.yr-label').empty()).toBeFalsy();
+            });
+
+            it('should scale "right" charts according to the right y-axis' , function () {
+                expect(rightChart.y()).toBe(chart.rightY());
+            });
+
+            it('should set the domain of the right axis', function () {
+                expect(rightChart.yAxisMin()).toBe(0);
+                expect(rightChart.yAxisMax()).toBe(281);
+            });
+
+            it('domain', function () {
+                expect(chart.rightY().domain()).toEqual([0, 281]);
+                expect(chart.y().domain()).toEqual([0, 132]);
+            });
+
+            it('should set "right" chart y-axes to the composite chart right y-axis', function () {
+                expect(rightChart.yAxis()).toBe(chart.rightYAxis());
+            });
+
+            describe('horizontal gridlines', function() {
+                beforeEach(function() {
+                    chart.yAxis().ticks(3);
+                    chart.rightYAxis().ticks(6);
+                    chart.renderHorizontalGridLines(true).render();
+                });
+
+                it('should draw left horizontal gridlines by default', function() {
+                    expect(chart.selectAll('.grid-line.horizontal line').size()).toBe(3);
+                });
+
+                it('should allow right horizontal gridlines to be used', function() {
+                    chart.useRightAxisGridLines(true).render();
+                    expect(chart.selectAll('.grid-line.horizontal line').size()).toBe(6);
+                });
+            });
+        });
+
+        describe('when composing charts with just a left axis', function() {
+            beforeEach(function() {
+                chart.yAxis().ticks(4);
+                chart.compose([
+                    dc.lineChart(chart).group(dateGroup)
+                ]).renderHorizontalGridLines(true).render();
+            });
+
+            it('should only render a left y axis', function () {
+                expect(chart.selectAll('.axis.y').empty()).toBeFalsy();
+                expect(chart.selectAll('.axis.yr').empty()).toBeTruthy();
+            });
+
+            it('should only draw left horizontal gridlines', function () {
+                expect(chart.selectAll('.grid-line.horizontal line').size()).toBe(4);
+            });
+        });
+
+        describe('when composing charts with just a right axis', function() {
+            beforeEach(function () {
+                chart.yAxis().ticks(7);
+                chart.compose([
+                    dc.lineChart(chart).group(dateGroup).useRightYAxis(true)
+                ]).renderHorizontalGridLines(true).render();
             });
 
             it('should only render a right y axis', function () {
                 expect(chart.selectAll('.axis.y').empty()).toBeTruthy();
                 expect(chart.selectAll('.axis.yr').empty()).toBeFalsy();
             });
+
+            it('should only draw the right horizontal gridlines', function () {
+                expect(chart.selectAll('.grid-line.horizontal line').size()).toBe(7);
+            });
         });
+
+        function nthGridLine(n) {
+            return d3.select(chart.selectAll('.grid-line.horizontal line')[0][n]);
+        }
     });
 
     describe('sub-charts with different filter types', function() {

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -44,7 +44,8 @@ dc.compositeChart = function (parent, chartGroup) {
     var _rightYAxis = d3.svg.axis(),
         _rightYAxisLabel = 0,
         _rightYAxisLabelPadding = DEFAULT_RIGHT_Y_AXIS_LABEL_PADDING,
-        _rightY;
+        _rightY,
+        _rightAxisGridLines = false;
 
     _chart._mandatoryAttributes([]);
     _chart.transitionDuration(500);
@@ -83,6 +84,13 @@ dc.compositeChart = function (parent, chartGroup) {
     _chart._prepareYAxis = function () {
         if (leftYAxisChildren().length !== 0) { prepareLeftYAxis(); }
         if (rightYAxisChildren().length !== 0) { prepareRightYAxis(); }
+
+        if (leftYAxisChildren().length > 0 && !_rightAxisGridLines) {
+            _chart._renderHorizontalGridLinesForAxis(_chart.g(), _chart.y(), _chart.yAxis());
+        }
+        else if (rightYAxisChildren().length > 0) {
+            _chart._renderHorizontalGridLinesForAxis(_chart.g(), _rightY, _rightYAxis);
+        }
     };
 
     _chart.renderYAxis = function () {
@@ -155,6 +163,19 @@ dc.compositeChart = function (parent, chartGroup) {
 
             child._activateRenderlets();
         }
+    };
+
+    /**
+    #### .useRightAxisGridLines(bool)
+    Get or set whether to draw gridlines from the right y axis.
+    Drawing from the left y axis is the default behavior. This option is only respected when
+    subcharts with both left and right y-axes are present.
+    **/
+    _chart.useRightAxisGridLines = function(_) {
+        if (!arguments) return _rightAxisGridLines;
+
+        _rightAxisGridLines = _;
+        return _chart;
     };
 
     /**

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -426,7 +426,7 @@ dc.coordinateGridMixin = function (_chart) {
         if (_useRightYAxis)
             _yAxis.orient("right");
 
-        renderHorizontalGridLines(g);
+        _chart._renderHorizontalGridLinesForAxis(g, _y, _yAxis);
     };
 
     _chart.renderYAxisLabel = function(axisClass, text, rotation, labelXPosition) {
@@ -466,11 +466,11 @@ dc.coordinateGridMixin = function (_chart) {
         _chart.renderYAxisLabel("y", _chart.yAxisLabel(), rotation, labelPosition);
     };
 
-    function renderHorizontalGridLines(g) {
+    _chart._renderHorizontalGridLinesForAxis = function (g, scale, axis) {
         var gridLineG = g.selectAll("g." + HORIZONTAL_CLASS);
 
         if (_renderHorizontalGridLine) {
-            var ticks = _yAxis.tickValues() ? _yAxis.tickValues() : _y.ticks(_yAxis.ticks()[0]);
+            var ticks = axis.tickValues() ? axis.tickValues() : scale.ticks(axis.ticks()[0]);
 
             if (gridLineG.empty()) {
                 gridLineG = g.insert("g", ":first-child")
@@ -486,11 +486,11 @@ dc.coordinateGridMixin = function (_chart) {
                 .append("line")
                 .attr("x1", 1)
                 .attr("y1", function (d) {
-                    return _y(d);
+                    return scale(d);
                 })
                 .attr("x2", _chart.xAxisLength())
                 .attr("y2", function (d) {
-                    return _y(d);
+                    return scale(d);
                 })
                 .attr("opacity", 0);
             dc.transition(linesGEnter, _chart.transitionDuration())
@@ -500,11 +500,11 @@ dc.coordinateGridMixin = function (_chart) {
             dc.transition(lines, _chart.transitionDuration())
                 .attr("x1", 1)
                 .attr("y1", function (d) {
-                    return _y(d);
+                    return scale(d);
                 })
                 .attr("x2", _chart.xAxisLength())
                 .attr("y2", function (d) {
-                    return _y(d);
+                    return scale(d);
                 });
 
             // exit
@@ -513,7 +513,7 @@ dc.coordinateGridMixin = function (_chart) {
         else {
             gridLineG.selectAll("line").remove();
         }
-    }
+    };
 
     _chart._yAxisX = function () {
         return _chart.useRightYAxis() ? _chart.width() - _chart.margins().right : _chart.margins().left;

--- a/web/examples/composite.html
+++ b/web/examples/composite.html
@@ -41,6 +41,7 @@ q.await(function(error, exp1, exp2) {
         .x(d3.scale.linear().domain([0,20]))
         .yAxisLabel("The Y Axis")
         .legend(dc.legend().x(80).y(20).itemHeight(13).gap(5))
+        .renderHorizontalGridLines(true)
         .compose([
             dc.lineChart(composite)
                 .dimension(dim)


### PR DESCRIPTION
Fixes #451.

This adds a `.useRightAxisGridLines` method to composite charts that allows you to control which of the two axes from which gridlines will be drawn. This option is only respected when there are subcharts for both y-axes.
