### PR TITLE
Show filtered elements on render and not only on redraw

### DIFF
--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -856,6 +856,8 @@ dc.coordinateGridMixin = function (_chart) {
                 _chart.redrawBrush(g);
             }
         }
+
+        _chart.fadeDeselectedArea();
     };
 
     _chart.setHandlePaths = function (gBrush) {


### PR DESCRIPTION
Filtered elements were not shown on render only on redraw. Useful to resize charts for example.
