### PR TITLE
Fix ordering option for the barChart.

### DIFF
--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -951,6 +951,64 @@ describe('dc.barChart', function() {
         });
     });
 
+    describe('check ordering option of the x axis', function() {
+            beforeEach(function() {
+                var rows = [
+                    {x: 'a', y: 1},
+                    {x: 'b', y: 3},
+                    {x: 'd', y: 4},
+                    {x: 'c', y: 2}
+                ];
+
+                id = 'bar-chart';
+                appendChartID(id);
+                data = crossfilter(rows);
+                dimension = data.dimension(function(d) {
+                    return d.x;
+                });
+                group = dimension.group().reduceSum(function(d) {
+                    return d.y;
+                });
+
+                chart = dc.barChart('#' + id);
+                chart.width(500).transitionDuration(0)
+                    .x(d3.scale.ordinal())
+                    .xUnits(dc.units.ordinal)
+                    .elasticY(true).elasticX(true)
+                    .dimension(dimension)
+                    .group(group);
+                chart.render();
+            });
+
+            it('should be ordered by default alphabetical order', function() {
+                var data = chart.data()["0"].values;
+                var expectedData = ["a", "b", "c", "d"];
+                expect(data.map(function(d) { return d.x; })).toEqual(expectedData);
+            });
+
+            it('should be ordered by value increasing', function() {
+                chart.ordering(function(d) { return d.data.value; });
+                chart.redraw();
+                expect(xAxisText()).toEqual(["a", "c", "b", "d"]);
+            });
+
+            it('should be ordered by value decreasing', function() {
+                chart.ordering(function(d) { return -d.data.value; });
+                chart.redraw();
+                expect(xAxisText()).toEqual(["d", "b", "c", "a"]);
+            });
+
+            it('should be ordered by alphabetical order', function() {
+                chart.ordering(function(d) { return d.data.key; });
+                chart.redraw();
+                expect(xAxisText()).toEqual(["a", "b", "c", "d"]);
+            });
+
+            function xAxisText() {
+                return chart.selectAll("g.x text")[0].map(function(x) { return d3.select(x).text(); });
+            }
+    });
+
     function nthStack(n) {
         var stack = d3.select(chart.selectAll(".stack")[0][n]);
 

--- a/src/stack-mixin.js
+++ b/src/stack-mixin.js
@@ -170,7 +170,13 @@ dc.stackMixin = function (_chart) {
     };
 
     function flattenStack() {
-        return _chart.data().reduce(function (all, layer) {
+        var groups = _chart.data();
+
+        if(groups.length){
+            groups[0].values = _chart._computeOrderedGroups(groups[0].values);
+        }
+
+        return groups.reduce(function (all, layer) {
             return all.concat(layer.values);
         }, []);
     }


### PR DESCRIPTION
Fix the bug: ordering not working on barChart.

If you write in the barChart definition:

1. **chart.ordering(function (d) { return  d.data.value;   });** 
It will order the barChart xAxis by value increasing.

2. **chart.ordering(function (d) { return  -d.data.value;   });** 
It will order the barChart xAxis by value decreasing.

3. **chart.ordering(function (d) { return  d.data.key;   });** 
It will order the barChart xAxis by key, alphabetical order.



