### PR TITLE
allow clearing of a single renderlet or all renderlets

### DIFF
--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -45,6 +45,20 @@ describe("dc.baseMixin", function () {
             expect(firstRenderlet).toHaveBeenCalled();
             expect(secondRenderlet).toHaveBeenCalled();
         });
+
+        it('should clear a renderlet when asked', function () {
+            chart.clearRenderlet(firstRenderlet);
+            chart.redraw();
+            expect(firstRenderlet).not.toHaveBeenCalled();
+            expect(secondRenderlet).toHaveBeenCalled();
+        });
+
+        it('should clear all renderlets when asked', function () {
+            chart.clearRenderlets();
+            chart.redraw();
+            expect(firstRenderlet).not.toHaveBeenCalled();
+            expect(secondRenderlet).not.toHaveBeenCalled();
+        });
     });
 
     describe('event listeners', function () {

--- a/src/base-mixin.js
+++ b/src/base-mixin.js
@@ -996,6 +996,25 @@ dc.baseMixin = function (_chart) {
         return _chart;
     };
 
+    /**
+     #### .clearRenderlet(renderletFunction)
+     Removes a renderlet function you have previously added to the chart
+     **/
+    _chart.clearRenderlet = function (_) {
+        for (var i = 0; i < _renderlets.length; ++i) {
+            if (_renderlets[i] === _) { _renderlets.splice(i, 1); }
+        }
+    };
+
+    /**
+     #### .clearRenderlets()
+     Removes all renderlet functions from the chart
+     **/
+    _chart.clearRenderlets = function () {
+        _renderlets.length = 0;
+        return _chart;
+    };
+
     function runAllRenderlets() {
         for (var i = 0; i < _renderlets.length; ++i) {
             _renderlets[i](_chart);


### PR DESCRIPTION
See #776 for rationale

This adds two new functions on chart:

```javascript
var renderletFn = function (chart) { /* do something with chart */ };
// add a renderlet
chart.renderlet(renderletFn);
// clear it
chart.clearRenderlet(renderletFn);
// clear all renderlets
chart.clearRenderlets();
```