### PR TITLE
make line chart dots and xy refs optional with new api

### DIFF
--- a/spec/line-chart-spec.js
+++ b/spec/line-chart-spec.js
@@ -110,6 +110,20 @@ describe('dc.lineChart', function() {
             });
         });
 
+        describe('data point highlights and refs off', function () {
+            beforeEach(function () {
+                chart.title(function (d) { return d.value; });
+                chart.brushOn(false).xyTipsOn(false).render();
+            });
+            it('should not generate per data points', function () {
+                expect(chart.selectAll('circle.dot').size()).toBe(0);
+            });
+            it('should not generate x and y refs', function () {
+                expect(chart.selectAll('path.xRef').size()).toBe(0);
+                expect(chart.selectAll('path.yRef').size()).toBe(0);
+            });
+        });
+
         describe('data point highlights', function () {
             beforeEach(function () {
                 chart.title(function (d) { return d.value; });

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -54,6 +54,7 @@ dc.lineChart = function (parent, chartGroup) {
     var _tension = 0.7;
     var _defined;
     var _dashStyle;
+    var _xyTipsOn = true;
 
     _chart.transitionDuration(500);
     _chart._rangeBandPadding(1);
@@ -151,6 +152,18 @@ dc.lineChart = function (parent, chartGroup) {
         return _chart;
     };
 
+    /**
+    #### .xyTipsOn([boolean])
+    Turn on/off the mouseover behavior on an individual data point which renders a circle and x/y axis
+    dashed lines back to each respective axis.  This is ignored if the chart brush is on (i.e. `brushOn` is true).
+    Default: true
+    **/
+    _chart.xyTipsOn = function (_) {
+        if (!arguments.length) return _xyTipsOn;
+        _xyTipsOn = _;
+        return _chart;
+    };
+
     function colors(d, i) {
         return _chart.getColor.call(d,d.values,i);
     }
@@ -220,7 +233,7 @@ dc.lineChart = function (parent, chartGroup) {
     }
 
     function drawDots(chartBody, layers) {
-        if (!_chart.brushOn()) {
+        if (!_chart.brushOn() && _chart.xyTipsOn()) {
             var tooltipListClass = TOOLTIP_G_CLASS + "-list";
             var tooltips = chartBody.select("g." + tooltipListClass);
 


### PR DESCRIPTION
This is a fix for issue #689 that I filed.  
