### PR TITLE
fixed typo in doc (angel -> angle)

### DIFF
--- a/dc.js
+++ b/dc.js
@@ -3416,9 +3416,9 @@ dc.pieChart = function (parent, chartGroup) {
     };
 
     /**
-    #### .minAngelForLabel([minAngle])
+    #### .minAngleForLabel([minAngle])
     Get or set the minimal slice angle for label rendering. Any slice with a smaller angle will not render slice label.
-    Default min angel is 0.5.
+    Default min angle is 0.5.
     **/
     _chart.minAngleForLabel = function (_) {
         if (!arguments.length) return _minAngleForLabel;

--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -292,9 +292,9 @@ dc.pieChart = function (parent, chartGroup) {
     };
 
     /**
-    #### .minAngelForLabel([minAngle])
+    #### .minAngleForLabel([minAngle])
     Get or set the minimal slice angle for label rendering. Any slice with a smaller angle will not render slice label.
-    Default min angel is 0.5.
+    Default min angle is 0.5.
     **/
     _chart.minAngleForLabel = function (_) {
         if (!arguments.length) return _minAngleForLabel;

--- a/web/docs/api-1.5.0.md
+++ b/web/docs/api-1.5.0.md
@@ -482,9 +482,9 @@ Get center x coordinate position. This function is **not chainable**.
 #### .cy()
 Get center y coordinate position. This function is **not chainable**.
 
-#### .minAngelForLabel([minAngle])
+#### .minAngleForLabel([minAngle])
 Get or set the minimal slice angle for label rendering. Any slice with a smaller angle will not render slice label.
-Default min angel is 0.5.
+Default min angle is 0.5.
 
 #### .slicesCap([cap])
 Get or set the maximum number of slices the pie chart will generate. Slices are ordered by its value from high to low.

--- a/web/docs/api-1.6.0.md
+++ b/web/docs/api-1.6.0.md
@@ -609,9 +609,9 @@ Get center x coordinate position. This function is **not chainable**.
 #### .cy()
 Get center y coordinate position. This function is **not chainable**.
 
-#### .minAngelForLabel([minAngle])
+#### .minAngleForLabel([minAngle])
 Get or set the minimal slice angle for label rendering. Any slice with a smaller angle will not render slice label.
-Default min angel is 0.5.
+Default min angle is 0.5.
 
 ## <a name="bar-chart" href="#bar-chart">#</a> Bar Chart [Concrete] < [Stackable Chart](#stackable-chart) < [CoordinateGrid Chart](#coordinate-grid-chart)
 Concrete bar chart/histogram implementation.

--- a/web/docs/api-latest.md
+++ b/web/docs/api-latest.md
@@ -775,9 +775,9 @@ Get center x coordinate position. This function is **not chainable**.
 #### .cy()
 Get center y coordinate position. This function is **not chainable**.
 
-#### .minAngelForLabel([minAngle])
+#### .minAngleForLabel([minAngle])
 Get or set the minimal slice angle for label rendering. Any slice with a smaller angle will not render slice label.
-Default min angel is 0.5.
+Default min angle is 0.5.
 
 ## Bar Chart
 

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -690,9 +690,9 @@ will be essentially rendered as a doughnut chart. Default inner radius is 0px.</
 <p>Get center x coordinate position. This function is <strong>not chainable</strong>.</p>
 <h4 id="-cy-">.cy()</h4>
 <p>Get center y coordinate position. This function is <strong>not chainable</strong>.</p>
-<h4 id="-minangelforlabel-minangle-">.minAngelForLabel([minAngle])</h4>
+<h4 id="-minangleforlabel-minangle-">.minAngleForLabel([minAngle])</h4>
 <p>Get or set the minimal slice angle for label rendering. Any slice with a smaller angle will not render slice label.
-Default min angel is 0.5.</p>
+Default min angle is 0.5.</p>
 <h2 id="bar-chart">Bar Chart</h2>
 <p>Includes: <a href="#stack Mixin">Stack Mixin</a>, <a href="#coordinate-grid-mixin">Coordinate Grid Mixin</a></p>
 <p>Concrete bar chart/histogram implementation.</p>

--- a/web/js/dc.js
+++ b/web/js/dc.js
@@ -3416,9 +3416,9 @@ dc.pieChart = function (parent, chartGroup) {
     };
 
     /**
-    #### .minAngelForLabel([minAngle])
+    #### .minAngleForLabel([minAngle])
     Get or set the minimal slice angle for label rendering. Any slice with a smaller angle will not render slice label.
-    Default min angel is 0.5.
+    Default min angle is 0.5.
     **/
     _chart.minAngleForLabel = function (_) {
         if (!arguments.length) return _minAngleForLabel;


### PR DESCRIPTION
Mostly in docs but I've made changes to doc parts of src/pie-chart.js

The commands I used are;

```
git grep -l minAngel | xargs sed --in-place 's/minAngel/minAngle/g'
git grep -l angel | xargs sed --in-place 's/angel/angle/g'
```
