### PR TITLE
Expose geo-choropleth's path object

### DIFF
--- a/src/geo-choropleth-chart.js
+++ b/src/geo-choropleth-chart.js
@@ -236,6 +236,19 @@ dc.geoChoroplethChart = function (parent, chartGroup) {
     };
 
     /**
+    #### .geoPath()
+    Return the d3.geo.path object used to render the projection and features.  Can be useful for figuring out the bounding
+    box of the feature set and thus a way to calculate scale and translation for the projection.
+
+    Return:
+    d3.geo.path()
+
+    **/
+    _chart.geoPath = function () {
+        return _geoPath;
+    }
+
+    /**
     #### .removeGeoJson(name)
     Remove a GeoJson layer from this chart by name
 


### PR DESCRIPTION
Simple change to expose object.  The d3.geo.path object can be used to calculate the bounding box of the geoJson features and thus a way to set scale and translate on the projection correctly:

See:
http://stackoverflow.com/questions/14492284/center-a-map-in-d3-given-a-geojson-object
