### PR TITLE
new boolean property on linechart to toggle mouseover dots

### DIFF
--- a/spec/line-chart-spec.js
+++ b/spec/line-chart-spec.js
@@ -122,6 +122,20 @@ describe('dc.lineChart', function() {
             });
         });
 
+        describe('data point highlights and refs off', function () {
+            beforeEach(function () {
+                chart.title(function (d) { return d.value; });
+                chart.brushOn(false).xyTipsOn(false).render();
+            });
+            it('should not generate per data points', function () {
+                expect(chart.selectAll('circle.dot').size())toBe(0);
+            });
+            it('should not generate x and y refs', function () {
+                expect(chart.selectAll('path.xRef').size()).toBe(0);
+                expect(chart.selectAll('path.yRef').size()).toBe(0);
+            });
+        });
+
         describe('data point highlights', function () {
             beforeEach(function () {
                 chart.title(function (d) { return d.value; });

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -52,6 +52,7 @@ dc.lineChart = function (parent, chartGroup) {
     var _tension = 0.7;
     var _defined;
     var _dashStyle;
+    var _xyTipsOn = true;
 
     _chart.transitionDuration(500);
     _chart._rangeBandPadding(1);
@@ -233,7 +234,7 @@ dc.lineChart = function (parent, chartGroup) {
     }
 
     function drawDots(chartBody, layers) {
-        if (!_chart.brushOn()) {
+        if (!_chart.brushOn() && _chart.xyTipsOn()) {
             var tooltipListClass = TOOLTIP_G_CLASS + '-list';
             var tooltips = chartBody.select('g.' + tooltipListClass);
 
@@ -337,6 +338,20 @@ dc.lineChart = function (parent, chartGroup) {
             dot.append('title').text(dc.pluck('data', _chart.title(d.name)));
         }
     }
+
+    /**
+     #### .xyTipsOn([boolean])
+     Turn on/off the mouseover behavior of an individual data point which renders a circle and x/y axis
+     dashed lines back to each respective axis.  This is ignored if the chart brush is on (`brushOn`)
+     Default: true
+     */
+    _chart.xyTipsOn = function (_) {
+        if (!arguments.length) {
+            return _xyTipsOn;
+        }
+        _xyTipsOn = _;
+        return _chart;
+    };
 
     /**
     #### .dotRadius([dotRadius])


### PR DESCRIPTION
So, on line charts, this feature:

![screen shot 2014-10-18 at 12 21 31 am](https://cloud.githubusercontent.com/assets/186677/4688529/4cff9ab8-567e-11e4-8b8f-261a328b142f.png)

i.e. the x/y tracking to the axes, and the dot that tracks the line on mouseover is something that is currently *not optional*.  It is always generated.  I had a need to build something else for my line charts...namely a tracker that shows up not just if you mouseover on the line but on the whole chart, and also a linear regression slope, and I wanted a larger dot to make it more visible.

![screen shot 2014-10-18 at 12 26 41 am](https://cloud.githubusercontent.com/assets/186677/4688542/0073290c-567f-11e4-9028-7f991ee6df74.png)


Seeing as how my linechart features collided with the built-in features, I wanted to make the built-in features optional, so I added a new property on linechart:  

```javascript
linechart.xyTipsOn(true); // the default
linechart.xyTipsOn(false); // disable the tracking dot and xy refs
```

By default, the behavior is still on, so it should affect nothing.  This just gives me the ability to disable it to inject my own behavior that doesn't collide with it.

Added documentation for the new public API, as well as a few unit tests.

