### PR TITLE
Fix vertical lines for ordinal charts

### DIFF
--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -382,7 +382,7 @@ dc.coordinateGridMixin = function (_chart) {
                     .attr("class", GRID_LINE_CLASS + " " + VERTICAL_CLASS)
                     .attr("transform", "translate(" + _chart.margins().left + "," + _chart.margins().top + ")");
 
-            var ticks = _xAxis.tickValues() ? _xAxis.tickValues() : _x.ticks(_xAxis.ticks()[0]);
+            var ticks = _xAxis.tickValues() ? _xAxis.tickValues() : (typeof _x.ticks === 'function' ? _x.ticks(_xAxis.ticks()[0]) : _x.domain());
 
             var lines = gridLineG.selectAll("line")
                 .data(ticks);


### PR DESCRIPTION
Charts using ordinal scales on the x axis with .renderVerticalGridLines
set did not work because ordinal scales do not have a .ticks function.
This patch checks for the existence of a .ticks function on the x scale
before trying to use it when rendering vertical lines, and if there isn't
one uses the scale's domain.
