### PR TITLE
update module.exports for browserify compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,4 @@
 
 d3 = require("d3");
 crossfilter = require("crossfilter");
-require("./dc");
-module.exports = dc;
+module.exports = require("./dc");


### PR DESCRIPTION
assigns the require of dc base package to module.exports for browserify compatibility.
This is so you can require the package and not have to put it in a script tag
