### PR TITLE
Enhancement: Speed up geoChoropleth tests

### DIFF
--- a/spec/geo-choropleth-chart-spec.js
+++ b/spec/geo-choropleth-chart-spec.js
@@ -10,9 +10,15 @@ describe('dc.geoChoropleth', function() {
         districtDimension = data.dimension(function(d){return d.district;});
         districtValueEnrollGroup = districtDimension.group().reduceSum(function(d){return d.value;});
 
-        geoJson = loadGeoFixture();
-        geoJson2 = loadGeoFixture2();
-        geoJson3 = loadGeoFixture3();
+        if ( !geoJson ) {
+            geoJson = loadGeoFixture();
+        }
+        if ( !geoJson2 ) {
+            geoJson2 = loadGeoFixture2();
+        }
+        if ( !geoJson3 ) {
+            geoJson3 = loadGeoFixture3();
+        }
     });
 
     function buildChart(id) {


### PR DESCRIPTION
My initial analysis showed a LOT of time spent re-parsing JSON fixture, so I altered the tests to re-use the fixtures after they are generated and it seemed to increase the test run speed by a large factor.

This is for Issue #817 .