### PR TITLE
"Auto" width for items in horizontal legend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-- '0.10'
-script: grunt ci
+  - '0.10'
+script:
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then grunt ci; else grunt ci-pull; fi'
 env:
   global:
   - secure: Kt+5IJDJRVwr28xRnmR5YDsJceXDcDR21/JUBfk6DYFixPbIq7LCPnZUmiSZQs8akU95ucXwB5hsirUAdEhXdYKilec6go70lticVlZBLy8IdJ+Di1uPwMOeMHvalC2P0woIRJSMzP8u5E+e+5ASggTjsXID7/p1rE0jXtoOueQ=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -277,6 +277,7 @@ module.exports = function (grunt) {
     grunt.registerTask('test', ['docs', 'jasmine:specs', 'test-stock-example', 'shell:hooks']);
     grunt.registerTask('coverage', ['docs', 'jasmine:coverage']);
     grunt.registerTask('ci', ['test', 'jasmine:specs:build', 'connect:server', 'saucelabs-jasmine']);
+    grunt.registerTask('ci-pull', ['test', 'jasmine:specs:build', 'connect:server']);
     grunt.registerTask('lint', ['build', 'jshint']);
     grunt.registerTask('default', ['build']);
 };


### PR DESCRIPTION
Continuing #549 - I have reworked my proposal to be backwards compatible with existing code using DC.js and added tests for Jasmine. By default autoItemWidth is set to "false" so itemWidth is taken into account when laying out horizontal legends just like it is now. If autoItemWidth is explicitly set to "true", itemWidth is ignored and legend items are laid out according to their actual width, with a gap equal to gap() between them.

Unfortunately my build still fails this test locally (see #550 and #559):

```
dc.compositeChart elastic chart axes should set the x domain
```

But I hope this is an issue completely on my side. All other tests are passed.
