### PR TITLE
Fixes bug 551

### DIFF
--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -90,7 +90,8 @@ dc.barChart = function (parent, chartGroup) {
         bars.enter()
             .append("rect")
             .attr("class", "bar")
-            .attr("fill", dc.pluck('data',_chart.getColor));
+            .attr("fill", dc.pluck('data',_chart.getColor))
+            .attr("height", 0);
 
         if (_chart.renderTitle())
             bars.append("title").text(dc.pluck('data',_chart.title(d.name)));


### PR DESCRIPTION
Fixes Bug #551.  When a bar enters, this initializes the height of the bar to 0.

There also seems to be a failing test case with the regression suite.  Would you like me to run that update as well and include in the pull request?
