### PR TITLE
Added bubble overlay reset. Bubble font size setter and getter. Bubble radii min and max range. Points list add.

### DIFF
--- a/spec/bubble-overlay-spec.js
+++ b/spec/bubble-overlay-spec.js
@@ -30,6 +30,7 @@ describe('dc.bubbleOverlay', function() {
                 .point("Oklahoma", 200, 350);
 
             chart.render();
+
         });
 
         it('should generate an instance of the dc chart', function() {
@@ -96,6 +97,64 @@ describe('dc.bubbleOverlay', function() {
             expect(d3.select(chart.selectAll("g.node")[0][1]).attr("class")).toEqual("node colorado selected");
             expect(d3.select(chart.selectAll("g.node")[0][3]).attr("class")).toEqual("node ontario deselected");
         });
+
+        it('should not find circle, title or text elements after a reset', function(){
+            chart.reset();
+            expect(chart.selectAll("circle.bubble")[0].length).toEqual(0);
+            expect(chart.selectAll("g.node text")[0].length).toEqual(0);
+            expect(chart.selectAll("g.node title")[0].length).toEqual(0);
+        });
+
+        it('should add the correct number of bubbles after a reset', function(){
+            var points = [];
+            points.push({name : "California", x:100, y:120});
+            points.push({name : "Colorado", x:300, y:120});
+            points.push({name : "Delaware", x:500, y:220});
+            points.push({name : "Ontario", x:180, y:90});
+            points.push({name : "Mississippi", x:120, y:220});
+            points.push({name : "Oklahoma", x:200, y:350});
+            chart.reset();
+            chart.addPoints(points);
+            chart.render();
+
+            expect(chart.selectAll("circle.bubble")[0].length).toEqual(6);
+        });
+
+        it('should set the min and maximum range of a bubbles radius', function(){
+            var points = [];
+            points.push({name : "California", x:100, y:120});
+            points.push({name : "Colorado", x:300, y:120});
+            points.push({name : "Delaware", x:500, y:220});
+            points.push({name : "Ontario", x:180, y:90});
+            points.push({name : "Mississippi", x:120, y:220});
+            points.push({name : "Oklahoma", x:200, y:350});
+            chart.reset();
+            chart.addPoints(points);
+            chart.minBubbleR(0);
+            chart.maxBubbleR(1);
+            chart.render();
+
+            expect(d3.select(chart.selectAll("circle.bubble")[0][0]).attr("r")).toEqual("0.308");
+            expect(d3.select(chart.selectAll("circle.bubble")[0][3]).attr("r")).toEqual("0.154");
+        });
+
+        it('should set the min and maximum range of a bubbles radius', function(){
+            var points = [];
+            points.push({name : "California", x:100, y:120});
+            points.push({name : "Colorado", x:300, y:120});
+            points.push({name : "Delaware", x:500, y:220});
+            points.push({name : "Ontario", x:180, y:90});
+            points.push({name : "Mississippi", x:120, y:220});
+            points.push({name : "Oklahoma", x:200, y:350});
+            chart.reset();
+            chart.addPoints(points);
+            chart.fontSize("20px");
+            chart.render();
+
+            expect(d3.select(chart.selectAll("g.node text")[0][0]).attr("font-size")).toEqual("20px");
+            expect(d3.select(chart.selectAll("g.node text")[0][3]).attr("font-size")).toEqual("20px");
+        });
+
     });
 });
 

--- a/src/bubble-mixin.js
+++ b/src/bubble-mixin.js
@@ -8,6 +8,7 @@ This Mixin provides reusable functionalities for any chart that needs to visuali
 dc.bubbleMixin = function (_chart) {
     var _maxBubbleRelativeSize = 0.3;
     var _minRadiusWithLabel = 10;
+    var _fontSize = "10px";
 
     _chart.BUBBLE_NODE_CLASS = 'node';
     _chart.BUBBLE_CLASS = 'bubble';
@@ -42,6 +43,19 @@ dc.bubbleMixin = function (_chart) {
     };
 
     /**
+    #### .fontSize(bubbleFontSize)
+    Get or set the bubble label text font size. By default the bubble label text font size
+    is 10px.
+    **/
+    _chart.fontSize = function(_){
+        if(!arguments.length) {
+            return _fontSize;
+        }
+        _fontSize = _;
+        return _chart;
+    }
+
+    /**
     #### .radiusValueAccessor([radiusValueAccessor])
     Get or set the radius value accessor function. If set, the radius value accessor function will
     be used to retrieve a data value for each bubble. The data retrieved then will be mapped using
@@ -74,7 +88,7 @@ dc.bubbleMixin = function (_chart) {
     _chart.bubbleR = function (d) {
         var value = _chart.radiusValueAccessor()(d);
         var r = _chart.r()(value);
-        if (isNaN(r) || value <= 0) {
+        if (isNaN(r) || value <= 0 || r < 0) {
             r = 0;
         }
         return r;
@@ -101,6 +115,7 @@ dc.bubbleMixin = function (_chart) {
 
             label
                 .attr('opacity', 0)
+                .attr("font-size", _chart.fontSize())
                 .text(labelFunction);
             dc.transition(label, _chart.transitionDuration())
                 .attr('opacity', labelOpacity);


### PR DESCRIPTION
I have extended the bubble overlay to allow the client to remove the circle, text and title elements. I found this useful when re-rendering the bubble overlay with different points.

I have added setters and getters for the bubble radii range. This allows the radii of the bubble to be in a bound range that is not dependent on the width of the bubble overlay and allows for a more readable setup.

I have added setters and getters for the bubble label font size. This allows bubble text to be added to the bubble for a wider range of bubble sizes, without the text dominating the bubble. Default size is 10px.

Added the ability to add a list of points to the bubble-overlay.