### PR TITLE
fix error in comments for API docs y and x AxisMin & Max

### DIFF
--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -612,7 +612,7 @@ dc.coordinateGridMixin = function (_chart) {
     };
 
     /**
-    #### .xAxisMin()
+    #### .xAxisMax()
     Return the maximum x value to diplay in the chart. Includes xAxisPadding if set.
     **/
     _chart.xAxisMax = function () {
@@ -623,7 +623,7 @@ dc.coordinateGridMixin = function (_chart) {
     };
 
     /**
-    #### .xAxisMin()
+    #### .yAxisMin()
     Return the minimum y value to diplay in the chart. Includes yAxisPadding if set.
     **/
     _chart.yAxisMin = function () {


### PR DESCRIPTION
looks like some old copy/paste on these resulted in a small bug to the API docs.  no change to functionality.
