### PR TITLE
Specify module dependencies.

### DIFF
--- a/src/banner.js
+++ b/src/banner.js
@@ -16,5 +16,5 @@
  *  limitations under the License.
  */
 
-(function() { function _dc(d3) {
+(function() { function _dc(d3, crossfilter) {
 'use strict';

--- a/src/footer.js
+++ b/src/footer.js
@@ -10,11 +10,14 @@ dc.stackableChart = dc.stackMixin;
 
 return dc;}
     if(typeof define === "function" && define.amd) {
-        define(["d3"], _dc);
+        define(["d3", "crossfilter"], _dc);
     } else if(typeof module === "object" && module.exports) {
-        module.exports = _dc(d3);
+        // When using window global, window.crossfilter is a function
+        // When using require, the value will be an object with 'crossfilter'
+        // field, so we need to access it here.
+        module.exports = _dc(require('d3'), require('crossfilter').crossfilter);
     } else {
-        this.dc = _dc(d3);
+        this.dc = _dc(d3, crossfilter);
     }
 }
 )();


### PR DESCRIPTION
While dc.js has code to make it usable as CommonJS module,
it does not require its dependencies, so when using browserify,
both d3 and crossfilter still has to be present as window globals.

This patch adds necessary require call, and the code using dc.js
can now be bundled into a single js file.

'grunt test' is clean. I've verified on my project that I only need to include the output of browserify, and everything works fine.
