### PR TITLE
fixed typos and (hopefully) improved annotated example; uglify fixed for node 0.12

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function (grunt) {
             jsmin: {
                 options: {
                     mangle: true,
-                    compress: true,
+                    compress: {},
                     sourceMap: output.map
                 },
                 src: output.js,

--- a/web/docs/stock.html
+++ b/web/docs/stock.html
@@ -52,7 +52,9 @@ filtered by other page controls.</p>
 <span class="hljs-keyword">var</span> dayOfWeekChart = dc.rowChart(<span class="hljs-string">'#day-of-week-chart'</span>);
 <span class="hljs-keyword">var</span> moveChart = dc.lineChart(<span class="hljs-string">'#monthly-move-chart'</span>);
 <span class="hljs-keyword">var</span> volumeChart = dc.barChart(<span class="hljs-string">'#monthly-volume-chart'</span>);
-<span class="hljs-keyword">var</span> yearlyBubbleChart = dc.bubbleChart(<span class="hljs-string">'#yearly-bubble-chart'</span>);</pre></div></div>
+<span class="hljs-keyword">var</span> yearlyBubbleChart = dc.bubbleChart(<span class="hljs-string">'#yearly-bubble-chart'</span>);
+<span class="hljs-keyword">var</span> nasdaqCount = dc.dataCount(<span class="hljs-string">'.dc-data-count'</span>);
+<span class="hljs-keyword">var</span> nasdaqTable = dc.dataTable(<span class="hljs-string">'.dc-data-table'</span>);</pre></div></div>
             
         </li>
         
@@ -119,9 +121,11 @@ selection for bar chart). Enable this with <code>chart.turnOnControls(true)</cod
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>     &lt;div id=<span class="hljs-string">'chart'</span>&gt;
-       <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'reset'</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">'javascript:myChart.filterAll();dc.redrawAll();'</span> <span class="hljs-attribute">style</span>=<span class="hljs-value">'display: none;'</span>&gt;</span>reset<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
-     <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
+            <div class="content"><div class='highlight'><pre>    &lt;div id=<span class="hljs-string">'chart'</span>&gt;
+       <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'reset'</span>
+          <span class="hljs-attribute">href</span>=<span class="hljs-value">'javascript:myChart.filterAll();dc.redrawAll();'</span>
+          <span class="hljs-attribute">style</span>=<span class="hljs-value">'display: none;'</span>&gt;</span>reset<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
+    <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
 </span></pre></div></div>
             
         </li>
@@ -139,7 +143,9 @@ any html element with css class set to ‘filter’</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    &lt;div id=<span class="hljs-string">'chart'</span>&gt;
-        <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'reset'</span> <span class="hljs-attribute">style</span>=<span class="hljs-value">'display: none;'</span>&gt;</span>Current filter: <span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'filter'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+        <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'reset'</span> <span class="hljs-attribute">style</span>=<span class="hljs-value">'display: none;'</span>&gt;</span>
+          Current filter: <span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'filter'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+        <span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
     <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
 */
 
@@ -472,17 +478,13 @@ jQuery.getJson(<span class="hljs-string">'data.json'</span>, <span class="hljs-f
 <p>Create a bubble chart and use the given css selector as anchor. You can also specify
 an optional chart group for this chart to be scoped within. When a chart belongs
 to a specific group then any interaction with such chart will only trigger redraw
-on other charts within the same chart group.</p>
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#bubble-chart">Bubble Chart</a></p>
 
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.bubbleChart('#yearly-bubble-chart', 'chartGroup') */</span>
-    yearlyBubbleChart
-        .width(<span class="hljs-number">990</span>) <span class="hljs-comment">// (optional) define chart width, :default = 200</span>
-        .height(<span class="hljs-number">250</span>)  <span class="hljs-comment">// (optional) define chart height, :default = 200</span>
-        .transitionDuration(<span class="hljs-number">1500</span>) <span class="hljs-comment">// (optional) define chart transition duration, :default = 750</span>
-        .margins({top: <span class="hljs-number">10</span>, right: <span class="hljs-number">50</span>, bottom: <span class="hljs-number">30</span>, left: <span class="hljs-number">40</span>})
-        .dimension(yearlyDimension)</pre></div></div>
+    yearlyBubbleChart</pre></div></div>
             
         </li>
         
@@ -493,14 +495,11 @@ on other charts within the same chart group.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-23">&#182;</a>
               </div>
-              <p>Bubble chart expect the groups are reduced to multiple values which would then be used
-to generate x, y, and radius for each key (bubble) in the group</p>
+              <p>(<em>optional</em>) define chart width, <code>default = 200</code></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>        .group(yearlyPerformanceGroup)
-        .colors(colorbrewer.RdYlGn[<span class="hljs-number">9</span>]) <span class="hljs-comment">// (optional) define color function or array for bubbles</span>
-        .colorDomain([-<span class="hljs-number">500</span>, <span class="hljs-number">500</span>]) <span class="hljs-comment">//(optional) define color domain to match your data domain if you want to bind data or</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre>        .width(<span class="hljs-number">990</span>)</pre></div></div>
             
         </li>
         
@@ -511,15 +510,93 @@ to generate x, y, and radius for each key (bubble) in the group</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-24">&#182;</a>
               </div>
-              <p>color</p>
-<h5 id="accessors">Accessors</h5>
+              <p>(<em>optional</em>) define chart height, <code>default = 200</code></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .height(<span class="hljs-number">250</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-25">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-25">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) define chart transition duration, :default = 750</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .transitionDuration(<span class="hljs-number">1500</span>)
+        .margins({top: <span class="hljs-number">10</span>, right: <span class="hljs-number">50</span>, bottom: <span class="hljs-number">30</span>, left: <span class="hljs-number">40</span>})
+        .dimension(yearlyDimension)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-26">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-26">&#182;</a>
+              </div>
+              <p>Bubble chart group’s attributes are reduced to multiple values which would then be used
+to generate x, y, and radius for each key (bubble) in the group</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .group(yearlyPerformanceGroup)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-27">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-27">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) define color function or array for bubbles: <a href="http://colorbrewer2.org/">ColorBrewer</a>
+and <a href="http://bl.ocks.org/mbostock/5577023">Mike</a> to the rescue</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .colors(colorbrewer.RdYlGn[<span class="hljs-number">9</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-28">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-28">&#182;</a>
+              </div>
+              <p>(optional) define color domain to match your data domain if you want to bind data or color</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .colorDomain([-<span class="hljs-number">500</span>, <span class="hljs-number">500</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-29">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-29">&#182;</a>
+              </div>
+              <h5 id="accessors">Accessors</h5>
 <p>Accessor functions are applied to each value returned by the grouping</p>
 <ul>
 <li><code>.colorAccessor</code> The returned value will be mapped to an internal scale to determine a fill color</li>
 <li><code>.keyAccessor</code> Identifies the <code>X</code> value that will be applied against the <code>.x()</code> to identify pixel location</li>
 <li><code>.valueAccessor</code> Identifies the <code>Y</code> value that will be applied agains the <code>.y()</code> to identify pixel location</li>
-<li><code>.radiusValueAccessor</code> Identifies the value that will be applied agains the <code>.r()</code> determine radius size,</li>
-<li>by default this maps linearly to [0,100]</li>
+<li><code>.radiusValueAccessor</code> Identifies the value that will be applied agains the <code>.r()</code> determine radius size,
+by default this maps linearly to [0,100]</li>
 </ul>
 
             </div>
@@ -544,14 +621,14 @@ to generate x, y, and radius for each key (bubble) in the group</p>
         </li>
         
         
-        <li id="section-25">
+        <li id="section-30">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-25">&#182;</a>
+                <a class="pilcrow" href="#section-30">&#182;</a>
               </div>
               <h5 id="elastic-scaling">Elastic Scaling</h5>
-<p><code>.elasticX</code> and <code>.elasticX</code> determine whether the chart should rescale each axis to fit data.
+<p><code>.elasticY</code> and <code>.elasticX</code> determine whether the chart should rescale each axis to fit data.
 The <code>.yAxisPadding</code> and <code>.xAxisPadding</code> add padding to data above and below their max values in the same unit
 domains as the Accessors.</p>
 
@@ -560,31 +637,102 @@ domains as the Accessors.</p>
             <div class="content"><div class='highlight'><pre>        .elasticY(<span class="hljs-literal">true</span>)
         .elasticX(<span class="hljs-literal">true</span>)
         .yAxisPadding(<span class="hljs-number">100</span>)
-        .xAxisPadding(<span class="hljs-number">500</span>)
-        .renderHorizontalGridLines(<span class="hljs-literal">true</span>) <span class="hljs-comment">// (optional) render horizontal grid lines, :default=false</span>
-        .renderVerticalGridLines(<span class="hljs-literal">true</span>) <span class="hljs-comment">// (optional) render vertical grid lines, :default=false</span>
-        .xAxisLabel(<span class="hljs-string">'Index Gain'</span>) <span class="hljs-comment">// (optional) render an axis label below the x axis</span>
-        .yAxisLabel(<span class="hljs-string">'Index Gain %'</span>) <span class="hljs-comment">// (optional) render a vertical axis lable left of the y axis</span></pre></div></div>
+        .xAxisPadding(<span class="hljs-number">500</span>)</pre></div></div>
             
         </li>
         
         
-        <li id="section-26">
+        <li id="section-31">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-26">&#182;</a>
+                <a class="pilcrow" href="#section-31">&#182;</a>
               </div>
-              <h4 id="labels-and-titles">Labels and  Titles</h4>
-<p>Labels are displaed on the chart for each bubble. Titles displayed on mouseover.</p>
+              <p>(<em>optional</em>) render horizontal grid lines, <code>default=false</code></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>        .renderLabel(<span class="hljs-literal">true</span>) <span class="hljs-comment">// (optional) whether chart should render labels, :default = true</span>
+            <div class="content"><div class='highlight'><pre>        .renderHorizontalGridLines(<span class="hljs-literal">true</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-32">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-32">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) render vertical grid lines, <code>default=false</code></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .renderVerticalGridLines(<span class="hljs-literal">true</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-33">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-33">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) render an axis label below the x axis</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .xAxisLabel(<span class="hljs-string">'Index Gain'</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-34">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-34">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) render a vertical axis lable left of the y axis</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .yAxisLabel(<span class="hljs-string">'Index Gain %'</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-35">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-35">&#182;</a>
+              </div>
+              <h5 id="labels-and-titles">Labels and  Titles</h5>
+<p>Labels are displayed on the chart for each bubble. Titles displayed on mouseover.
+(<em>optional</em>) whether chart should render labels, <code>default = true</code></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .renderLabel(<span class="hljs-literal">true</span>)
         .label(<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(p)</span> </span>{
             <span class="hljs-keyword">return</span> p.key;
-        })
-        .renderTitle(<span class="hljs-literal">true</span>) <span class="hljs-comment">// (optional) whether chart should render titles, :default = false</span>
+        })</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-36">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-36">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) whether chart should render titles, <code>default = false</code></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .renderTitle(<span class="hljs-literal">true</span>)
         .title(<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(p)</span> </span>{
             <span class="hljs-keyword">return</span> [
                 p.key,
@@ -597,13 +745,13 @@ domains as the Accessors.</p>
         </li>
         
         
-        <li id="section-27">
+        <li id="section-37">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-27">&#182;</a>
+                <a class="pilcrow" href="#section-37">&#182;</a>
               </div>
-              <h4 id="customize-axis">Customize Axis</h4>
+              <h5 id="customize-axis">Customize Axis</h5>
 <p>Set a custom tick format. Note <code>.yAxis()</code> returns an axis object, so any additional method chaining applies
 to the axis, not the chart.</p>
 
@@ -616,30 +764,57 @@ to the axis, not the chart.</p>
         </li>
         
         
-        <li id="section-28">
+        <li id="section-38">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-28">&#182;</a>
+                <a class="pilcrow" href="#section-38">&#182;</a>
               </div>
               <h4 id="pie-donut-chart">Pie/Donut Chart</h4>
 <p>Create a pie chart and use the given css selector as anchor. You can also specify
 an optional chart group for this chart to be scoped within. When a chart belongs
 to a specific group then any interaction with such chart will only trigger redraw
-on other charts within the same chart group.</p>
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#pie-chart">Pie Chart</a></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.pieChart('#gain-loss-chart', 'chartGroup') */</span>
     gainOrLossChart
         .width(<span class="hljs-number">180</span>) <span class="hljs-comment">// (optional) define chart width, :default = 200</span>
-        .height(<span class="hljs-number">180</span>) <span class="hljs-comment">// (optional) define chart height, :default = 200</span>
-        .radius(<span class="hljs-number">80</span>) <span class="hljs-comment">// define pie radius</span>
+        .height(<span class="hljs-number">180</span>) <span class="hljs-comment">// (optional) define chart height, :default = 200</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-39">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-39">&#182;</a>
+              </div>
+              <p>define pie radius</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .radius(<span class="hljs-number">80</span>)
         .dimension(gainOrLoss) <span class="hljs-comment">// set dimension</span>
-        .group(gainOrLossGroup) <span class="hljs-comment">// set group</span>
-        <span class="hljs-comment">/* (optional) by default pie chart will use group.key as its label
-         * but you can overwrite it with a closure */</span>
-        .label(<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(d)</span> </span>{
+        .group(gainOrLossGroup) <span class="hljs-comment">// set group</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-40">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-40">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) by default pie chart will use <code>group.key</code> as its label but you can overwrite it with a closure.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .label(<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(d)</span> </span>{
             <span class="hljs-keyword">if</span> (gainOrLossChart.hasFilter() &amp;&amp; !gainOrLossChart.hasFilter(d.key)) {
                 <span class="hljs-keyword">return</span> d.key + <span class="hljs-string">'(0%)'</span>;
             }
@@ -654,13 +829,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-29">
+        <li id="section-41">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-29">&#182;</a>
+                <a class="pilcrow" href="#section-41">&#182;</a>
               </div>
-              <p>(optional) whether chart should render labels, :default = true</p>
+              <p>(<em>optional</em>) whether chart should render labels, <code>default = true</code></p>
 
             </div>
             
@@ -669,13 +844,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-30">
+        <li id="section-42">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-30">&#182;</a>
+                <a class="pilcrow" href="#section-42">&#182;</a>
               </div>
-              <p>(optional) if inner radius is used then a donut chart will be generated instead of pie chart</p>
+              <p>(<em>optional</em>) if inner radius is used then a donut chart will be generated instead of pie chart</p>
 
             </div>
             
@@ -684,13 +859,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-31">
+        <li id="section-43">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-31">&#182;</a>
+                <a class="pilcrow" href="#section-43">&#182;</a>
               </div>
-              <p>(optional) define chart transition duration, :default = 350</p>
+              <p>(<em>optional</em>) define chart transition duration, <code>default = 350</code></p>
 
             </div>
             
@@ -699,13 +874,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-32">
+        <li id="section-44">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-32">&#182;</a>
+                <a class="pilcrow" href="#section-44">&#182;</a>
               </div>
-              <p>(optional) define color array for slices</p>
+              <p>(<em>optional</em>) define color array for slices</p>
 
             </div>
             
@@ -714,13 +889,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-33">
+        <li id="section-45">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-33">&#182;</a>
+                <a class="pilcrow" href="#section-45">&#182;</a>
               </div>
-              <p>(optional) define color domain to match your data domain if you want to bind data or color</p>
+              <p>(<em>optional</em>) define color domain to match your data domain if you want to bind data or color</p>
 
             </div>
             
@@ -729,19 +904,20 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-34">
+        <li id="section-46">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-34">&#182;</a>
+                <a class="pilcrow" href="#section-46">&#182;</a>
               </div>
-              <p>(optional) define color value accessor</p>
+              <p>(<em>optional</em>) define color value accessor</p>
 
             </div>
             
             <div class="content"><div class='highlight'><pre>        .colorAccessor(function(d, i){return d.value;})
         */;
 
+    /* dc.pieChart('#quarter-chart', 'chartGroup'); */
     quarterChart.width(180)
         .height(180)
         .radius(80)
@@ -752,17 +928,23 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-35">
+        <li id="section-47">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-35">&#182;</a>
+                <a class="pilcrow" href="#section-47">&#182;</a>
               </div>
               <h4 id="row-chart">Row Chart</h4>
+<p>Create a row chart and use the given css selector as anchor. You can also specify
+an optional chart group for this chart to be scoped within. When a chart belongs
+to a specific group then any interaction with such chart will only trigger redraw
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#row-chart">Row Chart</a></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    dayOfWeekChart.width(<span class="hljs-number">180</span>)
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.rowChart('#day-of-week-chart', 'chartGroup'); */</span>
+    dayOfWeekChart.width(<span class="hljs-number">180</span>)
         .height(<span class="hljs-number">180</span>)
         .margins({top: <span class="hljs-number">20</span>, left: <span class="hljs-number">10</span>, right: <span class="hljs-number">10</span>, bottom: <span class="hljs-number">20</span>})
         .group(dayOfWeekGroup)
@@ -771,11 +953,11 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-36">
+        <li id="section-48">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-36">&#182;</a>
+                <a class="pilcrow" href="#section-48">&#182;</a>
               </div>
               <p>assign colors to each value in the x scale domain</p>
 
@@ -789,11 +971,11 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-37">
+        <li id="section-49">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-37">&#182;</a>
+                <a class="pilcrow" href="#section-49">&#182;</a>
               </div>
               <p>title sets the row text</p>
 
@@ -808,21 +990,22 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-38">
+        <li id="section-50">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-38">&#182;</a>
+                <a class="pilcrow" href="#section-50">&#182;</a>
               </div>
               <h4 id="bar-chart">Bar Chart</h4>
 <p>Create a bar chart and use the given css selector as anchor. You can also specify
 an optional chart group for this chart to be scoped within. When a chart belongs
 to a specific group then any interaction with such chart will only trigger redraw
-on other charts within the same chart group.</p>
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#bar-chart">Bar Chart</a></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.barChart('#volume-month-chart') */</span>
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.barChart('#volume-month-chart', 'chartGroup') */</span>
     fluctuationChart.width(<span class="hljs-number">420</span>)
         .height(<span class="hljs-number">180</span>)
         .margins({top: <span class="hljs-number">10</span>, right: <span class="hljs-number">50</span>, bottom: <span class="hljs-number">30</span>, left: <span class="hljs-number">40</span>})
@@ -833,13 +1016,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-39">
+        <li id="section-51">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-39">&#182;</a>
+                <a class="pilcrow" href="#section-51">&#182;</a>
               </div>
-              <p>(optional) whether bar should be center to its x value. Not needed for ordinal chart, :default=false</p>
+              <p>(<em>optional</em>) whether bar should be center to its x value. Not needed for ordinal chart, <code>default=false</code></p>
 
             </div>
             
@@ -848,13 +1031,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-40">
+        <li id="section-52">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-40">&#182;</a>
+                <a class="pilcrow" href="#section-52">&#182;</a>
               </div>
-              <p>(optional) set gap between bars manually in px, :default=2</p>
+              <p>(<em>optional</em>) set gap between bars manually in px, <code>default=2</code></p>
 
             </div>
             
@@ -863,13 +1046,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-41">
+        <li id="section-53">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-41">&#182;</a>
+                <a class="pilcrow" href="#section-53">&#182;</a>
               </div>
-              <p>(optional) set filter brush rounding</p>
+              <p>(<em>optional</em>) set filter brush rounding</p>
 
             </div>
             
@@ -881,11 +1064,11 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-42">
+        <li id="section-54">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-42">&#182;</a>
+                <a class="pilcrow" href="#section-54">&#182;</a>
               </div>
               <p>customize the filter displayed in the control span</p>
 
@@ -900,11 +1083,11 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-43">
+        <li id="section-55">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-43">&#182;</a>
+                <a class="pilcrow" href="#section-55">&#182;</a>
               </div>
               <p>Customize axis</p>
 
@@ -917,18 +1100,21 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-44">
+        <li id="section-56">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-44">&#182;</a>
+                <a class="pilcrow" href="#section-56">&#182;</a>
               </div>
               <h4 id="stacked-area-chart">Stacked Area Chart</h4>
-<p>Specify an area chart, by using a line chart with <code>.renderArea(true)</code></p>
+<p>Specify an area chart by using a line chart with <code>.renderArea(true)</code>.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#stack-mixin">Stack Mixin</a>,
+<a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#line-chart">Line Chart</a></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    moveChart
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.lineChart('#monthly-move-chart', 'chartGroup'); */</span>
+    moveChart
         .renderArea(<span class="hljs-literal">true</span>)
         .width(<span class="hljs-number">990</span>)
         .height(<span class="hljs-number">200</span>)
@@ -940,11 +1126,11 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-45">
+        <li id="section-57">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-45">&#182;</a>
+                <a class="pilcrow" href="#section-57">&#182;</a>
               </div>
               <p>Specify a range chart to link the brush extent of the range with the zoom focue of the current chart.</p>
 
@@ -955,21 +1141,36 @@ on other charts within the same chart group.</p>
         .round(d3.time.month.round)
         .xUnits(d3.time.months)
         .elasticY(<span class="hljs-literal">true</span>)
-        .renderHorizontalGridLines(<span class="hljs-literal">true</span>)
-        .legend(dc.legend().x(<span class="hljs-number">800</span>).y(<span class="hljs-number">10</span>).itemHeight(<span class="hljs-number">13</span>).gap(<span class="hljs-number">5</span>))
+        .renderHorizontalGridLines(<span class="hljs-literal">true</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-58">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-58">&#182;</a>
+              </div>
+              <h5 id="legend">Legend</h5>
+<p>Position the legend relative to the chart origin and specify items’ height and separation.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .legend(dc.legend().x(<span class="hljs-number">800</span>).y(<span class="hljs-number">10</span>).itemHeight(<span class="hljs-number">13</span>).gap(<span class="hljs-number">5</span>))
         .brushOn(<span class="hljs-literal">false</span>)</pre></div></div>
             
         </li>
         
         
-        <li id="section-46">
+        <li id="section-59">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-46">&#182;</a>
+                <a class="pilcrow" href="#section-59">&#182;</a>
               </div>
               <p>Add the base layer of the stack with group. The second parameter specifies a series name for use in the
-legend
+legend.
 The <code>.valueAccessor</code> will be used for the base layer</p>
 
             </div>
@@ -982,11 +1183,11 @@ The <code>.valueAccessor</code> will be used for the base layer</p>
         </li>
         
         
-        <li id="section-47">
+        <li id="section-60">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-47">&#182;</a>
+                <a class="pilcrow" href="#section-60">&#182;</a>
               </div>
               <p>stack additional layers with <code>.stack</code>. The first paramenter is a new group.
 The second parameter is the series name. The third is a value accessor.</p>
@@ -1000,11 +1201,11 @@ The second parameter is the series name. The third is a value accessor.</p>
         </li>
         
         
-        <li id="section-48">
+        <li id="section-61">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-48">&#182;</a>
+                <a class="pilcrow" href="#section-61">&#182;</a>
               </div>
               <p>title can be called by any stack layer.</p>
 
@@ -1018,7 +1219,22 @@ The second parameter is the series name. The third is a value accessor.</p>
             <span class="hljs-keyword">return</span> dateFormat(d.key) + <span class="hljs-string">'\n'</span> + numberFormat(value);
         });
 
-    volumeChart.width(<span class="hljs-number">990</span>)
+    <span class="hljs-comment">/* dc.barChart('#monthly-volume-chart', 'chartGroup'); */</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-62">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-62">&#182;</a>
+              </div>
+              <p>Keep the dimensions in synch with the other stacked charts if you want alignment.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    volumeChart.width(<span class="hljs-number">990</span>)
         .height(<span class="hljs-number">40</span>)
         .margins({top: <span class="hljs-number">0</span>, right: <span class="hljs-number">50</span>, bottom: <span class="hljs-number">20</span>, left: <span class="hljs-number">40</span>})
         .dimension(moveMonths)
@@ -1028,49 +1244,48 @@ The second parameter is the series name. The third is a value accessor.</p>
         .x(d3.time.scale().domain([<span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-number">1985</span>, <span class="hljs-number">0</span>, <span class="hljs-number">1</span>), <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-number">2012</span>, <span class="hljs-number">11</span>, <span class="hljs-number">31</span>)]))
         .round(d3.time.month.round)
         .alwaysUseRounding(<span class="hljs-literal">true</span>)
-        .xUnits(d3.time.months);
-
-    <span class="hljs-comment">/*
-</span></pre></div></div>
+        .xUnits(d3.time.months);</pre></div></div>
             
         </li>
         
         
-        <li id="section-49">
+        <li id="section-63">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-49">&#182;</a>
+                <a class="pilcrow" href="#section-63">&#182;</a>
               </div>
               <h4 id="data-count">Data Count</h4>
 <p>Create a data count widget and use the given css selector as anchor. You can also specify
 an optional chart group for this chart to be scoped within. When a chart belongs
 to a specific group then any interaction with such chart will only trigger redraw
-on other charts within the same chart group.</p>
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#data-count-widget">Data Count Widget</a></p>
+<pre><code class="lang-html"><span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'dc-data-count'</span>&gt;</span>
+ <span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'filter-count'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+ selected out of <span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'total-count'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span> records.
+<span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
+</code></pre>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    &lt;div id=<span class="hljs-string">'data-count'</span>&gt;
-        <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'filter-count'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span> selected out of <span class="hljs-tag">&lt;<span class="hljs-title">span</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'total-count'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span> records
-    <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-    */
-    dc.dataCount('.dc-data-count')
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.dataCount('.dc-data-count', 'chartGroup'); */</span>
+    nasdaqCount
         .dimension(ndx)
-        .group(all)
-</span></pre></div></div>
+        .group(all)</pre></div></div>
             
         </li>
         
         
-        <li id="section-50">
+        <li id="section-64">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-50">&#182;</a>
+                <a class="pilcrow" href="#section-64">&#182;</a>
               </div>
-              <p>(optional) html, for setting different html for some records and all records.
-.html replaces everything in the anchor with the html given using the following function.
-%filter-count and %total-count are replaced with the values obtained.</p>
+              <p>(<em>optional</em>) <code>.html</code>, for setting different html for some records/all records.
+<code>.html</code> replaces everything in the anchor with the html given using the following function.
+<code>%filter-count</code> and <code>%total-count</code> are replaced with the values obtained.</p>
 
             </div>
             
@@ -1078,53 +1293,53 @@ on other charts within the same chart group.</p>
             some:<span class="hljs-string">'&lt;strong&gt;%filter-count&lt;/strong&gt; selected out of &lt;strong&gt;%total-count&lt;/strong&gt; records'</span> +
                 <span class="hljs-string">' | &lt;a href=\'javascript:dc.filterAll(); dc.renderAll();\'\'&gt;Reset All&lt;/a&gt;'</span>,
             all:<span class="hljs-string">'All records selected. Please click on the graph to apply filters.'</span>
-        });
-
-    <span class="hljs-comment">/*
-</span></pre></div></div>
+        });</pre></div></div>
             
         </li>
         
         
-        <li id="section-51">
+        <li id="section-65">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-51">&#182;</a>
+                <a class="pilcrow" href="#section-65">&#182;</a>
               </div>
               <h4 id="data-table">Data Table</h4>
 <p>Create a data table widget and use the given css selector as anchor. You can also specify
 an optional chart group for this chart to be scoped within. When a chart belongs
 to a specific group then any interaction with such chart will only trigger redraw
-on other charts within the same chart group.</p>
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#data-table-widget">Data Table Widget</a></p>
+<p>You can statically define the headers like in</p>
+<pre><code class="lang-html">   <span class="hljs-comment">&lt;!-- anchor div for data table --&gt;</span>
+   <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">id</span>=<span class="hljs-value">'data-table'</span>&gt;</span>
+      <span class="hljs-comment">&lt;!-- create a custom header --&gt;</span>
+      <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'header'</span>&gt;</span>
+          <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Date<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+          <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Open<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+          <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Close<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+          <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Change<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+          <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Volume<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
+      <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
+      <span class="hljs-comment">&lt;!-- data rows will filled in here --&gt;</span>
+   <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
+</code></pre>
+<p>or do it programmatically using <code>.columns()</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    &lt;!-- anchor div <span class="hljs-keyword">for</span> data table --&gt;
-    <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">id</span>=<span class="hljs-value">'data-table'</span>&gt;</span>
-        <span class="hljs-comment">&lt;!-- create a custom header --&gt;</span>
-        <span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">class</span>=<span class="hljs-value">'header'</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Date<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Open<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Close<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Change<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
-            <span class="hljs-tag">&lt;<span class="hljs-title">span</span>&gt;</span>Volume<span class="hljs-tag">&lt;/<span class="hljs-title">span</span>&gt;</span>
-        <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-        <span class="hljs-comment">&lt;!-- data rows will filled in here --&gt;</span>
-    <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
-    */
-    dc.dataTable('.dc-data-table')
-        .dimension(dateDimension)
-</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-comment">/* dc.dataTable('.dc-data-table', 'chartGroup') */</span>
+    nasdaqTable
+        .dimension(dateDimension)</pre></div></div>
             
         </li>
         
         
-        <li id="section-52">
+        <li id="section-66">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-52">&#182;</a>
+                <a class="pilcrow" href="#section-66">&#182;</a>
               </div>
               <p>data table does not use crossfilter group but rather a closure
 as a grouping function</p>
@@ -1134,46 +1349,130 @@ as a grouping function</p>
             <div class="content"><div class='highlight'><pre>        .group(<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(d)</span> </span>{
             <span class="hljs-keyword">var</span> format = d3.format(<span class="hljs-string">'02d'</span>);
             <span class="hljs-keyword">return</span> d.dd.getFullYear() + <span class="hljs-string">'/'</span> + format((d.dd.getMonth() + <span class="hljs-number">1</span>));
-        })
-        .size(<span class="hljs-number">10</span>) <span class="hljs-comment">// (optional) max number of records to be shown, :default = 25</span></pre></div></div>
+        })</pre></div></div>
             
         </li>
         
         
-        <li id="section-53">
+        <li id="section-67">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-53">&#182;</a>
+                <a class="pilcrow" href="#section-67">&#182;</a>
+              </div>
+              <p>(<em>optional</em>) max number of records to be shown, <code>default = 25</code></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .size(<span class="hljs-number">10</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-68">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-68">&#182;</a>
               </div>
               <p>There are several ways to specify the columns; see the data-table documentation.
 This code demonstrates generating the column header automatically based on the columns.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>        .columns([
-            <span class="hljs-string">'date'</span>,    <span class="hljs-comment">// d['date'], ie, a field accessor; capitalized automatically</span>
-            <span class="hljs-string">'open'</span>,    <span class="hljs-comment">// ...</span>
-            <span class="hljs-string">'close'</span>,   <span class="hljs-comment">// ...</span>
-            {
-                label: <span class="hljs-string">'Change'</span>, <span class="hljs-comment">// desired format of column name 'Change' when used as a label with a function.</span>
+            <div class="content"><div class='highlight'><pre>        .columns([</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-69">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-69">&#182;</a>
+              </div>
+              <p><code>d[&#39;date&#39;]</code>, i.e. a field accessor; capitalized automatically</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            <span class="hljs-string">'date'</span>,</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-70">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-70">&#182;</a>
+              </div>
+              <p>…</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            <span class="hljs-string">'open'</span>,</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-71">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-71">&#182;</a>
+              </div>
+              <p>…</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            <span class="hljs-string">'close'</span>,
+            {</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-72">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-72">&#182;</a>
+              </div>
+              <p>desired format of column name ‘Change’ when used as a label with a function.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>                label: <span class="hljs-string">'Change'</span>,
                 format: <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(d)</span> </span>{
                     <span class="hljs-keyword">return</span> numberFormat(d.close - d.open);
                 }
-            },
-            <span class="hljs-string">'volume'</span>   <span class="hljs-comment">// d['volume'], ie, a field accessor; capitalized automatically</span>
+            },</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-73">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-73">&#182;</a>
+              </div>
+              <p><code>d[&#39;volume&#39;]</code>, i.e. a field accessor; capitalized automatically</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            <span class="hljs-string">'volume'</span>
         ])</pre></div></div>
             
         </li>
         
         
-        <li id="section-54">
+        <li id="section-74">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-54">&#182;</a>
+                <a class="pilcrow" href="#section-74">&#182;</a>
               </div>
-              <p>(optional) sort using the given field, :default = function(d){return d;}</p>
+              <p>(<em>optional</em>) sort using the given field, <code>default = function(d){return d;}</code></p>
 
             </div>
             
@@ -1184,13 +1483,13 @@ This code demonstrates generating the column header automatically based on the c
         </li>
         
         
-        <li id="section-55">
+        <li id="section-75">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-55">&#182;</a>
+                <a class="pilcrow" href="#section-75">&#182;</a>
               </div>
-              <p>(optional) sort order, :default ascending</p>
+              <p>(<em>optional</em>) sort order, <code>default ascending</code></p>
 
             </div>
             
@@ -1199,13 +1498,13 @@ This code demonstrates generating the column header automatically based on the c
         </li>
         
         
-        <li id="section-56">
+        <li id="section-76">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-56">&#182;</a>
+                <a class="pilcrow" href="#section-76">&#182;</a>
               </div>
-              <p>(optional) custom renderlet to post-process chart using D3</p>
+              <p>(<em>optional</em>) custom renderlet to post-process chart using <a href="http://d3js.org">D3</a></p>
 
             </div>
             
@@ -1219,37 +1518,52 @@ This code demonstrates generating the column header automatically based on the c
         </li>
         
         
-        <li id="section-57">
+        <li id="section-77">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-57">&#182;</a>
+                <a class="pilcrow" href="#section-77">&#182;</a>
               </div>
               <h4 id="geo-choropleth-chart">Geo Choropleth Chart</h4>
 <p>Create a choropleth chart and use the given css selector as anchor. You can also specify
 an optional chart group for this chart to be scoped within. When a chart belongs
 to a specific group then any interaction with such chart will only trigger redraw
-on other charts within the same chart group.</p>
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#geo-choropleth-chart">Geo Chroropleth Chart</a></p>
 
             </div>
             
             <div class="content"><div class='highlight'><pre>    dc.geoChoroplethChart(<span class="hljs-string">'#us-chart'</span>)
         .width(<span class="hljs-number">990</span>) <span class="hljs-comment">// (optional) define chart width, :default = 200</span>
         .height(<span class="hljs-number">500</span>) <span class="hljs-comment">// (optional) define chart height, :default = 200</span>
-        .transitionDuration(<span class="hljs-number">1000</span>) <span class="hljs-comment">// (optional) define chart transition duration, :default = 1000</span>
-        .dimension(states) <span class="hljs-comment">// set crossfilter dimension, dimension key should match the name retrieved in geo json layer</span>
+        .transitionDuration(<span class="hljs-number">1000</span>) <span class="hljs-comment">// (optional) define chart transition duration, :default = 1000</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-78">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-78">&#182;</a>
+              </div>
+              <p>set crossfilter dimension, dimension key should match the name retrieved in geojson layer</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        .dimension(states)
         .group(stateRaisedSum) <span class="hljs-comment">// set crossfilter group</span></pre></div></div>
             
         </li>
         
         
-        <li id="section-58">
+        <li id="section-79">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-58">&#182;</a>
+                <a class="pilcrow" href="#section-79">&#182;</a>
               </div>
-              <p>(optional) define color function or array for bubbles</p>
+              <p>(<em>optional</em>) define color function or array for bubbles</p>
 
             </div>
             
@@ -1259,13 +1573,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-59">
+        <li id="section-80">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-59">&#182;</a>
+                <a class="pilcrow" href="#section-80">&#182;</a>
               </div>
-              <p>(optional) define color domain to match your data domain if you want to bind data or color</p>
+              <p>(<em>optional</em>) define color domain to match your data domain if you want to bind data or color</p>
 
             </div>
             
@@ -1274,13 +1588,13 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-60">
+        <li id="section-81">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-60">&#182;</a>
+                <a class="pilcrow" href="#section-81">&#182;</a>
               </div>
-              <p>(optional) define color value accessor</p>
+              <p>(<em>optional</em>) define color value accessor</p>
 
             </div>
             
@@ -1289,18 +1603,18 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-61">
+        <li id="section-82">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-61">&#182;</a>
+                <a class="pilcrow" href="#section-82">&#182;</a>
               </div>
-              <p>Project the given geojson. You can call this function mutliple times with different geojson feed to generate
+              <p>Project the given geojson. You can call this function multiple times with different geojson feed to generate
 multiple layers of geo paths.</p>
 <ul>
-<li>1st param - geo json data</li>
+<li>1st param - geojson data</li>
 <li>2nd param - name of the layer which will be used to generate css class</li>
-<li>3rd param - (optional) a function used to generate key for geo path, it should match the dimension key
+<li>3rd param - (<em>optional</em>) a function used to generate key for geo path, it should match the dimension key
 in order for the coloring to work properly</li>
 </ul>
 
@@ -1313,13 +1627,13 @@ in order for the coloring to work properly</li>
         </li>
         
         
-        <li id="section-62">
+        <li id="section-83">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-62">&#182;</a>
+                <a class="pilcrow" href="#section-83">&#182;</a>
               </div>
-              <p>(optional) closure to generate title for path, :default = d.key + ‘: ‘ + d.value</p>
+              <p>(<em>optional</em>) closure to generate title for path, <code>default = d.key + &#39;: &#39; + d.value</code></p>
 
             </div>
             
@@ -1330,17 +1644,18 @@ in order for the coloring to work properly</li>
         </li>
         
         
-        <li id="section-63">
+        <li id="section-84">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-63">&#182;</a>
+                <a class="pilcrow" href="#section-84">&#182;</a>
               </div>
               <h4 id="bubble-overlay-chart">Bubble Overlay Chart</h4>
 <p>Create a overlay bubble chart and use the given css selector as anchor. You can also specify
 an optional chart group for this chart to be scoped within. When a chart belongs
 to a specific group then any interaction with such chart will only trigger redraw
-on other charts within the same chart group.</p>
+on other charts within the same chart group.
+<br>API: <a href="https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#bubble-overlay-chart">Bubble Overlay Chart</a></p>
 
             </div>
             
@@ -1349,14 +1664,14 @@ on other charts within the same chart group.</p>
         </li>
         
         
-        <li id="section-64">
+        <li id="section-85">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-64">&#182;</a>
+                <a class="pilcrow" href="#section-85">&#182;</a>
               </div>
-              <p>bubble overlay chart does not generate it’s own svg element but rather resue an existing
-svg to generate it’s overlay layer</p>
+              <p>bubble overlay chart does not generate its own svg element but rather reuse an existing
+svg to generate its overlay layer</p>
 
             </div>
             
@@ -1371,11 +1686,11 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-65">
+        <li id="section-86">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-65">&#182;</a>
+                <a class="pilcrow" href="#section-86">&#182;</a>
               </div>
               <p>closure used to retrieve x value from multi-value group</p>
 
@@ -1386,11 +1701,11 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-66">
+        <li id="section-87">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-66">&#182;</a>
+                <a class="pilcrow" href="#section-87">&#182;</a>
               </div>
               <p>closure used to retrieve y value from multi-value group</p>
 
@@ -1401,13 +1716,13 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-67">
+        <li id="section-88">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-67">&#182;</a>
+                <a class="pilcrow" href="#section-88">&#182;</a>
               </div>
-              <p>(optional) define color function or array for bubbles</p>
+              <p>(<em>optional</em>) define color function or array for bubbles</p>
 
             </div>
             
@@ -1417,13 +1732,13 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-68">
+        <li id="section-89">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-68">&#182;</a>
+                <a class="pilcrow" href="#section-89">&#182;</a>
               </div>
-              <p>(optional) define color domain to match your data domain if you want to bind data or color</p>
+              <p>(<em>optional</em>) define color domain to match your data domain if you want to bind data or color</p>
 
             </div>
             
@@ -1432,13 +1747,13 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-69">
+        <li id="section-90">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-69">&#182;</a>
+                <a class="pilcrow" href="#section-90">&#182;</a>
               </div>
-              <p>(optional) define color value accessor</p>
+              <p>(<em>optional</em>) define color value accessor</p>
 
             </div>
             
@@ -1447,11 +1762,11 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-70">
+        <li id="section-91">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-70">&#182;</a>
+                <a class="pilcrow" href="#section-91">&#182;</a>
               </div>
               <p>closure used to retrieve radius value from multi-value group</p>
 
@@ -1462,11 +1777,11 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-71">
+        <li id="section-92">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-71">&#182;</a>
+                <a class="pilcrow" href="#section-92">&#182;</a>
               </div>
               <p>set radius scale</p>
 
@@ -1477,13 +1792,13 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-72">
+        <li id="section-93">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-72">&#182;</a>
+                <a class="pilcrow" href="#section-93">&#182;</a>
               </div>
-              <p>(optional) whether chart should render labels, :default = true</p>
+              <p>(<em>optional</em>) whether chart should render labels, <code>default = true</code></p>
 
             </div>
             
@@ -1492,13 +1807,13 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-73">
+        <li id="section-94">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-73">&#182;</a>
+                <a class="pilcrow" href="#section-94">&#182;</a>
               </div>
-              <p>(optional) closure to generate label per bubble, :default = group.key</p>
+              <p>(<em>optional</em>) closure to generate label per bubble, <code>default = group.key</code></p>
 
             </div>
             
@@ -1507,13 +1822,13 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-74">
+        <li id="section-95">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-74">&#182;</a>
+                <a class="pilcrow" href="#section-95">&#182;</a>
               </div>
-              <p>(optional) whether chart should render titles, :default = false</p>
+              <p>(<em>optional</em>) whether chart should render titles, <code>default = false</code></p>
 
             </div>
             
@@ -1522,13 +1837,13 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-75">
+        <li id="section-96">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-75">&#182;</a>
+                <a class="pilcrow" href="#section-96">&#182;</a>
               </div>
-              <p>(optional) closure to generate title per bubble, :default = d.key + ‘: ‘ + d.value</p>
+              <p>(<em>optional</em>) closure to generate title per bubble, <code>default = d.key + &#39;: &#39; + d.value</code></p>
 
             </div>
             
@@ -1539,15 +1854,15 @@ svg to generate it’s overlay layer</p>
         </li>
         
         
-        <li id="section-76">
+        <li id="section-97">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-76">&#182;</a>
+                <a class="pilcrow" href="#section-97">&#182;</a>
               </div>
-              <p>add data point to it’s layer dimension key that matches point name will be used to
-generate bubble. multiple data points can be added to bubble overlay to generate
-multiple bubbles</p>
+              <p>add data point to its layer dimension key that matches point name: it will be used to
+generate a bubble. Multiple data points can be added to the bubble overlay to generate
+multiple bubbles.</p>
 
             </div>
             
@@ -1557,15 +1872,15 @@ multiple bubbles</p>
         </li>
         
         
-        <li id="section-77">
+        <li id="section-98">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-77">&#182;</a>
+                <a class="pilcrow" href="#section-98">&#182;</a>
               </div>
-              <p>(optional) setting debug flag to true will generate a transparent layer on top of
-bubble overlay which can be used to obtain relative x,y coordinate for specific
-data point, :default = false</p>
+              <p>(<em>optional</em>) setting debug flag to true will generate a transparent layer on top of
+bubble overlay which can be used to obtain relative <code>x</code>,<code>y</code> coordinate for specific
+data point, <code>default = false</code></p>
 
             </div>
             
@@ -1575,14 +1890,14 @@ data point, :default = false</p>
         </li>
         
         
-        <li id="section-78">
+        <li id="section-99">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-78">&#182;</a>
+                <a class="pilcrow" href="#section-99">&#182;</a>
               </div>
               <h4 id="rendering">Rendering</h4>
-<p>simply call renderAll() to render all charts on the page</p>
+<p>simply call <code>dc.renderAll()</code> to render all charts on the page</p>
 
             </div>
             
@@ -1593,11 +1908,11 @@ data point, :default = false</p>
         </li>
         
         
-        <li id="section-79">
+        <li id="section-100">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-79">&#182;</a>
+                <a class="pilcrow" href="#section-100">&#182;</a>
               </div>
               <p>or you can render charts belong to a specific chart group</p>
 
@@ -1608,14 +1923,14 @@ data point, :default = false</p>
         </li>
         
         
-        <li id="section-80">
+        <li id="section-101">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-80">&#182;</a>
+                <a class="pilcrow" href="#section-101">&#182;</a>
               </div>
-              <p>once rendered you can call redrawAll to update charts incrementally when data
-change without re-rendering everything</p>
+              <p>once rendered you can call <code>dc.redrawAll()</code>
+to update charts incrementally when data change without re-rendering everything</p>
 
             </div>
             
@@ -1624,13 +1939,13 @@ change without re-rendering everything</p>
         </li>
         
         
-        <li id="section-81">
+        <li id="section-102">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-81">&#182;</a>
+                <a class="pilcrow" href="#section-102">&#182;</a>
               </div>
-              <p>or you can choose to redraw only those charts associated with a specific chart group</p>
+              <p>or you can choose to <code>dc.redraw(chartGroup)</code> only those charts associated with a specific chart group</p>
 
             </div>
             
@@ -1642,11 +1957,11 @@ change without re-rendering everything</p>
         </li>
         
         
-        <li id="section-82">
+        <li id="section-103">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-82">&#182;</a>
+                <a class="pilcrow" href="#section-103">&#182;</a>
               </div>
               <h4 id="versions">Versions</h4>
 <p>Determine the current version of dc with <code>dc.version</code></p>
@@ -1658,11 +1973,11 @@ change without re-rendering everything</p>
         </li>
         
         
-        <li id="section-83">
+        <li id="section-104">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-83">&#182;</a>
+                <a class="pilcrow" href="#section-104">&#182;</a>
               </div>
               <p>Determine latest stable version in the repo via Github API</p>
 

--- a/web/stock.js
+++ b/web/stock.js
@@ -15,6 +15,8 @@ var dayOfWeekChart = dc.rowChart('#day-of-week-chart');
 var moveChart = dc.lineChart('#monthly-move-chart');
 var volumeChart = dc.barChart('#monthly-volume-chart');
 var yearlyBubbleChart = dc.bubbleChart('#yearly-bubble-chart');
+var nasdaqCount = dc.dataCount('.dc-data-count');
+var nasdaqTable = dc.dataTable('.dc-data-table');
 
 // ### Anchor Div for Charts
 /*
@@ -27,13 +29,17 @@ var yearlyBubbleChart = dc.bubbleChart('#yearly-bubble-chart');
 // will automatically turn it on/off based on whether there is filter
 // set on this chart (slice selection for pie chart and brush
 // selection for bar chart). Enable this with `chart.turnOnControls(true)`
-     <div id='chart'>
-       <a class='reset' href='javascript:myChart.filterAll();dc.redrawAll();' style='display: none;'>reset</a>
-     </div>
+    <div id='chart'>
+       <a class='reset'
+          href='javascript:myChart.filterAll();dc.redrawAll();'
+          style='display: none;'>reset</a>
+    </div>
 // dc.js will also automatically inject applied current filter value into
 // any html element with css class set to 'filter'
     <div id='chart'>
-        <span class='reset' style='display: none;'>Current filter: <span class='filter'></span></span>
+        <span class='reset' style='display: none;'>
+          Current filter: <span class='filter'></span>
+        </span>
     </div>
 */
 
@@ -179,7 +185,7 @@ d3.csv('ndx.csv', function (data) {
     var dayOfWeekGroup = dayOfWeek.group();
 
     //### Define Chart Attributes
-    //Define chart attributes using fluent methods. See the
+    // Define chart attributes using fluent methods. See the
     // [dc API Reference](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md) for more information
     //
 
@@ -188,19 +194,25 @@ d3.csv('ndx.csv', function (data) {
     //an optional chart group for this chart to be scoped within. When a chart belongs
     //to a specific group then any interaction with such chart will only trigger redraw
     //on other charts within the same chart group.
+    // <br>API: [Bubble Chart](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#bubble-chart)
     /* dc.bubbleChart('#yearly-bubble-chart', 'chartGroup') */
     yearlyBubbleChart
-        .width(990) // (optional) define chart width, :default = 200
-        .height(250)  // (optional) define chart height, :default = 200
-        .transitionDuration(1500) // (optional) define chart transition duration, :default = 750
+        // (_optional_) define chart width, `default = 200`
+        .width(990)
+        // (_optional_) define chart height, `default = 200`
+        .height(250)
+        // (_optional_) define chart transition duration, :default = 750
+        .transitionDuration(1500)
         .margins({top: 10, right: 50, bottom: 30, left: 40})
         .dimension(yearlyDimension)
-        //Bubble chart expect the groups are reduced to multiple values which would then be used
+        //Bubble chart group's attributes are reduced to multiple values which would then be used
         //to generate x, y, and radius for each key (bubble) in the group
         .group(yearlyPerformanceGroup)
-        .colors(colorbrewer.RdYlGn[9]) // (optional) define color function or array for bubbles
-        .colorDomain([-500, 500]) //(optional) define color domain to match your data domain if you want to bind data or
-                                  //color
+        // (_optional_) define color function or array for bubbles: [ColorBrewer](http://colorbrewer2.org/)
+        // and [Mike](http://bl.ocks.org/mbostock/5577023) to the rescue
+        .colors(colorbrewer.RdYlGn[9])
+        //(optional) define color domain to match your data domain if you want to bind data or color
+        .colorDomain([-500, 500])
         //##### Accessors
         //Accessor functions are applied to each value returned by the grouping
         //
@@ -208,7 +220,7 @@ d3.csv('ndx.csv', function (data) {
         //* `.keyAccessor` Identifies the `X` value that will be applied against the `.x()` to identify pixel location
         //* `.valueAccessor` Identifies the `Y` value that will be applied agains the `.y()` to identify pixel location
         //* `.radiusValueAccessor` Identifies the value that will be applied agains the `.r()` determine radius size,
-        //*     by default this maps linearly to [0,100]
+        //   by default this maps linearly to [0,100]
         .colorAccessor(function (d) {
             return d.value.absGain;
         })
@@ -226,24 +238,30 @@ d3.csv('ndx.csv', function (data) {
         .y(d3.scale.linear().domain([-100, 100]))
         .r(d3.scale.linear().domain([0, 4000]))
         //##### Elastic Scaling
-        //`.elasticX` and `.elasticX` determine whether the chart should rescale each axis to fit data.
+        //`.elasticY` and `.elasticX` determine whether the chart should rescale each axis to fit data.
         //The `.yAxisPadding` and `.xAxisPadding` add padding to data above and below their max values in the same unit
         //domains as the Accessors.
         .elasticY(true)
         .elasticX(true)
         .yAxisPadding(100)
         .xAxisPadding(500)
-        .renderHorizontalGridLines(true) // (optional) render horizontal grid lines, :default=false
-        .renderVerticalGridLines(true) // (optional) render vertical grid lines, :default=false
-        .xAxisLabel('Index Gain') // (optional) render an axis label below the x axis
-        .yAxisLabel('Index Gain %') // (optional) render a vertical axis lable left of the y axis
-        //#### Labels and  Titles
-        //Labels are displaed on the chart for each bubble. Titles displayed on mouseover.
-        .renderLabel(true) // (optional) whether chart should render labels, :default = true
+        // (_optional_) render horizontal grid lines, `default=false`
+        .renderHorizontalGridLines(true)
+        // (_optional_) render vertical grid lines, `default=false`
+        .renderVerticalGridLines(true)
+        // (_optional_) render an axis label below the x axis
+        .xAxisLabel('Index Gain')
+        // (_optional_) render a vertical axis lable left of the y axis
+        .yAxisLabel('Index Gain %')
+        //##### Labels and  Titles
+        //Labels are displayed on the chart for each bubble. Titles displayed on mouseover.
+        // (_optional_) whether chart should render labels, `default = true`
+        .renderLabel(true)
         .label(function (p) {
             return p.key;
         })
-        .renderTitle(true) // (optional) whether chart should render titles, :default = false
+        // (_optional_) whether chart should render titles, `default = false`
+        .renderTitle(true)
         .title(function (p) {
             return [
                 p.key,
@@ -252,7 +270,7 @@ d3.csv('ndx.csv', function (data) {
                 'Fluctuation / Index Ratio: ' + numberFormat(p.value.fluctuationPercentage) + '%'
             ].join('\n');
         })
-        //#### Customize Axis
+        //##### Customize Axis
         //Set a custom tick format. Note `.yAxis()` returns an axis object, so any additional method chaining applies
         //to the axis, not the chart.
         .yAxis().tickFormat(function (v) {
@@ -264,15 +282,16 @@ d3.csv('ndx.csv', function (data) {
     // an optional chart group for this chart to be scoped within. When a chart belongs
     // to a specific group then any interaction with such chart will only trigger redraw
     // on other charts within the same chart group.
-
+    // <br>API: [Pie Chart](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#pie-chart)
+    /* dc.pieChart('#gain-loss-chart', 'chartGroup') */
     gainOrLossChart
         .width(180) // (optional) define chart width, :default = 200
         .height(180) // (optional) define chart height, :default = 200
-        .radius(80) // define pie radius
+        // define pie radius
+        .radius(80)
         .dimension(gainOrLoss) // set dimension
         .group(gainOrLossGroup) // set group
-        /* (optional) by default pie chart will use group.key as its label
-         * but you can overwrite it with a closure */
+        // (_optional_) by default pie chart will use `group.key` as its label but you can overwrite it with a closure.
         .label(function (d) {
             if (gainOrLossChart.hasFilter() && !gainOrLossChart.hasFilter(d.key)) {
                 return d.key + '(0%)';
@@ -283,20 +302,21 @@ d3.csv('ndx.csv', function (data) {
             }
             return label;
         }) /*
-        // (optional) whether chart should render labels, :default = true
+        // (_optional_) whether chart should render labels, `default = true`
         .renderLabel(true)
-        // (optional) if inner radius is used then a donut chart will be generated instead of pie chart
+        // (_optional_) if inner radius is used then a donut chart will be generated instead of pie chart
         .innerRadius(40)
-        // (optional) define chart transition duration, :default = 350
+        // (_optional_) define chart transition duration, `default = 350`
         .transitionDuration(500)
-        // (optional) define color array for slices
+        // (_optional_) define color array for slices
         .colors(['#3182bd', '#6baed6', '#9ecae1', '#c6dbef', '#dadaeb'])
-        // (optional) define color domain to match your data domain if you want to bind data or color
+        // (_optional_) define color domain to match your data domain if you want to bind data or color
         .colorDomain([-1750, 1644])
-        // (optional) define color value accessor
+        // (_optional_) define color value accessor
         .colorAccessor(function(d, i){return d.value;})
         */;
 
+    /* dc.pieChart('#quarter-chart', 'chartGroup'); */
     quarterChart.width(180)
         .height(180)
         .radius(80)
@@ -305,6 +325,12 @@ d3.csv('ndx.csv', function (data) {
         .group(quarterGroup);
 
     //#### Row Chart
+    // Create a row chart and use the given css selector as anchor. You can also specify
+    // an optional chart group for this chart to be scoped within. When a chart belongs
+    // to a specific group then any interaction with such chart will only trigger redraw
+    // on other charts within the same chart group.
+    // <br>API: [Row Chart](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#row-chart)
+    /* dc.rowChart('#day-of-week-chart', 'chartGroup'); */
     dayOfWeekChart.width(180)
         .height(180)
         .margins({top: 20, left: 10, right: 10, bottom: 20})
@@ -327,18 +353,19 @@ d3.csv('ndx.csv', function (data) {
     // an optional chart group for this chart to be scoped within. When a chart belongs
     // to a specific group then any interaction with such chart will only trigger redraw
     // on other charts within the same chart group.
-    /* dc.barChart('#volume-month-chart') */
+    // <br>API: [Bar Chart](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#bar-chart)
+    /* dc.barChart('#volume-month-chart', 'chartGroup') */
     fluctuationChart.width(420)
         .height(180)
         .margins({top: 10, right: 50, bottom: 30, left: 40})
         .dimension(fluctuation)
         .group(fluctuationGroup)
         .elasticY(true)
-        // (optional) whether bar should be center to its x value. Not needed for ordinal chart, :default=false
+        // (_optional_) whether bar should be center to its x value. Not needed for ordinal chart, `default=false`
         .centerBar(true)
-        // (optional) set gap between bars manually in px, :default=2
+        // (_optional_) set gap between bars manually in px, `default=2`
         .gap(1)
-        // (optional) set filter brush rounding
+        // (_optional_) set filter brush rounding
         .round(dc.round.floor)
         .alwaysUseRounding(true)
         .x(d3.scale.linear().domain([-25, 25]))
@@ -356,7 +383,10 @@ d3.csv('ndx.csv', function (data) {
     fluctuationChart.yAxis().ticks(5);
 
     //#### Stacked Area Chart
-    //Specify an area chart, by using a line chart with `.renderArea(true)`
+    //Specify an area chart by using a line chart with `.renderArea(true)`.
+    // <br>API: [Stack Mixin](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#stack-mixin),
+    // [Line Chart](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#line-chart)
+    /* dc.lineChart('#monthly-move-chart', 'chartGroup'); */
     moveChart
         .renderArea(true)
         .width(990)
@@ -372,10 +402,12 @@ d3.csv('ndx.csv', function (data) {
         .xUnits(d3.time.months)
         .elasticY(true)
         .renderHorizontalGridLines(true)
+        //##### Legend
+        // Position the legend relative to the chart origin and specify items' height and separation.
         .legend(dc.legend().x(800).y(10).itemHeight(13).gap(5))
         .brushOn(false)
         // Add the base layer of the stack with group. The second parameter specifies a series name for use in the
-        // legend
+        // legend.
         // The `.valueAccessor` will be used for the base layer
         .group(indexAvgByMonthGroup, 'Monthly Index Average')
         .valueAccessor(function (d) {
@@ -395,6 +427,8 @@ d3.csv('ndx.csv', function (data) {
             return dateFormat(d.key) + '\n' + numberFormat(value);
         });
 
+    /* dc.barChart('#monthly-volume-chart', 'chartGroup'); */
+    // Keep the dimensions in synch with the other stacked charts if you want alignment.
     volumeChart.width(990)
         .height(40)
         .margins({top: 0, right: 50, bottom: 20, left: 40})
@@ -407,48 +441,58 @@ d3.csv('ndx.csv', function (data) {
         .alwaysUseRounding(true)
         .xUnits(d3.time.months);
 
-    /*
     //#### Data Count
     // Create a data count widget and use the given css selector as anchor. You can also specify
     // an optional chart group for this chart to be scoped within. When a chart belongs
     // to a specific group then any interaction with such chart will only trigger redraw
     // on other charts within the same chart group.
-    <div id='data-count'>
-        <span class='filter-count'></span> selected out of <span class='total-count'></span> records
-    </div>
-    */
-    dc.dataCount('.dc-data-count')
+    // <br>API: [Data Count Widget](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#data-count-widget)
+    //
+    //```html
+    //<div class='dc-data-count'>
+    //  <span class='filter-count'></span>
+    //  selected out of <span class='total-count'></span> records.
+    //</div>
+    //```
+    /* dc.dataCount('.dc-data-count', 'chartGroup'); */
+    nasdaqCount
         .dimension(ndx)
         .group(all)
-        // (optional) html, for setting different html for some records and all records.
-        // .html replaces everything in the anchor with the html given using the following function.
-        // %filter-count and %total-count are replaced with the values obtained.
+        // (_optional_) `.html`, for setting different html for some records/all records.
+        // `.html` replaces everything in the anchor with the html given using the following function.
+        // `%filter-count` and `%total-count` are replaced with the values obtained.
         .html({
             some:'<strong>%filter-count</strong> selected out of <strong>%total-count</strong> records' +
                 ' | <a href=\'javascript:dc.filterAll(); dc.renderAll();\'\'>Reset All</a>',
             all:'All records selected. Please click on the graph to apply filters.'
         });
 
-    /*
     //#### Data Table
     // Create a data table widget and use the given css selector as anchor. You can also specify
     // an optional chart group for this chart to be scoped within. When a chart belongs
     // to a specific group then any interaction with such chart will only trigger redraw
     // on other charts within the same chart group.
-    <!-- anchor div for data table -->
-    <div id='data-table'>
-        <!-- create a custom header -->
-        <div class='header'>
-            <span>Date</span>
-            <span>Open</span>
-            <span>Close</span>
-            <span>Change</span>
-            <span>Volume</span>
-        </div>
-        <!-- data rows will filled in here -->
-    </div>
-    */
-    dc.dataTable('.dc-data-table')
+    // <br>API: [Data Table Widget](https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#data-table-widget)
+    //
+    // You can statically define the headers like in
+    //
+    // ```html
+    //    <!-- anchor div for data table -->
+    //    <div id='data-table'>
+    //       <!-- create a custom header -->
+    //       <div class='header'>
+    //           <span>Date</span>
+    //           <span>Open</span>
+    //           <span>Close</span>
+    //           <span>Change</span>
+    //           <span>Volume</span>
+    //       </div>
+    //       <!-- data rows will filled in here -->
+    //    </div>
+    // ```
+    // or do it programmatically using `.columns()`.
+    /* dc.dataTable('.dc-data-table', 'chartGroup') */
+    nasdaqTable
         .dimension(dateDimension)
         // data table does not use crossfilter group but rather a closure
         // as a grouping function
@@ -456,29 +500,35 @@ d3.csv('ndx.csv', function (data) {
             var format = d3.format('02d');
             return d.dd.getFullYear() + '/' + format((d.dd.getMonth() + 1));
         })
-        .size(10) // (optional) max number of records to be shown, :default = 25
+        // (_optional_) max number of records to be shown, `default = 25`
+        .size(10)
         // There are several ways to specify the columns; see the data-table documentation.
         // This code demonstrates generating the column header automatically based on the columns.
         .columns([
-            'date',    // d['date'], ie, a field accessor; capitalized automatically
-            'open',    // ...
-            'close',   // ...
+            // `d['date']`, i.e. a field accessor; capitalized automatically
+            'date',
+            // ...
+            'open',
+            // ...
+            'close',
             {
-                label: 'Change', // desired format of column name 'Change' when used as a label with a function.
+                // desired format of column name 'Change' when used as a label with a function.
+                label: 'Change',
                 format: function (d) {
                     return numberFormat(d.close - d.open);
                 }
             },
-            'volume'   // d['volume'], ie, a field accessor; capitalized automatically
+            // `d['volume']`, i.e. a field accessor; capitalized automatically
+            'volume'
         ])
 
-        // (optional) sort using the given field, :default = function(d){return d;}
+        // (_optional_) sort using the given field, `default = function(d){return d;}`
         .sortBy(function (d) {
             return d.dd;
         })
-        // (optional) sort order, :default ascending
+        // (_optional_) sort order, `default ascending`
         .order(d3.ascending)
-        // (optional) custom renderlet to post-process chart using D3
+        // (_optional_) custom renderlet to post-process chart using [D3](http://d3js.org)
         .renderlet(function (table) {
             table.selectAll('.dc-table-group').classed('info', true);
         });
@@ -489,30 +539,33 @@ d3.csv('ndx.csv', function (data) {
     //an optional chart group for this chart to be scoped within. When a chart belongs
     //to a specific group then any interaction with such chart will only trigger redraw
     //on other charts within the same chart group.
+    // <br>API: [Geo Chroropleth Chart][choro]
+    // [choro]: https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#geo-choropleth-chart
     dc.geoChoroplethChart('#us-chart')
         .width(990) // (optional) define chart width, :default = 200
         .height(500) // (optional) define chart height, :default = 200
         .transitionDuration(1000) // (optional) define chart transition duration, :default = 1000
-        .dimension(states) // set crossfilter dimension, dimension key should match the name retrieved in geo json layer
+        // set crossfilter dimension, dimension key should match the name retrieved in geojson layer
+        .dimension(states)
         .group(stateRaisedSum) // set crossfilter group
-        // (optional) define color function or array for bubbles
+        // (_optional_) define color function or array for bubbles
         .colors(['#ccc', '#E2F2FF','#C4E4FF','#9ED2FF','#81C5FF','#6BBAFF','#51AEFF','#36A2FF','#1E96FF','#0089FF',
             '#0061B5'])
-        // (optional) define color domain to match your data domain if you want to bind data or color
+        // (_optional_) define color domain to match your data domain if you want to bind data or color
         .colorDomain([-5, 200])
-        // (optional) define color value accessor
+        // (_optional_) define color value accessor
         .colorAccessor(function(d, i){return d.value;})
-        // Project the given geojson. You can call this function mutliple times with different geojson feed to generate
+        // Project the given geojson. You can call this function multiple times with different geojson feed to generate
         // multiple layers of geo paths.
         //
-        // * 1st param - geo json data
+        // * 1st param - geojson data
         // * 2nd param - name of the layer which will be used to generate css class
-        // * 3rd param - (optional) a function used to generate key for geo path, it should match the dimension key
+        // * 3rd param - (_optional_) a function used to generate key for geo path, it should match the dimension key
         // in order for the coloring to work properly
         .overlayGeoJson(statesJson.features, 'state', function(d) {
             return d.properties.name;
         })
-        // (optional) closure to generate title for path, :default = d.key + ': ' + d.value
+        // (_optional_) closure to generate title for path, `default = d.key + ': ' + d.value`
         .title(function(d) {
             return 'State: ' + d.key + '\nTotal Amount Raised: ' + numberFormat(d.value ? d.value : 0) + 'M';
         });
@@ -522,9 +575,11 @@ d3.csv('ndx.csv', function (data) {
         // an optional chart group for this chart to be scoped within. When a chart belongs
         // to a specific group then any interaction with such chart will only trigger redraw
         // on other charts within the same chart group.
+        // <br>API: [Bubble Overlay Chart][bubble]
+        // [bubble]: https://github.com/dc-js/dc.js/blob/master/web/docs/api-latest.md#bubble-overlay-chart
         dc.bubbleOverlay('#bubble-overlay')
-            // bubble overlay chart does not generate it's own svg element but rather resue an existing
-            // svg to generate it's overlay layer
+            // bubble overlay chart does not generate its own svg element but rather reuse an existing
+            // svg to generate its overlay layer
             .svg(d3.select('#bubble-overlay svg'))
             .width(990) // (optional) define chart width, :default = 200
             .height(500) // (optional) define chart height, :default = 200
@@ -536,48 +591,48 @@ d3.csv('ndx.csv', function (data) {
             .keyAccessor(function(p) {return p.value.absGain;})
             // closure used to retrieve y value from multi-value group
             .valueAccessor(function(p) {return p.value.percentageGain;})
-            // (optional) define color function or array for bubbles
+            // (_optional_) define color function or array for bubbles
             .colors(['#ccc', '#E2F2FF','#C4E4FF','#9ED2FF','#81C5FF','#6BBAFF','#51AEFF','#36A2FF','#1E96FF','#0089FF',
                 '#0061B5'])
-            // (optional) define color domain to match your data domain if you want to bind data or color
+            // (_optional_) define color domain to match your data domain if you want to bind data or color
             .colorDomain([-5, 200])
-            // (optional) define color value accessor
+            // (_optional_) define color value accessor
             .colorAccessor(function(d, i){return d.value;})
             // closure used to retrieve radius value from multi-value group
             .radiusValueAccessor(function(p) {return p.value.fluctuationPercentage;})
             // set radius scale
             .r(d3.scale.linear().domain([0, 3]))
-            // (optional) whether chart should render labels, :default = true
+            // (_optional_) whether chart should render labels, `default = true`
             .renderLabel(true)
-            // (optional) closure to generate label per bubble, :default = group.key
+            // (_optional_) closure to generate label per bubble, `default = group.key`
             .label(function(p) {return p.key.getFullYear();})
-            // (optional) whether chart should render titles, :default = false
+            // (_optional_) whether chart should render titles, `default = false`
             .renderTitle(true)
-            // (optional) closure to generate title per bubble, :default = d.key + ': ' + d.value
+            // (_optional_) closure to generate title per bubble, `default = d.key + ': ' + d.value`
             .title(function(d) {
                 return 'Title: ' + d.key;
             })
-            // add data point to it's layer dimension key that matches point name will be used to
-            // generate bubble. multiple data points can be added to bubble overlay to generate
-            // multiple bubbles
+            // add data point to its layer dimension key that matches point name: it will be used to
+            // generate a bubble. Multiple data points can be added to the bubble overlay to generate
+            // multiple bubbles.
             .point('California', 100, 120)
             .point('Colorado', 300, 120)
-            // (optional) setting debug flag to true will generate a transparent layer on top of
-            // bubble overlay which can be used to obtain relative x,y coordinate for specific
-            // data point, :default = false
+            // (_optional_) setting debug flag to true will generate a transparent layer on top of
+            // bubble overlay which can be used to obtain relative `x`,`y` coordinate for specific
+            // data point, `default = false`
             .debug(true);
     */
 
     //#### Rendering
-    //simply call renderAll() to render all charts on the page
+    //simply call `dc.renderAll()` to render all charts on the page
     dc.renderAll();
     /*
     // or you can render charts belong to a specific chart group
     dc.renderAll('group');
-    // once rendered you can call redrawAll to update charts incrementally when data
-    // change without re-rendering everything
+    // once rendered you can call `dc.redrawAll()`
+    // to update charts incrementally when data change without re-rendering everything
     dc.redrawAll();
-    // or you can choose to redraw only those charts associated with a specific chart group
+    // or you can choose to `dc.redraw(chartGroup)` only those charts associated with a specific chart group
     dc.redrawAll('group');
     */
 


### PR DESCRIPTION
I have fixed few typos (it's --> its; displaed --> displayed; ...)
(Hopefully) Improved annotated example with extra text, links to API, ...

In order to pass all test I had to use [this fix](https://github.com/gruntjs/grunt-contrib-uglify/issues/298) for `grunt uglify`, i.e. from `compress: true,` to `compress: {},`