### PR TITLE
Guard for -Infinite/Infinite in key/valueAccessors

### DIFF
--- a/spec/bubble-chart-spec.js
+++ b/spec/bubble-chart-spec.js
@@ -348,4 +348,34 @@ describe('dc.bubbleChart', function() {
             expect(chart.y().domain()[1]).toBe(12);
         });
     });
+
+    describe('with logarithmic scales', function() {
+        beforeEach(function () {
+            var rowDimension = data.dimension(function(d, i) {
+                return i;
+            });
+            var rowGroup = rowDimension.group();
+
+            chart
+				.dimension(rowDimension).group(rowGroup)
+                .keyAccessor(function(kv) {
+                    return 0;
+                })
+                .valueAccessor(function(kv) {
+                    return 0;
+                })
+				.x(d3.scale.log().domain([1, 300]))
+				.y(d3.scale.log().domain([1, 10]))
+				.elasticX(false)
+				.elasticY(false)
+				;
+        });
+
+        it('renders without errors', function () {
+            chart.render();
+            chart.selectAll("g.node").each(function (d, i) {
+				expect(d3.select(this).attr("transform")).toMatchTranslate(0,0);
+            });
+        });
+    });
 });

--- a/src/bubble-chart.js
+++ b/src/bubble-chart.js
@@ -125,14 +125,14 @@ dc.bubbleChart = function(parent, chartGroup) {
 
     function bubbleX(d) {
         var x = _chart.x()(_chart.keyAccessor()(d));
-        if (isNaN(x))
+        if (!isFinite(x))
             x = 0;
         return x;
     }
 
     function bubbleY(d) {
         var y = _chart.y()(_chart.valueAccessor()(d));
-        if (isNaN(y))
+        if (!isFinite(y))
             y = 0;
         return y;
     }


### PR DESCRIPTION
If scale is log(), then value can be calcuted to be -Infinite. d3.js throws exception when assigning attribute to element: 'Error: Invalid value for <g> attribute transform="translate(-Infinity,191)".'
Probably similar changes should be made in other places/charts.