### PR TITLE
Row Chart: optionally ignore values that are zero

### DIFF
--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -53,6 +53,8 @@ dc.rowChart = function (parent, chartGroup) {
 
     var _rowData;
 
+    var _ignoreZeroValue = false;
+
     _chart.rowsCap = _chart.cap;
 
     function calculateAxisScale() {
@@ -124,7 +126,14 @@ dc.rowChart = function (parent, chartGroup) {
     }
 
     function drawChart() {
-        _rowData = _chart.data();
+
+        if (_ignoreZeroValue){
+            _rowData = _chart.data().filter(function(d){
+                return _chart.valueAccessor()(d) !== 0;
+            });
+        }else{
+            _rowData = _chart.data();
+        }
 
         drawAxis();
         drawGridLines();
@@ -351,6 +360,12 @@ dc.rowChart = function (parent, chartGroup) {
     _chart.titleLabelOffsetX = function (o) {
         if (!arguments.length) return _titleLabelOffsetX;
         _titleLabelOffsetX = o;
+        return _chart;
+    };
+
+    _chart.ignoreZeroValue = function(x){
+        if(!arguments.length) return _ignoreZeroValue;
+        _ignoreZeroValue = x;
         return _chart;
     };
 


### PR DESCRIPTION
I see that there are some [hacky proposals](https://groups.google.com/forum/#!topic/dc-js-user-group/UERVo4QGX7w) if users need to prevent having rows (elements) that appear with data.value = 0

This PR introduces `chart.ignoreZeroValue(true)` to enable this functionality
