### PR TITLE
Generate valid clip path id

### DIFF
--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -845,7 +845,7 @@ dc.coordinateGridMixin = function (_chart) {
     };
 
     function getClipPathId() {
-        return _chart.anchorName() + "-clip";
+        return _chart.anchorName().replace(/[ .#]/g, '-') + "-clip";
     }
 
     /**


### PR DESCRIPTION
Prior to this patch, if you created a dc chart using a complex selector
like dc.barChart('#area .bar'), the resulting clip path id was invalid:
'area .bar-clip'. This patch replaces spaces, periods, and hash marks
in the id with hyphens to generate a valid clip path id.
