### PR TITLE
Exposes filter functions so they can be easily overriden

### DIFF
--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -1,5 +1,5 @@
 describe("dc.baseMixin", function () {
-    var chart, dimension, group;
+    var chart, dimension, group, addFilterHandler, removeFilterHandler, hasFilterHandler, resetFilterHandler;
 
     beforeEach(function () {
         var data = crossfilter(loadDateFixture());
@@ -16,6 +16,10 @@ describe("dc.baseMixin", function () {
                 group: group,
                 transitionDuration: 0
             });
+        addFilterHandler = chart.addFilterHandler();
+        hasFilterHandler = chart.hasFilterHandler();
+        removeFilterHandler = chart.removeFilterHandler();
+        resetFilterHandler = chart.resetFilterHandler();
     });
 
     describe('renderlets', function () {
@@ -297,6 +301,144 @@ describe("dc.baseMixin", function () {
             it('should ask the callback for the width', function () {
                 expect(chart.width()).toEqual(800);
             });
+        });
+    });
+
+    describe('filter handling', function () {
+        var filter, notFilter;
+        beforeEach(function () {
+            // 1 && 0 should handle most cases.  Could be true/false booleans...
+            filter = 1;
+            notFilter = 0;
+            chart.addFilterHandler(addFilterHandler);
+            chart.hasFilterHandler(hasFilterHandler);
+            chart.removeFilterHandler(removeFilterHandler);
+            chart.resetFilterHandler(resetFilterHandler);
+            chart.filterAll();
+        });
+        it('has a default hasFilterHandler', function () {
+            chart.filter(filter);
+            expect(chart.hasFilter(filter)).toBeTruthy();
+            expect(chart.hasFilter(notFilter)).toBeFalsy();
+        });
+        it('has a truthy hasFilterHandler', function () {
+            chart.filter(filter);
+            chart.hasFilterHandler(function () { return true; });
+            expect(chart.hasFilter(filter)).toBeTruthy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+        });
+        it('has a falsy hasFilterHandler', function () {
+            chart.filter(filter);
+            chart.hasFilterHandler(function () { return false; });
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeFalsy();
+        });
+        it('has a default addFilterHandler', function () {
+            chart.filter(filter);
+            expect(chart.hasFilter(filter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(1);
+        });
+        it('has a noop addFilterHandler', function () {
+            chart.addFilterHandler(function (filters, filter) {
+                return filters;
+            });
+            chart.filter(filter);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeFalsy();
+            expect(chart.filters().length).toEqual(0);
+        });
+        it('has a static addFilterHandler', function () {
+            chart.addFilterHandler(function (filters, filter) {
+                filters.push(notFilter);
+                return filters;
+            });
+            chart.filter(filter);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(1);
+        });
+        it('has a default removeFilterHandler', function () {
+            chart.filter(filter);
+            chart.filter(notFilter);
+            expect(chart.filters().length).toEqual(2);
+            chart.filter(filter);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(1);
+            chart.filter(notFilter);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeFalsy();
+            expect(chart.filters().length).toEqual(0);
+        });
+        it('has a noop removeFilterHandler', function () {
+            chart.filter(filter);
+            chart.filter(notFilter);
+            chart.removeFilterHandler(function (filters, filter) {
+                return filters;
+            });
+            expect(chart.filters().length).toEqual(2);
+            chart.filter(filter);
+            expect(chart.hasFilter(filter)).toBeTruthy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(2);
+            chart.filter(notFilter);
+            expect(chart.hasFilter(filter)).toBeTruthy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(2);
+        });
+        it('has a shift removeFilterHandler', function () {
+            chart.filter(filter);
+            chart.filter(notFilter);
+            chart.removeFilterHandler(function (filters, filter) {
+                if (filters.length > 0) {
+                    filters.shift();
+                }
+                return filters;
+            });
+            expect(chart.filters().length).toEqual(2);
+            chart.filter(notFilter);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(1);
+            chart.filter(notFilter);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeFalsy();
+            expect(chart.filters().length).toEqual(0);
+        });
+        it('has a default resetFilterHandler', function () {
+            chart.filter(filter);
+            chart.filter(notFilter);
+            chart.filter(null);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeFalsy();
+            expect(chart.filters().length).toEqual(0);
+        });
+        it('has a noop resetFilterHandler', function () {
+            chart.filter(filter);
+            chart.filter(notFilter);
+            chart.resetFilterHandler(function (filters) {
+                return filters;
+            });
+            chart.filter(null);
+            expect(chart.hasFilter(filter)).toBeTruthy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(2);
+        });
+        it('has a shift resetFilterHandler', function () {
+            chart.filter(filter);
+            chart.filter(notFilter);
+            chart.resetFilterHandler(function (filters) {
+                filters.shift();
+                return filters;
+            });
+            chart.filter(null);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeTruthy();
+            expect(chart.filters().length).toEqual(1);
+            chart.filter(null);
+            expect(chart.hasFilter(filter)).toBeFalsy();
+            expect(chart.hasFilter(notFilter)).toBeFalsy();
+            expect(chart.filters().length).toEqual(0);
         });
     });
 });

--- a/src/base-mixin.js
+++ b/src/base-mixin.js
@@ -488,22 +488,26 @@ dc.baseMixin = function (_chart) {
     };
 
     var _hasFilterHandler = function (filters, filter) {
-        if (!filter) return filters.length > 0;
-        return filters.some(function(f) {
+        if (filter === null || typeof(filter) === 'undefined') {
+            return filters.length > 0;
+        }
+        return filters.some(function (f) {
             return filter <= f && filter >= f;
         });
     };
 
     /**
     Set or get the has filter handler. The has filter handler is a function that performs the logical check if the
-    current chart filters has a specific filter.  Using a custom has filter handler allows you to perform additional
+    current chart's filters have a specific filter.  Using a custom has filter handler allows you to perform additional
     logic upon checking if a filter exists.
 
     ```js
-    // default remove filter handler
+    // default has filter handler
     function (filters, filter) {
-        if (!arguments.length) return _filters.length > 0;
-        return _filters.some(function(f) {
+        if (filter === null || typeof(filter) === 'undefined') {
+            return filters.length > 0;
+        }
+        return filters.some(function (f) {
             return filter <= f && filter >= f;
         });
     }
@@ -512,16 +516,19 @@ dc.baseMixin = function (_chart) {
     chart.hasFilterHandler(function(filter) {
         return false;
     });
+    ```
     **/
     _chart.hasFilterHandler = function (_) {
-        if (!arguments.length) return _hasFilterHandler;
+        if (!arguments.length) {
+            return _hasFilterHandler;
+        }
         _hasFilterHandler = _;
         return _chart;
     };
 
     /**
     #### .hasFilter([filter])
-    Check whether is any active filter or a specific filter is associated with particular chart instance.
+    Check whether any active filter or a specific filter is associated with particular chart instance.
     This function is **not chainable**.
 
     **/
@@ -530,8 +537,8 @@ dc.baseMixin = function (_chart) {
     };
 
     var _removeFilterHandler = function (filters, filter) {
-        for(var i = 0; i < filters.length; i++) {
-            if(filters[i] <= filter && filters[i] >= filter) {
+        for (var i = 0; i < filters.length; i++) {
+            if (filters[i] <= filter && filters[i] >= filter) {
                 filters.splice(i, 1);
                 break;
             }
@@ -541,14 +548,14 @@ dc.baseMixin = function (_chart) {
 
     /**
     Set or get the remove filter handler. The remove filter handler is a function that performs the removal of a filter
-    from the charts filter list. Using a custom remove filter handler allows you to perform additional logic
-    upon removing a filter.
+    from the chart's current filters. Using a custom remove filter handler allows you to perform additional logic
+    upon removing a filter.  Any changes should modify the `filters` argument reference and return that reference.
 
     ```js
     // default remove filter handler
     function (filters, filter) {
-        for(var i = 0; i < filters.length; i++) {
-            if(filters[i] <= filter && filters[i] >= filter) {
+        for (var i = 0; i < filters.length; i++) {
+            if (filters[i] <= filter && filters[i] >= filter) {
                 filters.splice(i, 1);
                 break;
             }
@@ -560,9 +567,12 @@ dc.baseMixin = function (_chart) {
     chart.removeFilterHandler(function(filters, filter) {
         return filters;
     });
+    ```
     **/
     _chart.removeFilterHandler = function (_) {
-        if (!arguments.length) return _removeFilterHandler;
+        if (!arguments.length) {
+            return _removeFilterHandler;
+        }
         _removeFilterHandler = _;
         return _chart;
     };
@@ -575,10 +585,10 @@ dc.baseMixin = function (_chart) {
     /**
     Set or get the add filter handler. The add filter handler is a function that performs the addition of a filter
     to the charts filter list. Using a custom add filter handler allows you to perform additional logic
-    upon adding a filter.
+    upon adding a filter.  Any changes should modify the `filters` argument reference and return that reference.
 
     ```js
-    // default remove filter handler
+    // default add filter handler
     function (filters, filter) {
         filters.push(filter);
         return filters;
@@ -588,21 +598,24 @@ dc.baseMixin = function (_chart) {
     chart.addFilterHandler(function(filters, filter) {
         return filters;
     });
+    ```
     **/
     _chart.addFilterHandler = function (_) {
-        if (!arguments.length) return _addFilterHandler;
+        if (!arguments.length) {
+            return _addFilterHandler;
+        }
         _addFilterHandler = _;
         return _chart;
     };
 
-    var _resetFilterHandler = function(filters) {
+    var _resetFilterHandler = function (filters) {
         return [];
     };
 
     /**
     Set or get the reset filter handler. The reset filter handler is a function that performs the reset of the filters
     list by returning the new list. Using a custom reset filter handler allows you to perform additional logic
-    upon reseting the filters.
+    upon reseting the filters.  This function should return an array.
 
     ```js
     // default remove filter handler
@@ -614,9 +627,12 @@ dc.baseMixin = function (_chart) {
     chart.addFilterHandler(function(filters) {
         return filters;
     });
+    ```
     **/
     _chart.resetFilterHandler = function (_) {
-        if (!arguments.length) return _resetFilterHandler;
+        if (!arguments.length) {
+            return _resetFilterHandler;
+        }
         _resetFilterHandler = _;
         return _chart;
     };
@@ -642,7 +658,6 @@ dc.baseMixin = function (_chart) {
     // filter by a single age
     chart.filter(18);
     ```
-
     **/
     _chart.filter = function (_) {
         if (!arguments.length) return _filters.length > 0 ? _filters[0] : null;


### PR DESCRIPTION
the _chart.filter(_) function is nice, but it's not reusable at all.  This exposes each portion of the filter function as necessary.  Also gives some code reuse when encountering the array filter. 
