### PR TITLE
Update api-1.6.0.md

### DIFF
--- a/web/docs/api-1.6.0.md
+++ b/web/docs/api-1.6.0.md
@@ -370,7 +370,7 @@ chart.x(d3.time.scale().domain([new Date(1985, 0, 1), new Date(2012, 11, 31)]))
 #### .xUnits([xUnits function])
 Set or get the xUnits function. xUnits function is the coordinate grid chart uses to calculate number of data
 projections on x axis such as number bars for a bar chart and number of dots for a line chart. This function is
-expected to return an Javascript array of all data points on x axis. d3 time range functions d3.time.days, d3.time.months,
+expected to return a Javascript array of all data points on x axis. d3 time range functions d3.time.days, d3.time.months,
 and d3.time.years are all valid xUnits function. dc.js also provides a few units function, see [Utilities](#util)
 section for a list of built-in units functions. Default xUnits function is dc.units.integers.
 ```js


### PR DESCRIPTION
Change "an Javascript array" to "a Javascript array" since "an" is only used before words that begin with a vowel (https://owl.english.purdue.edu/owl/resource/591/01/).
