### PR TITLE
Add a mouse wheel mixin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -295,6 +295,7 @@ module.exports.jsFiles = [
     "src/stack-mixin.js",
     "src/cap-mixin.js",
     "src/bubble-mixin.js",
+    "src/wheel-mixin.js",
     "src/pie-chart.js",
     "src/bar-chart.js",
     "src/line-chart.js",

--- a/src/wheel-mixin.js
+++ b/src/wheel-mixin.js
@@ -1,0 +1,140 @@
+/**
+## Wheel Mixin
+
+Wheel Mixin is an abstract chart functional class created to simplify use of
+  as a mix-in for any concrete
+chart implementation.
+
+**/
+
+dc.wheelMixin = function(_chart) {
+
+    /*
+     * These 3 elements below allow to disable an action during a certain time.
+     * It is necessary because the mousewheel call the function several time successively.
+     */
+    var disabledActions = {
+        mousewheel : false,
+    };
+
+    function delayAction (name, delay) {
+        disabledActions[name] = true;
+        d3.timer(function () { enableAction(name); return true; }, delay);
+    }
+
+    function enableAction (name) {
+        disabledActions[name] = false;
+    }
+
+
+    /**
+    #### .onMouseWheel(d, zoomIn, zoomOut)
+
+    This function will be called on mouseweel event.
+
+    **Parameters:**
+
+    * `d`: d3 SVG element on which we zoomed
+    * `zoomIn`: optional, indicates if zoomIn behavior is allowed (default: true)
+    * `zoomOut`:  optional, indicates if zoomOut behavior is allowed (default: true)
+
+    You should call this function when a mouseweel event is done on an element of the SVG.
+    To do this, simply use this code when on the SVG elements that you want:
+
+    ```js
+    // only allows zoomIn
+    elements
+        .on("mousewheel", function(d) { _chart.onMouseWheel(d, true, false); })
+        .on("DOMMouseScroll", _chart.onMouseWheel function(d) { _chart.onMouseWheel(d, true, false); }) // older versions of Firefox
+        .on("wheel", function(d) { _chart.onMouseWheel(d, true, false); }); // newer versions of Firefox
+    ```
+    */
+    _chart.onMouseWheel = function (d, zoomIn, zoomOut) {
+        if (zoomIn === undefined)
+            zoomIn = true;
+        if (zoomOut === undefined)
+            zoomOut = true;
+
+        // on zoomIn
+        if (!disabledActions.mousewheel && zoomIn && (d3.event.deltaY < 0 || d3.event.wheelDeltaY > 0) && _chart._callbackZoomIn !== undefined) {
+            delayAction('mousewheel', 1500);
+            _chart._zoomIn(d);
+        }
+
+        // on zoomIn-out
+        else if (!disabledActions.mousewheel && zoomOut && (d3.event.deltaY > 0 || d3.event.wheelDeltaY < 0) && _chart._callbackZoomOut !== undefined) {
+            delayAction('mousewheel', 1500);
+            _chart._zoomOut();
+        }
+
+        // prevent scrolling on page
+        d3.event.preventDefault();
+        return false;
+    };
+
+    _chart._zoomIn = function (d) {
+        _chart._onZoomIn(d);
+        _chart.callbackZoomIn()(_chart.keyAccessor()(d));
+    };
+
+    _chart._zoomOut = function (d) {
+        _chart._onZoomOut();
+        _chart.callbackZoomOut()();
+    };
+
+    /**
+    #### ._onZoomIn(d)
+    Function called on zoom in. Default behavior does nothing. Your chart should redefine this if you want to do something on zoom in other that calling the callback.
+    **/
+    _chart._onZoomIn = function (d) {
+    };
+
+    /**
+    #### ._onZoomOut()
+    Function called on zoom out. Default behavior does nothing. Your chart should redefine this if you want to do something on zoom out other that calling the callback.
+    **/
+    _chart._onZoomOut = function () {
+    };
+
+    /**
+    #### .callbackZoomIn([callback])
+    Set or get the current callback function on zoomIn.
+
+    If `callback` is `null`, removes the callback.
+    **/
+    _chart.callbackZoomIn = function (callback) {
+        if (!arguments.length) {
+            if (_chart._callbackZoomIn !== undefined)
+                return _chart._callbackZoomIn;
+            else
+                return null;
+        }
+
+        if (callback === null) _chart._callbackZoomIn = undefined;
+        else _chart._callbackZoomIn = callback;
+
+        return _chart;
+    };
+
+    /**
+    #### .callbackZoomOut([callback])
+    Set or get the current callback function on zoomOut.
+
+    If `callback` is `null`, removes the callback.
+    **/
+    _chart.callbackZoomOut = function (callback) {
+        if (!arguments.length) {
+            if (_chart._callbackZoomOut !== undefined)
+                return _chart._callbackZoomOut;
+            else
+                return null;
+        }
+
+        if (callback === null) _chart._callbackZoomOut = undefined;
+        else _chart._callbackZoomOut = callback;
+
+        return _chart;
+    };
+
+    return _chart;
+};


### PR DESCRIPTION
This mixin is an helper to add mousewheel behavior handling for the charts. It allows you to set callbacks [1] on mouse wheel events (for the chart user) and add code that will be ran [2] on the same event (for the chart developper).

Example of usage:

``` js
// inside a chart definition
_chart._onZoomIn = function(d) { console.log("this code will be launched on zoom on"); } // [2]
elements
        .on("mousewheel", function(d) { _chart.onMouseWheel(d, true, false); })
        .on("DOMMouseScroll", _chart.onMouseWheel function(d) { _chart.onMouseWheel(d, true, false); }) // older versions of Firefox
        .on("wheel", function(d) { _chart.onMouseWheel(d, true, false); }); // newer versions of Firefox

// for the user [1]
myChart.callbackZoomIn(function(d) { console.log("You just zoomed on "+d) });
```

We use this because we do OLAP viz with dc.js and want drill-down / roll-up behavior on charts. If you want to see how we use this mixin, see https://github.com/loganalysis/dc.js/tree/feature/bar_chart
