### PR TITLE
added .fixedBarHeight([height]) to rowChart - useful for TopN charts

### DIFF
--- a/spec/row-chart-spec.js
+++ b/spec/row-chart-spec.js
@@ -56,6 +56,20 @@ describe('dc.rowChart', function() {
         });
     });
 
+    describe('with a fixedBarHeight', function () {
+        beforeEach(function () {
+            chart.group(positiveGroupHolder.group);
+            chart.elasticX(false);
+            chart.x(d3.scale.log());
+            chart.fixedBarHeight(10);
+            chart.render();
+        });
+
+        it('should render fixed rect height', function () {
+            expect(chart.select('g.row rect').attr('height')).toBeWithinDelta(10, 0.0);
+        });
+    });
+
     function itShouldBehaveLikeARowChartWithGroup(groupHolder) {
         describe('for ' + groupHolder.groupType + ' data', function () {
             var group;

--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -33,6 +33,7 @@ dc.rowChart = function (parent, chartGroup) {
 
     var _gap = 5;
 
+    var _fixedBarHeight = false;
     var _rowCssClass = "row";
     var _titleRowCssClass = "titlerow";
     var _renderTitleLabel = false;
@@ -146,7 +147,9 @@ dc.rowChart = function (parent, chartGroup) {
     function updateElements(rows) {
         var n = _rowData.length;
 
-        var height = (_chart.effectiveHeight() - (n + 1) * _gap) / n;
+        var height;
+        if (!_fixedBarHeight) height = (_chart.effectiveHeight() - (n + 1) * _gap) / n;
+            else height = _fixedBarHeight;
 
         var rect = rows.attr("transform",function (d, i) {
                 return "translate(0," + ((i + 1) * _gap + i * height) + ")";
@@ -265,6 +268,36 @@ dc.rowChart = function (parent, chartGroup) {
     _chart.xAxis = function () {
         return _xAxis;
     };
+    
+    /**
+    #### .fixedBarHeight([height])
+    Get or set the fixed bar height. Default is [false] which will auto-scale bars.
+    For example, if you want to fix the height for a specific number of bars (useful in TopN charts) 
+    you could fix height as follows (where count = total number of bars in your TopN and gap is your vertical gap space).  
+    ```js
+     chart.fixedBarHeight( chartheight - (count + 1) * gap / count);
+    ```
+    **/
+    _chart.fixedBarHeight = function (g) {
+        if (!arguments.length) return _fixedBarHeight;
+        _fixedBarHeight = g;
+        return _chart;
+    };
+
+    /**
+    #### .fixedBarHeight([height])
+    Get or set the fixed bar height. Default is [false] which will auto-scale bars.
+    For example, if you want to fix the height for a specific number of bars (useful in TopN charts) 
+    you could fix height as follows (where count = total number of bars in your TopN and gap is your vertical gap space).  
+    ```js
+     chart.fixedBarHeight( chartheight - (count + 1) * gap / count);
+    ```
+    **/
+    _chart.fixedBarHeight = function (g) {
+        if (!arguments.length) return _fixedBarHeight;
+        _fixedBarHeight = g;
+        return _chart;
+    };    
 
     /**
     #### .gap([gap])


### PR DESCRIPTION
This was a UX request from a designer, and I found it useful.  Sometimes the rowChart autoscaling looks a little fat and chunky, say for example 2 rows when it normally shows 10 rows.

We use TopN charts, and graphically it is appealing if the bar height always stays the same.  So if we do Top 10, we always show bars that are height / 10 (plus gap).  Then we don't get fat bars.
The documentation for this parameter shows how to calculate bar height with a gap for nicely formatted viewing.
