### PR TITLE
Add 'clickFilterBehavior' to base-mixin to allow ctrl-click joins

### DIFF
--- a/web/stock.js
+++ b/web/stock.js
@@ -237,6 +237,9 @@ d3.csv("ndx.csv", function (data) {
                    "Fluctuation / Index Ratio: " + numberFormat(p.value.fluctuationPercentage) + "%"]
                    .join("\n");
         })
+        //#### Customize how new filter selection clicks are handled
+        // Change from the default behavior to work like e.g. PowerPoint, where single left click selects, and ctrl-click adds or subtracts from the selection.
+        .clickFilterBehavior("replaceCtrlToggle")
         //#### Customize Axis
         //Set a custom tick format. Note `.yAxis()` returns an axis object, so any additional method chaining applies to the axis, not the chart.
         .yAxis().tickFormat(function (v) {


### PR DESCRIPTION
The clickFilterBehavior option is intended for ordinal charts, bubble charts, pie charts, etc, i.e., those where clicking on an svg node filters to that node. I have not tested what would happen if a user tried to enable on a brush filter for example. 

.clickFilterBehavior has 4 modes:
- "replace": The clicked node replaces the current filter list. Note that it is not possible to remove the filter in this case without a reset link.
- "toggle": Filtering for the clicked node is toggled from its current state. Therefore, if no filters are applied, clicking a node will filter all but that node (by applying an inverse filter under the hood).
- "replaceThenToggle": This is the current behavior. If there are no filters applied, act as 'replace'. If there is one ore more filter applied, act as 'toggle'. 
- "replaceCtrlToggle": This acts like selecting graphics objects in e.g. PowerPoint.  Left-click acts as 'replace', and ctrl-click acts as 'toggle'. 
