### PR TITLE
Allow brushing filters to only occur at brush end

### DIFF
--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -577,13 +577,14 @@ describe('dc.barChart', function() {
             beforeEach(function () {
                 d3.select("#" + id).append("span").attr("class", "filter").style("display", "none");
                 d3.select("#" + id).append("a").attr("class", "reset").style("display", "none");
-                chart.filter([makeDate(2012, 5, 1), makeDate(2012, 5, 30)]).redraw();
+                chart.filter(dc.filters.RangedFilter(makeDate(2012, 5, 1), makeDate(2012, 5, 30))).redraw();
                 dc.dateFormat = d3.time.format.utc("%m/%d/%Y");
                 chart.redraw();
             });
 
             it('should set the chart filter', function () {
-                expect(chart.filter()).toEqual([makeDate(2012, 5, 1), makeDate(2012, 5, 30)]);
+                expect(chart.filter()[0]).toEqual(makeDate(2012, 5, 1));
+                expect(chart.filter()[1]).toEqual(makeDate(2012, 5, 30));
             });
 
             it("should enable the reset link after rendering", function() {

--- a/spec/composite-chart-spec.js
+++ b/spec/composite-chart-spec.js
@@ -257,7 +257,7 @@ describe('dc.compositeChart', function() {
 
             describe('when filtering the chart', function () {
                 beforeEach(function () {
-                    chart.filter([makeDate(2012, 5, 1), makeDate(2012, 5, 30)]).redraw();
+                    chart.filter(dc.filters.RangedFilter(makeDate(2012, 5, 1), makeDate(2012, 5, 30))).redraw();
                 });
 
                 it('should set extent width to chart width based on filter set', function () {

--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -599,7 +599,7 @@ describe('dc.coordinateGridChart', function() {
     });
 
     describe("applying a filter", function () {
-        var filter = [makeDate(2012, 5, 20), makeDate(2012, 6, 15)];
+        var filter = dc.filters.RangedFilter(makeDate(2012, 5, 20), makeDate(2012, 6, 15));
         beforeEach(function () {
             chart.brushOn(true);
             chart.render();
@@ -607,7 +607,8 @@ describe('dc.coordinateGridChart', function() {
         });
 
         it("should update the brush extent", function () {
-            expect(chart.brush().extent()).toEqual(filter);
+            expect(chart.brush().extent()[0]).toEqual(filter[0]);
+            expect(chart.brush().extent()[1]).toEqual(filter[1]);
         });
     });
 

--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -155,31 +155,16 @@ dc.barChart = function (parent, chartGroup) {
 
     _chart.fadeDeselectedArea = function () {
         var bars = _chart.chartBodyG().selectAll('rect.bar');
-        var extent = _chart.brush().extent();
-
-        if (_chart.isOrdinal()) {
-            if (_chart.hasFilter()) {
-                bars.classed(dc.constants.SELECTED_CLASS, function (d) {
-                    return _chart.hasFilter(d.x);
-                });
-                bars.classed(dc.constants.DESELECTED_CLASS, function (d) {
-                    return !_chart.hasFilter(d.x);
-                });
-            } else {
-                bars.classed(dc.constants.SELECTED_CLASS, false);
-                bars.classed(dc.constants.DESELECTED_CLASS, false);
-            }
+        if (_chart.hasFilter()) {
+            bars.classed(dc.constants.SELECTED_CLASS, function (d) {
+                return _chart.hasFilter(d.x);
+            });
+            bars.classed(dc.constants.DESELECTED_CLASS, function (d) {
+                return !_chart.hasFilter(d.x);
+            });
         } else {
-            if (!_chart.brushIsEmpty(extent)) {
-                var start = extent[0];
-                var end = extent[1];
-
-                bars.classed(dc.constants.DESELECTED_CLASS, function (d) {
-                    return d.x < start || d.x >= end;
-                });
-            } else {
-                bars.classed(dc.constants.DESELECTED_CLASS, false);
-            }
+            bars.classed(dc.constants.SELECTED_CLASS, false);
+            bars.classed(dc.constants.DESELECTED_CLASS, false);
         }
     };
 
@@ -244,16 +229,10 @@ dc.barChart = function (parent, chartGroup) {
         return _chart;
     };
 
-    _chart.extendBrush = function () {
-        var extent = _chart.brush().extent();
+    _chart.extendBrush = function (extent) {
         if (_chart.round() && (!_centerBar || _alwaysUseRounding)) {
-            extent[0] = extent.map(_chart.round())[0];
-            extent[1] = extent.map(_chart.round())[1];
-
-            _chart.chartBodyG().select('.brush')
-                .call(_chart.brush().extent(extent));
+            return extent.map(_chart.round());
         }
-
         return extent;
     };
 

--- a/src/base-mixin.js
+++ b/src/base-mixin.js
@@ -536,7 +536,7 @@ dc.baseMixin = function (_chart) {
             return filters.length > 0;
         }
         return filters.some(function (f) {
-            return filter <= f && filter >= f;
+            return (f.isFiltered && f.isFiltered(filter)) || filter <= f && filter >= f;
         });
     };
 
@@ -700,6 +700,14 @@ dc.baseMixin = function (_chart) {
             _filters = fs ? fs : _filters;
         }
     }
+
+    _chart.setFilter = function(_) {
+        if (_) {
+            _filters = [_];
+        } else {
+            _filters = [];
+        }
+    };
 
     _chart.replaceFilter = function (_) {
         _filters = [];

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -74,16 +74,27 @@ dc.compositeChart = function (parent, chartGroup) {
         return g;
     });
 
-    _chart._brushing = function () {
-        var extent = _chart.extendBrush();
-        var brushIsEmpty = _chart.brushIsEmpty(extent);
-
+    _chart.on('filtered.composite', function(chart, filter) {
         for (var i = 0; i < _children.length; ++i) {
-            _children[i].filter(null);
-            if (!brushIsEmpty) {
-                _children[i].filter(extent);
-            }
+            _children[i].replaceFilter(filter);
         }
+    });
+
+    _chart._brushing = function () {
+        _chart._brush(function (filter) {
+            for (var i = 0; i < _children.length; ++i) {
+                _children[i].replaceFilter(filter);
+            }
+        });
+    };
+
+    _chart._nonFilteredBrushing = function () {
+        _chart._brush(function (filter) {
+            for (var i = 0; i < _children.length; ++i) {
+                _children[i].setFilter(filter);
+                _children[i].fadeDeselectedArea();
+            }
+        });
     };
 
     _chart._prepareYAxis = function () {
@@ -203,9 +214,7 @@ dc.compositeChart = function (parent, chartGroup) {
 
     _chart.fadeDeselectedArea = function () {
         for (var i = 0; i < _children.length; ++i) {
-            var child = _children[i];
-            child.brush(_chart.brush());
-            child.fadeDeselectedArea();
+            _children[i].fadeDeselectedArea();
         }
     };
 

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -1,4 +1,11 @@
+/**
+ ## Coordinate Grid Mixin
+ Includes: [Color Mixin](#color-mixin), [Margin Mixin](#margin-mixin), [Base Mixin](#base-mixin)
 
+ Coordinate Grid is an abstract base chart designed to support a number of coordinate grid based
+ concrete chart types, e.g. bar chart, line chart, and bubble chart.
+
+ **/
 dc.coordinateGridMixin = function (_chart) {
     var GRID_LINE_CLASS = 'grid-line';
     var HORIZONTAL_CLASS = 'horizontal';

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -813,22 +813,6 @@ dc.coordinateGridMixin = function (_chart) {
         return _chart;
     };
 
-    dc.override(_chart, 'filter', function (_) {
-        if (!arguments.length) {
-            return _chart._filter();
-        }
-
-        _chart._filter(_);
-
-        if (_) {
-            _chart.brush().extent(_);
-        } else {
-            _chart.brush().clear();
-        }
-
-        return _chart;
-    });
-
     _chart.brush = function (_) {
         if (!arguments.length) {
             return _brush;
@@ -837,107 +821,49 @@ dc.coordinateGridMixin = function (_chart) {
         return _chart;
     };
 
+    /**
+     #### .brushOn([boolean])
+     Turn on/off the brush-based range filter. When brushing is on then user can drag the mouse
+     across a chart with a quantitative scale to perform range filtering based on the extent of the
+     brush, or click on the bars of an ordinal bar chart or slices of a pie chart to filter and
+     unfilter them. However turning on the brush filter will disable other interactive elements on
+     the chart such as highlighting, tool tips, and reference lines. Zooming will still be possible
+     if enabled, but only via scrolling (panning will be disabled.) Default: true
+
+     **/
+    _chart.brushOn = function (_) {
+        if (!arguments.length) {
+            return _brushOn;
+        }
+        // If brush on is switched, we should reset the filters.
+        // We should not mix range filters with click filters
+        if (_brushOn !== _ && _chart.hasFilter()) {
+            _chart.filterAll();
+        }
+        _brushOn = _;
+        return _chart;
+    };
+
+    /**
+     #### .filterOnBrushEnd([boolean])
+     Allows one to specify when the brush filtering should be performed.  If this is false,
+     filtering happens at every move of the brush.  If this is true, filtering occurs when the
+     brush is dropped.  Default: false
+     */
+    _chart.filterOnBrushEnd = function (_) {
+        if (!arguments.length) {
+            return _filterOnBrushEnd;
+        }
+        _filterOnBrushEnd = _;
+        return _chart;
+    };
+
     function brushHeight() {
         return _chart._xAxisY() - _chart.margins().top;
     }
 
-    _chart.renderBrush = function (g) {
-        if (_brushOn) {
-            _brush.on('brushstart', _chart._disableMouseZoom);
-            _brush.on('brushend', configureMouseZoom);
-            if (!_filterOnBrushEnd) {
-                _brush.on('brush', _chart._brushing);
-                _brush.on('brushend.filter', function () {});
-            } else {
-                _brush.on('brush', _chart._nonFilteredBrushing);
-                _brush.on('brushend.filter', _chart._brushing);
-            }
-
-            var gBrush = g.append('g')
-                .attr('class', 'brush')
-                .attr('transform', 'translate(' + _chart.margins().left + ',' + _chart.margins().top + ')')
-                .call(_brush.x(_chart.x()));
-            _chart.setBrushY(gBrush);
-            _chart.setHandlePaths(gBrush);
-
-            if (_chart.hasFilter()) {
-                _chart.redrawBrush(g);
-            }
-        }
-    };
-
-    _chart.setHandlePaths = function (gBrush) {
-        gBrush.selectAll('.resize').append('path').attr('d', _chart.resizeHandlePath);
-    };
-
-    _chart.setBrushY = function (gBrush) {
-        gBrush.selectAll('rect').attr('height', brushHeight());
-    };
-
-    _chart.extendBrush = function () {
-        var extent = _brush.extent();
-        if (_chart.round()) {
-            extent[0] = extent.map(_chart.round())[0];
-            extent[1] = extent.map(_chart.round())[1];
-
-            _g.select('.brush')
-                .call(_brush.extent(extent));
-        }
-        return extent;
-    };
-
-    _chart.brushIsEmpty = function (extent) {
-        return _brush.empty() || !extent || extent[1] <= extent[0];
-    };
-
-    function _brushing (redrawFn) {
-        var extent = _chart.extendBrush();
-
-        _chart.redrawBrush(_g);
-
-        if (_chart.brushIsEmpty(extent)) {
-            dc.events.trigger(function () {
-                _chart.filter(null);
-                redrawFn();
-            }, dc.constants.EVENT_DELAY);
-        } else {
-            var rangedFilter = dc.filters.RangedFilter(extent[0], extent[1]);
-
-            dc.events.trigger(function () {
-                _chart.replaceFilter(rangedFilter);
-                redrawFn();
-            }, dc.constants.EVENT_DELAY);
-        }
-    }
-
-    _chart._brushing = function () {
-        _brushing(_chart.redrawGroup);
-    };
-
-    _chart._nonFilteredBrushing = function () {
-        _brushing(_chart.redraw);
-    };
-
-    _chart.redrawBrush = function (g) {
-        if (_brushOn) {
-            if (_chart.filter() && _chart.brush().empty()) {
-                _chart.brush().extent(_chart.filter());
-            }
-
-            var gBrush = g.select('g.brush');
-            gBrush.call(_chart.brush().x(_chart.x()));
-            _chart.setBrushY(gBrush);
-        }
-
-        _chart.fadeDeselectedArea();
-    };
-
-    _chart.fadeDeselectedArea = function () {
-        // do nothing, sub-chart should override this function
-    };
-
     // borrowed from Crossfilter example
-    _chart.resizeHandlePath = function (d) {
+    function resizeHandlePath (d) {
         var e = +(d === 'e'), x = e ? 1 : -1, y = brushHeight() / 3;
         return 'M' + (0.5 * x) + ',' + y +
             'A6,6 0 0 ' + e + ' ' + (6.5 * x) + ',' + (y + 6) +
@@ -948,6 +874,83 @@ dc.coordinateGridMixin = function (_chart) {
             'V' + (2 * y - 8) +
             'M' + (4.5 * x) + ',' + (y + 8) +
             'V' + (2 * y - 8);
+    }
+
+    _chart.on('filtered.brush', function (chart, filter) {
+        if (filter) {
+            _brush.extent(filter);
+        } else {
+            _brush.clear();
+        }
+    });
+
+    _chart.renderBrush = function (g) {
+        _brush.on('brushstart', _chart._disableMouseZoom);
+        _brush.on('brushend', configureMouseZoom);
+        if (!_filterOnBrushEnd) {
+            _brush.on('brush', _chart._brushing);
+            _brush.on('brushend.filter', function () {});
+        } else {
+            _brush.on('brush', _chart._nonFilteredBrushing);
+            _brush.on('brushend.filter', _chart._brushing);
+        }
+        var gBrush = g.append('g')
+            .attr('class', 'brush')
+            .attr('transform', 'translate(' + _chart.margins().left + ',' + _chart.margins().top + ')')
+            .call(_brush.x(_chart.x()));
+        gBrush.selectAll('.resize').append('path').attr('d', resizeHandlePath);
+        _chart.redrawBrush(g);
+    };
+
+    _chart.redrawBrush = function (g) {
+        if (_chart.filter() && _chart.brush().empty()) {
+            _chart.brush().extent(_chart.filter());
+        } else if (!_chart.filter() && !_chart.brush().empty()) {
+            _chart.brush().clear();
+        }
+        var gBrush = g.select('g.brush');
+        gBrush.call(_chart.brush().x(_chart.x()));
+        gBrush.selectAll('rect').attr('height', brushHeight());
+    };
+
+    _chart.extendBrush = function (extent) {
+        if (_chart.round()) {
+            return extent.map(_chart.round());
+        }
+        return extent;
+    };
+
+    _chart._brush = function (redrawFn) {
+        var extent = !_brush.empty() && _brush.extent(),
+            filter = null;
+        if (extent) {
+            extent = _chart.extendBrush(extent);
+            _g.select('.brush').call(_brush.extent(extent));
+            filter = dc.filters.RangedFilter(extent[0], extent[1]);
+        } else {
+            _brush.clear();
+        }
+        redrawFn(filter);
+    };
+
+    _chart._brushing = function () {
+        _chart._brush(function (filter) {
+            dc.events.trigger(function () {
+                _chart.replaceFilter(filter);
+                _chart.redrawGroup();
+            }, dc.constants.EVENT_DELAY);
+        });
+    };
+
+    _chart._nonFilteredBrushing = function () {
+        _chart._brush(function (filter) {
+            _chart.setFilter(filter);
+            _chart.fadeDeselectedArea();
+        });
+    };
+
+    _chart.fadeDeselectedArea = function () {
+        // do nothing, sub-chart should override this function
     };
 
     function getClipPathId() {
@@ -1028,11 +1031,14 @@ dc.coordinateGridMixin = function (_chart) {
             _chart.renderYAxis(_chart.g());
         }
 
-        if (render) {
-            _chart.renderBrush(_chart.g());
-        } else {
-            _chart.redrawBrush(_chart.g());
+        if (_brushOn) {
+            if (render) {
+                _chart.renderBrush(_chart.g());
+            } else {
+                _chart.redrawBrush(_chart.g());
+            }
         }
+        _chart.fadeDeselectedArea();
     }
 
     function configureMouseZoom () {
@@ -1131,43 +1137,6 @@ dc.coordinateGridMixin = function (_chart) {
         }
         return false;
     }
-
-    /**
-    #### .brushOn([boolean])
-    Turn on/off the brush-based range filter. When brushing is on then user can drag the mouse
-    across a chart with a quantitative scale to perform range filtering based on the extent of the
-    brush, or click on the bars of an ordinal bar chart or slices of a pie chart to filter and
-    unfilter them. However turning on the brush filter will disable other interactive elements on
-    the chart such as highlighting, tool tips, and reference lines. Zooming will still be possible
-    if enabled, but only via scrolling (panning will be disabled.) Default: true
-
-    **/
-    _chart.brushOn = function (_) {
-        if (!arguments.length) {
-            return _brushOn;
-        }
-        // If brush on is switched, we should reset the filters.
-        // We should not mix range filters with click filters
-        if (_brushOn !== _ && _chart.hasFilter()) {
-            _chart.filterAll();
-        }
-        _brushOn = _;
-        return _chart;
-    };
-
-    /**
-     #### .filterOnBrushEnd([boolean])
-     Allows one to specify when the brush filtering should be performed.  If this is false,
-     filtering happens at every move of the brush.  If this is true, filtering occurs when the
-     brush is dropped.  Default: false
-     */
-    _chart.filterOnBrushEnd = function (_) {
-        if (!arguments.length) {
-            return _filterOnBrushEnd;
-        }
-        _filterOnBrushEnd = _;
-        return _chart;
-    };
 
     function hasRangeSelected(range) {
         return range instanceof Array && range.length > 1;

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -849,7 +849,7 @@ dc.coordinateGridMixin = function (_chart) {
                 _brush.on('brush', _chart._brushing);
                 _brush.on('brushend.filter', function () {});
             } else {
-                _brush.on('brush', function () {});
+                _brush.on('brush', _chart._nonFilteredBrushing);
                 _brush.on('brushend.filter', _chart._brushing);
             }
 
@@ -890,7 +890,7 @@ dc.coordinateGridMixin = function (_chart) {
         return _brush.empty() || !extent || extent[1] <= extent[0];
     };
 
-    _chart._brushing = function () {
+    function _brushing (redrawFn) {
         var extent = _chart.extendBrush();
 
         _chart.redrawBrush(_g);
@@ -898,16 +898,24 @@ dc.coordinateGridMixin = function (_chart) {
         if (_chart.brushIsEmpty(extent)) {
             dc.events.trigger(function () {
                 _chart.filter(null);
-                _chart.redrawGroup();
+                redrawFn();
             }, dc.constants.EVENT_DELAY);
         } else {
             var rangedFilter = dc.filters.RangedFilter(extent[0], extent[1]);
 
             dc.events.trigger(function () {
                 _chart.replaceFilter(rangedFilter);
-                _chart.redrawGroup();
+                redrawFn();
             }, dc.constants.EVENT_DELAY);
         }
+    }
+
+    _chart._brushing = function () {
+        _brushing(_chart.redrawGroup);
+    };
+
+    _chart._nonFilteredBrushing = function () {
+        _brushing(_chart.redraw);
     };
 
     _chart.redrawBrush = function (g) {

--- a/src/filters.js
+++ b/src/filters.js
@@ -19,6 +19,11 @@ mention below which chart uses which filter.  In some cases, many instances of a
  axis brushing for the [coordinate grid charts](#coordinate-grid-mixin).
 **/
 dc.filters.RangedFilter = function (low, high) {
+    if (low > high) {
+        var tmp = high;
+        high = low;
+        low = tmp;
+    }
     var range = new Array(low, high);
     range.isFiltered = function (value) {
         return value >= this[0] && value < this[1];


### PR DESCRIPTION
This is perf change.  Constantly calling brushes can create big issues in performance with multiple charts.  Granted the interval between filtering could also be changed.  This just allows you to turn off that intermediate brushing calls and only trigger at the end.

Also, if brushOn is turned on/off, we should clear the current state of filters.  Mixing range filters with click filters is probably bad.