### PR TITLE
Update docs to emphasize selector can be a string or a DOM node

### DIFF
--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -14,8 +14,8 @@ Examples:
 Create a bar chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string|compositeChart - any valid d3 single selector representing typically a dom block element such
-   as a div, or if this bar chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
+* parent : string | node | compositeChart - a valid d3 single selector (typically representing a DOM block element such
+   as a div), a DOM node, or if this bar chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/base-mixin.js
+++ b/src/base-mixin.js
@@ -263,9 +263,8 @@ dc.baseMixin = function (_chart) {
     };
 
     /**
-    #### .anchor([anchorChart/anchorSelector], [chartGroup])
-    Set the svg root to either be an existing chart's root or the first element returned from a d3 css string selector. Optionally registers the chart within the chartGroup. This class is called internally on chart initialization, but be called again to relocate the chart. However, it will orphan any previously created SVG elements.
-
+    #### .anchor([anchorChart/anchorSelector/anchorNode], [chartGroup])
+    Set the svg root to either be an existing chart's root or the result returned by d3's select method, which can operate on a css string selector or a DOM node. Optionally registers the chart within the chartGroup. This class is called internally on chart initialization, but be called again to relocate the chart. However, it will orphan any previously created SVG elements.
     **/
     _chart.anchor = function (a, chartGroup) {
         if (!arguments.length) return _anchor;

--- a/src/box-plot.js
+++ b/src/box-plot.js
@@ -9,7 +9,7 @@
  Create a box plot instance and attach it to the given parent element.
 
  Parameters:
- * parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+ * parent : string | node - any valid d3 single selector (typically representing a dom block element such as a div) or a DOM node.
  * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
  in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
  chart group.

--- a/src/bubble-chart.js
+++ b/src/bubble-chart.js
@@ -18,7 +18,7 @@ Examples:
 Create a bubble chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/bubble-overlay.js
+++ b/src/bubble-overlay.js
@@ -15,8 +15,8 @@ Examples:
 Create a bubble overlay chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div. Typically
-   this element should also be the parent of the underlying image.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
+  Typically this element should also be the parent of the underlying image.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -12,7 +12,7 @@ charting effects.
 Create a composite chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/data-count.js
+++ b/src/data-count.js
@@ -19,7 +19,7 @@ Create a data count widget instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/data-grid.js
+++ b/src/data-grid.js
@@ -13,7 +13,7 @@
  Create a data grid widget instance and attach it to the given parent element.
 
  Parameters:
- * parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+ * parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
  * chartGroup : string (optional) - name of the chart group this chart instance should be
  placed in. Once a chart is placed in a chart group then any interaction with the chart
  will only trigger events and redraw within the same chart group.

--- a/src/data-table.js
+++ b/src/data-table.js
@@ -13,7 +13,7 @@ Examples:
 Create a data table widget instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/geo-choropleth-chart.js
+++ b/src/geo-choropleth-chart.js
@@ -14,7 +14,7 @@ Examples:
 Create a choropleth chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/heatmap.js
+++ b/src/heatmap.js
@@ -9,7 +9,7 @@
  Create a heat map instance and attach it to the given parent element.
 
  Parameters:
- * parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+ * parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
  * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
  in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
  chart group.

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -14,8 +14,8 @@ Create a line chart instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string|compositeChart - any valid d3 single selector representing typically a dom block element such
-   as a div, or if this line chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
+* parent : string | node | compositeChart - any valid d3 single selector (typically representing a DOM block element such
+   as a div), a DOM node, or if this line chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/number-display.js
+++ b/src/number-display.js
@@ -16,7 +16,7 @@ Unlike other charts, you do not need to set a dimension. Instead a valid group o
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div or span
+* parent : string | node - any valid d3 single selector typically representing a DOM block element such as a div or span or a DOM node
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -16,8 +16,8 @@ Create a pie chart instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such
-   as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such
+   as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
    in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
    chart group.

--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -10,7 +10,7 @@ Create a row chart instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed in a certain chart group then any interaction with such instance will only trigger events and redraw within the same chart group.
 
 Return a newly created row chart instance

--- a/src/scatter-plot.js
+++ b/src/scatter-plot.js
@@ -10,8 +10,8 @@ Create a scatter plot instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string|compositeChart - any valid d3 single selector representing typically a dom block element such
-as a div, or if this scatter plot is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
+* parent : string | node | compositeChart - any valid d3 single selector (typically representing a DOM block element such
+as a div), a DOM node, or if this scatter plot is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.

--- a/src/series-chart.js
+++ b/src/series-chart.js
@@ -11,7 +11,7 @@
  Create a series chart instance and attach it to the given parent element.
 
  Parameters:
- * parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+ * parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
  * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
  in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
  chart group.

--- a/web/docs/api-latest.md
+++ b/web/docs/api-latest.md
@@ -168,8 +168,8 @@ d3.select("#chart-id").selectAll(selector);
 This function is **not chainable** since it does not return a chart instance; however the d3 selection result is
 chainable from d3's perspective.
 
-#### .anchor([anchorChart/anchorSelector], [chartGroup])
-Set the svg root to either be an existing chart's root or the first element returned from a d3 css string selector. Optionally registers the chart within the chartGroup. This class is called internally on chart initialization, but be called again to relocate the chart. However, it will orphan any previously created SVG elements.
+#### .anchor([anchorChart/anchorSelector/anchorNode], [chartGroup])
+Set the svg root to either be an existing chart's root or the result returned by d3's select method, which can operate on a css string selector or a DOM node. Optionally registers the chart within the chartGroup. This class is called internally on chart initialization, but be called again to relocate the chart. However, it will orphan any previously created SVG elements.
 
 #### .anchorName()
 Return the dom ID for chart's anchored location
@@ -742,8 +742,8 @@ Create a pie chart instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such
-as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such
+   as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -795,8 +795,8 @@ Examples:
 Create a bar chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string|compositeChart - any valid d3 single selector representing typically a dom block element such
-as a div, or if this bar chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
+* parent : string | node | compositeChart - any valid d3 single selector (typically representing a DOM block element such
+   as a div), a DOM node, or if this bar chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -858,8 +858,8 @@ Create a line chart instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string|compositeChart - any valid d3 single selector representing typically a dom block element such
-as a div, or if this line chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
+* parent : string | node | compositeChart - any valid d3 single selector (typically representing a DOM block element such
+   as a div), a DOM node, or if this line chart is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -928,7 +928,7 @@ Create a data count widget instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -965,7 +965,7 @@ Examples:
 Create a data table widget instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1032,7 +1032,7 @@ Examples:
 Create a data grid widget instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be
 placed in. Once a chart is placed in a chart group then any interaction with the chart
 will only trigger events and redraw within the same chart group.
@@ -1095,7 +1095,7 @@ Examples:
 Create a bubble chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1127,7 +1127,7 @@ charting effects.
 Create a composite chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1215,7 +1215,7 @@ all composite features other than recomposing the chart.
 Create a series chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1262,7 +1262,7 @@ Examples:
 Create a choropleth chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1335,8 +1335,8 @@ Examples:
 Create a bubble overlay chart instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div. Typically
-this element should also be the parent of the underlying image.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
+Typically this element should also be the parent of the underlying image.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1377,7 +1377,7 @@ Create a row chart instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed in a certain chart group then any interaction with such instance will only trigger events and redraw within the same chart group.
 
 Return a newly created row chart instance
@@ -1469,8 +1469,8 @@ Create a scatter plot instance and attach it to the given parent element.
 
 Parameters:
 
-* parent : string|compositeChart - any valid d3 single selector representing typically a dom block element such
-as a div, or if this scatter plot is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
+* parent : string | node | compositeChart - any valid d3 single selector (typically representing a DOM block element such
+as a div), a DOM node, or if this scatter plot is a sub-chart in a [Composite Chart](#composite-chart) then pass in the parent composite chart instance.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1518,7 +1518,7 @@ Unlike other charts, you do not need to set a dimension. Instead a valid group o
 
 Parameters:
 
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div or span
+* parent : string | node - any valid d3 single selector typically representing a DOM block element such as a div or span or a DOM node
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1551,7 +1551,7 @@ A heat map is matrix that represents the values of two dimensions of data using 
 Create a heat map instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a DOM block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.
@@ -1576,7 +1576,7 @@ A box plot is a chart that depicts numerical data via their quartile ranges.
 Create a box plot instance and attach it to the given parent element.
 
 Parameters:
-* parent : string - any valid d3 single selector representing typically a dom block element such as a div.
+* parent : string | node - any valid d3 single selector (typically representing a dom block element such as a div) or a DOM node.
 * chartGroup : string (optional) - name of the chart group this chart instance should be placed in. Once a chart is placed
 in a certain chart group then any interaction with such instance will only trigger events and redraw within the same
 chart group.


### PR DESCRIPTION
When instantiating a chart, the docs suggest that you have to pass in a d3 css string selector as the input parameter called `parent`. When creating the chart, `parent` is passed in as the input parameter to d3's select function. Because [d3's select works on DOM nodes](https://github.com/mbostock/d3/wiki/Selections#d3_select) in addition to string selectors,  `parent` could be a DOM node too.

Explicitly pointing out the ability to instantiate a chart with a DOM node is useful for anyone trying create a chart before injecting it into the DOM tree (for example in a Backbone.js view).
