### PR TITLE
renderTitle flag not being respected

### DIFF
--- a/spec/composite-chart-spec.js
+++ b/spec/composite-chart-spec.js
@@ -420,6 +420,18 @@ describe('dc.compositeChart', function() {
         });
     });
 
+    describe('subchart title rendering', function () {
+        beforeEach(function () {
+            chart.renderTitle(false);
+            chart.render();
+        });
+
+        it('should respect boolean flag when title not set', function () {
+            expect(chart.select(".sub._0 .dc-tooltip._0 .dot").empty()).toBeTruthy();
+            expect(chart.select(".sub._1 .dc-tooltip._0 .dot").empty()).toBeTruthy();
+        });
+    });
+
     describe('when using a right y-axis', function () {
         var rightChart;
 

--- a/spec/line-chart-spec.js
+++ b/spec/line-chart-spec.js
@@ -243,6 +243,18 @@ describe('dc.lineChart', function() {
             });
         });
 
+        describe('title rendering', function () {
+            beforeEach(function () {
+                chart.renderTitle(false);
+                chart.render();
+            });
+
+            it('should not render tooltips when boolean flag is false', function () {
+                expect(chart.select(".sub._0 .dc-tooltip._0 .dot").empty()).toBeTruthy();
+                expect(chart.select(".sub._1 .dc-tooltip._0 .dot").empty()).toBeTruthy();
+            });
+        });
+
         describe('data point highlights', function () {
             beforeEach(function () {
                 chart.title(function (d) { return d.value; });

--- a/src/base-mixin.js
+++ b/src/base-mixin.js
@@ -40,7 +40,7 @@ dc.baseMixin = function (_chart) {
     var _title = function (d) {
         return _chart.keyAccessor()(d) + ": " + _chart.valueAccessor()(d);
     };
-    var _renderTitle = false;
+    var _renderTitle = true;
 
     var _transitionDuration = 750;
 
@@ -731,7 +731,7 @@ dc.baseMixin = function (_chart) {
     _chart.title = function (_) {
         if (!arguments.length) return _title;
         _title = _;
-        _renderTitle = true;
+        // _renderTitle = true;
         return _chart;
     };
 

--- a/src/bubble-mixin.js
+++ b/src/bubble-mixin.js
@@ -17,7 +17,7 @@ dc.bubbleMixin = function (_chart) {
     _chart = dc.colorMixin(_chart);
 
     _chart.renderLabel(true);
-    _chart.renderTitle(false);
+    _chart.renderTitle(true);
 
     _chart.data(function(group) {
         return group.top(Infinity);

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -62,6 +62,7 @@ dc.compositeChart = function (parent, chartGroup) {
             child.xUnits(_chart.xUnits());
             child.transitionDuration(_chart.transitionDuration());
             child.brushOn(_chart.brushOn());
+            child.renderTitle(_chart.renderTitle());
         }
 
         return g;

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -211,6 +211,12 @@ dc.lineChart = function (parent, chartGroup) {
                     .append("circle")
                     .attr("class", DOT_CIRCLE_CLASS)
                     .attr("r", getDotRadius())
+                    .attr("cx", function (d) {
+                        return dc.utils.safeNumber(_chart.x()(d.x));
+                    })
+                    .attr("cy", function (d) {
+                        return dc.utils.safeNumber(_chart.y()(d.y + d.y0));
+                    })
                     .attr("fill", _chart.getColor)
                     .style("fill-opacity", _dataPointFillOpacity)
                     .style("stroke-opacity", _dataPointStrokeOpacity)
@@ -224,15 +230,7 @@ dc.lineChart = function (parent, chartGroup) {
                         hideDot(dot);
                         hideRefLines(g);
                     })
-                    .append("title").text(dc.pluck('data', _chart.title(d.name)));
-
-                dots.attr("cx", function (d) {
-                        return dc.utils.safeNumber(_chart.x()(d.x));
-                    })
-                    .attr("cy", function (d) {
-                        return dc.utils.safeNumber(_chart.y()(d.y + d.y0));
-                    })
-                    .select("title").text(dc.pluck('data', _chart.title(d.name)));
+                    .call(renderTitle, d);
 
                 dots.exit().remove();
             });
@@ -277,6 +275,10 @@ dc.lineChart = function (parent, chartGroup) {
     function hideRefLines(g) {
         g.select("path." + Y_AXIS_REF_LINE_CLASS).style("display", "none");
         g.select("path." + X_AXIS_REF_LINE_CLASS).style("display", "none");
+    }
+
+    function renderTitle(dot, d) {
+        if (_chart.renderTitle()) dot.append("title").text(dc.pluck('data', _chart.title(d.name)));
     }
 
     /**

--- a/test/bubble-chart-test.js
+++ b/test/bubble-chart-test.js
@@ -37,7 +37,6 @@ function buildChart(id) {
         .renderTitle(true)
         .title(function (p) {
             return p.key + ": {count:" + p.value.count + ",value:" + p.value.value + "}";
-
         });
     chart.render();
     return chart;


### PR DESCRIPTION
Rendertitle flag was only respected if called after calling title method, otherwise it was always [true]. Additionally, in line charts, rendertitle was never checked. The flag now defaults to [true] and is respected by all charts regardless of setting a title.
