### PR TITLE
Fixes Bug 776 - Provide API to remove renderlets

### DIFF
--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -29,9 +29,6 @@ describe("dc.baseMixin", function () {
             var expectedCallbackSignature = function (callbackChart) {
                 expect(callbackChart).toBe(chart);
             };
-            var namedRenderlet = function (callbackChart) {
-                expect(callbackChart).toBe(chart);
-            }
             firstRenderlet = jasmine.createSpy().and.callFake(expectedCallbackSignature);
             secondRenderlet = jasmine.createSpy().and.callFake(expectedCallbackSignature);
             thirdRenderlet = jasmine.createSpy().and.callFake(expectedCallbackSignature);
@@ -52,25 +49,27 @@ describe("dc.baseMixin", function () {
             expect(secondRenderlet).toHaveBeenCalled();
         });
 
-        it('should add a named renderlet called after a render', function () {
+        it('should execute a named renderlet after a render', function () {
             chart.render();
             expect(thirdRenderlet).toHaveBeenCalled();
         });
 
-        it('should add a named renderlet called after a redraw', function () {
+        it('should execute a named renderlet after a redraw', function () {
             chart.redraw();
             expect(thirdRenderlet).toHaveBeenCalled();
         });
 
-        it('should add a named renderlet, remove it and expect no call after a redraw', function () {
+        it('should remove a named renderlet expect no call after a redraw', function () {
             chart.removeRenderlet(third);
             chart.redraw();
+            expect(secondRenderlet).toHaveBeenCalled();
             expect(thirdRenderlet).not.toHaveBeenCalled();
         });
 
-        it('should add a named renderlet, remove it and expect no call after a redraw', function () {
+        it('should remove a named renderlet and expect no call after a redraw', function () {
             chart.removeRenderlet(third);
             chart.render();
+            expect(secondRenderlet).toHaveBeenCalled();
             expect(thirdRenderlet).not.toHaveBeenCalled();
         });
     });

--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -23,15 +23,21 @@ describe("dc.baseMixin", function () {
     });
 
     describe('renderlets', function () {
-        var firstRenderlet, secondRenderlet;
+        var firstRenderlet, secondRenderlet, thirdRenderlet,
+            third = 'third';
         beforeEach(function () {
             var expectedCallbackSignature = function (callbackChart) {
                 expect(callbackChart).toBe(chart);
             };
+            var namedRenderlet = function (callbackChart) {
+                expect(callbackChart).toBe(chart);
+            }
             firstRenderlet = jasmine.createSpy().and.callFake(expectedCallbackSignature);
             secondRenderlet = jasmine.createSpy().and.callFake(expectedCallbackSignature);
+            thirdRenderlet = jasmine.createSpy().and.callFake(expectedCallbackSignature);
             chart.renderlet(firstRenderlet);
             chart.renderlet(secondRenderlet);
+            chart.addRenderlet(third, thirdRenderlet);
         });
 
         it('should execute each renderlet after a render', function () {
@@ -44,6 +50,28 @@ describe("dc.baseMixin", function () {
             chart.redraw();
             expect(firstRenderlet).toHaveBeenCalled();
             expect(secondRenderlet).toHaveBeenCalled();
+        });
+
+        it('should add a named renderlet called after a render', function () {
+            chart.render();
+            expect(thirdRenderlet).toHaveBeenCalled();
+        });
+
+        it('should add a named renderlet called after a redraw', function () {
+            chart.redraw();
+            expect(thirdRenderlet).toHaveBeenCalled();
+        });
+
+        it('should add a named renderlet, remove it and expect no call after a redraw', function () {
+            chart.removeRenderlet(third);
+            chart.redraw();
+            expect(thirdRenderlet).not.toHaveBeenCalled();
+        });
+
+        it('should add a named renderlet, remove it and expect no call after a redraw', function () {
+            chart.removeRenderlet(third);
+            chart.render();
+            expect(thirdRenderlet).not.toHaveBeenCalled();
         });
     });
 

--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -24,7 +24,7 @@ describe("dc.baseMixin", function () {
 
     describe('renderlets', function () {
         var firstRenderlet, secondRenderlet, thirdRenderlet,
-            third = 'third';
+            third = 'renderlet.third';
         beforeEach(function () {
             var expectedCallbackSignature = function (callbackChart) {
                 expect(callbackChart).toBe(chart);
@@ -34,7 +34,7 @@ describe("dc.baseMixin", function () {
             thirdRenderlet = jasmine.createSpy().and.callFake(expectedCallbackSignature);
             chart.renderlet(firstRenderlet);
             chart.renderlet(secondRenderlet);
-            chart.addRenderlet(third, thirdRenderlet);
+            chart.on(third, thirdRenderlet);
         });
 
         it('should execute each renderlet after a render', function () {
@@ -60,14 +60,14 @@ describe("dc.baseMixin", function () {
         });
 
         it('should remove a named renderlet expect no call after a redraw', function () {
-            chart.removeRenderlet(third);
+            chart.on(third);
             chart.redraw();
             expect(secondRenderlet).toHaveBeenCalled();
             expect(thirdRenderlet).not.toHaveBeenCalled();
         });
 
         it('should remove a named renderlet and expect no call after a redraw', function () {
-            chart.removeRenderlet(third);
+            chart.on(third);
             chart.render();
             expect(secondRenderlet).toHaveBeenCalled();
             expect(thirdRenderlet).not.toHaveBeenCalled();

--- a/src/base-mixin.js
+++ b/src/base-mixin.js
@@ -996,9 +996,9 @@ dc.baseMixin = function (_chart) {
     ```
 
     **/
-    _chart.renderlet = function (_) {
+    _chart.renderlet = dc.logger.deprecate(function (_) {
         _chart.on(RENDERLET_KEY + '.' + dc.utils.uniqueId(), _);
-    };
+    }, 'chart.renderlet has been deprecated.  Please use chart.on("renderlet.<renderletKey>", renderletFunction)');
 
     /**
     #### .chartGroup([group])

--- a/src/logger.js
+++ b/src/logger.js
@@ -25,3 +25,16 @@ dc.logger.debug = function (msg) {
 
     return dc.logger;
 };
+
+dc.logger.deprecate = function (fn, msg) {
+    // Allow logging of deprecation
+    var warned = false;
+    function deprecated() {
+        if (!warned) {
+            dc.logger.warn(msg);
+            warned = true;
+        }
+        return fn.apply(this, arguments);
+    }
+    return deprecated;
+};


### PR DESCRIPTION
Fixes Bug #776 

This change adds the following methods:
- .addRenderlet
- .removeRenderlet
- .renderlets

This deprecates:
- .renderlet (in favor of .addRenderlet, which it calls behind the scenes using `dc.utils.uniqueId` as the renderlet key)

If you are opposed, I'm fine with removing the `.renderlets` getter function.  I just thought it might be useful to trigger the renderlets at a time other than `render` and `redraw`, or specifically call a single renderlet.

**Edit** Oop didn't see the other pull request #779 open :P  I would still say we need to keep backwards compatability for `.renderlet` and this uses `d3.dispatch` as @gordonwoodhull had suggested.