### PR TITLE
calculateColorDomain(); to return chart

### DIFF
--- a/src/color-mixin.js
+++ b/src/color-mixin.js
@@ -114,6 +114,7 @@ dc.colorMixin = function (_chart) {
         var newDomain = [d3.min(_chart.data(), _chart.colorAccessor()),
                          d3.max(_chart.data(), _chart.colorAccessor())];
         _colors.domain(newDomain);
+        return _chart;
     };
 
     /**


### PR DESCRIPTION
The `calculateColorDomain()` doesn't return `_chart`.  I think this function to return `_chart`.  Also, it might be ideal to pass in a argument `true` to fit in with the convention followed by other functions e.g `elasticY(true)`.

Let me know what you think!
