### PR TITLE
Fixes Bug 775 - setting the chartGroup

### DIFF
--- a/spec/composite-chart-spec.js
+++ b/spec/composite-chart-spec.js
@@ -327,8 +327,8 @@ describe('dc.compositeChart', function() {
 
                 dateValueGroupLine2.on("click")(dateValueGroupLine2.datum());
                 expect(dateValueGroupLine2.text()).toBe('Date Value Group Line 2');
-                expect(d3.select(chart.selectAll('g.dc-legend g.dc-legend-item')[0][3]).classed("fadeout")).toBeTruthy();                
-                expect(chart.selectAll("path.line").size()).toEqual(3);
+                expect(dateValueGroupLine2.classed("fadeout")).toBeFalsy();
+                expect(chart.selectAll("path.line").size()).toEqual(1);
             });
         });
     });

--- a/spec/core-spec.js
+++ b/spec/core-spec.js
@@ -80,6 +80,20 @@ describe('dc.core', function() {
             dc.deregisterChart(chartGrouped, chartGroup);
             expect(dc.hasChart(chartGrouped)).toBeFalsy();
         });
+
+        it('should have switched to an existing group', function () {
+            chart.chartGroup(chartGroup);
+            expect(dc.hasChart(chart)).toBeTruthy();
+            expect(dc.chartRegistry.list(chartGroup).indexOf(chart) > -1).toBeTruthy();
+            expect(dc.chartRegistry.list(null).indexOf(chart) > -1).toBeFalsy();
+        });
+
+        it('should have switched to the global group', function () {
+            chart.chartGroup(null);
+            expect(dc.hasChart(chart)).toBeTruthy();
+            expect(dc.chartRegistry.list(chartGroup).indexOf(chart) > -1).toBeFalsy();
+            expect(dc.chartRegistry.list(null).indexOf(chart) > -1).toBeTruthy();
+        });
     });
 
     describe('transition', function() {

--- a/src/base-mixin.js
+++ b/src/base-mixin.js
@@ -1011,7 +1011,9 @@ dc.baseMixin = function (_chart) {
         if (!arguments.length) {
             return _chartGroup;
         }
+        dc.deregisterChart(_chart, _chartGroup);
         _chartGroup = _;
+        dc.registerChart(_chart, _chartGroup);
         return _chart;
     };
 


### PR DESCRIPTION
Fixes Bug #775 

I think the logic between the two functions (i.e. `anchor` & `chartGroup`) is correct now.  I'm not really a fan of having more than one way of doing things (`anchor`, `chartGroup`, `dc.chartRegistry`), but I can't really pull this out for compatibility.

Also, there was a weird test case from the composite mixin spec that inadvertently failed after my pretty minimal change.  After some investigation, I think it was broken, but passing?  Could use a second pair of eyes on that.