### PR TITLE
Fixed error when un-brushing range chart

### DIFF
--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -746,6 +746,14 @@ describe('dc.coordinateGridChart', function() {
             expect(chart.focus).toHaveBeenCalledWith(selectedRange);
         });
 
+        it("should zoom the focus chart back out when range chart is un-brushed", function () {
+            rangeChart.brush().extent(selectedRange);
+            rangeChart.brush().event(rangeChart.g());
+            spyOn(chart, "focus");
+            rangeChart.filter(null);
+            expect(chart.focus).toHaveBeenCalledWith(null);
+        });
+
         it("should update the range chart brush to match zoomed domain of focus chart", function () {
             spyOn(rangeChart, "replaceFilter");
             chart.focus(selectedRange);

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -993,18 +993,17 @@ dc.coordinateGridMixin = function (_chart) {
         if (!range1 && !range2) {
             return true;
         }
-
-        if (range1.length === 0 && range2.length === 0) {
+        else if (!range1 || !range2) {
+            return false;
+        }
+        else if (range1.length === 0 && range2.length === 0) {
             return true;
         }
-
-        if (range1 && range2 &&
-            range1[0].valueOf() === range2[0].valueOf() &&
+        else if (range1[0].valueOf() === range2[0].valueOf() &&
             range1[1].valueOf() === range2[1].valueOf()) {
             return true;
         }
-
-        return false;
+        else return false;
     }
 
     /**


### PR DESCRIPTION
This fixes issue #488 - when you brush the range chart, then click it to un-brush, an error occurs and focus chart fails to zoom back out.
