### PR TITLE
Fix a bug with bar charts not returning the instance on render

### DIFF
--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -34,6 +34,10 @@ describe('dc.barChart', function() {
             });
         });
 
+        it("should preserve method chaining", function() {
+            expect(chart.render()).toEqual(chart);
+        });
+
         describe("with centered bars", function() {
             beforeEach(function() {
                 chart.centerBar(true).render();

--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -56,7 +56,7 @@ dc.barChart = function (parent, chartGroup) {
                          'See dc.js bar chart API documentation for details.');
         }
 
-        _chart._render();
+        return _chart._render();
     });
 
     _chart.plotData = function () {


### PR DESCRIPTION
Noticed a small issue, the bar chart render function was overridden but the result was not returned so method chaining was broken