### PR TITLE
FIX #579 Maintain brushOn when redrawing series chart with new data

### DIFF
--- a/spec/series-chart-spec.js
+++ b/spec/series-chart-spec.js
@@ -48,13 +48,24 @@ describe('dc.seriesChart', function() {
             expect(d3.select(lines[0][1]).attr("d")).toMatchPath("M0,43L130,0");
         });
 
+
         it('should color lines using the colors in the data', function() {
             var lines = chart.selectAll("path.line");
 
             expect(d3.select(lines[0][0]).attr("stroke")).toBe("#000001");
             expect(d3.select(lines[0][1]).attr("stroke")).toBe("#000002");
         });
+
+        describe('with brush off', function () {
+          it('should create line chart dots', function () {
+            chart.brushOn(false).render();
+            var dots = chart.selectAll('circle.dot');
+            expect(dots[0].length).toEqual(4);
+            chart.brushOn(true);
+          });
+        });
     });
+
 
     describe('series sorting', function() {
         beforeEach(function() {
@@ -88,4 +99,36 @@ describe('dc.seriesChart', function() {
         });
     });
 
+    describe('#redraw', function () {
+      var jsonData = JSON.parse("[" +
+        "{\"colData\":\"1\", \"rowData\": \"1\", \"colorData\": \"1\"}," +
+        "{\"colData\":\"1\", \"rowData\": \"2\", \"colorData\": \"2\"}," +
+        "{\"colData\":\"2\", \"rowData\": \"1\", \"colorData\": \"3\"}," +
+        "{\"colData\":\"2\", \"rowData\": \"2\", \"colorData\": \"4\"}," +
+        "{\"colData\":\"3\", \"rowData\": \"1\", \"colorData\": \"5\"}," +
+        "{\"colData\":\"3\", \"rowData\": \"2\", \"colorData\": \"6\"}" +
+      "]");
+      var data = crossfilter(jsonData);
+      beforeEach(function () {
+        chart.brushOn(false);
+        chart.render();
+
+        var dimensionData = data.dimension(function (d) { return [+d.colData, +d.rowData]; });
+        var groupData = dimensionData.group().reduceSum(function(d) { return +d.colorData; });
+
+        chart.dimension(dimensionData).group(groupData);
+
+
+        chart.redraw();
+      });
+
+      afterEach(function () {
+        chart.brushOn(true);
+      });
+
+      it ('is redrawn with dots', function () {
+        var dots = chart.selectAll('circle.dot');
+        expect(dots[0].length).toEqual(6);
+      });
+    });
 });

--- a/src/series-chart.js
+++ b/src/series-chart.js
@@ -63,7 +63,8 @@ dc.seriesChart = function (parent, chartGroup) {
                     .dimension(_chart.dimension())
                     .group({all:d3.functor(sub.values)}, sub.key)
                     .keyAccessor(_chart.keyAccessor())
-                    .valueAccessor(_chart.valueAccessor());
+                    .valueAccessor(_chart.valueAccessor())
+                    .brushOn(_chart.brushOn());
             });
         // this works around the fact compositeChart doesn't really
         // have a removal interface


### PR DESCRIPTION
Implements and tests the fix suggested in #579
