### PR TITLE
Added external radius padding

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -41,7 +41,8 @@ dc.pieChart = function (parent, chartGroup) {
     var _emptyTitle = 'empty';
 
     var _radius,
-        _innerRadius = 0;
+        _innerRadius = 0,
+        _externalRadiusPadding = 0;
 
     var _g;
     var _cx;
@@ -252,6 +253,20 @@ dc.pieChart = function (parent, chartGroup) {
     }
 
     /**
+     #### .externalRadiusPadding([externalRadiusPadding])
+     Get or set the external radius padding of the pie chart. This will force the radius of the
+     pie chart to become smaller or larger depending on the value.  Default external radius padding is 0px.
+
+     **/
+    _chart.externalRadiusPadding = function (_) {
+        if (!arguments.length) {
+            return _externalRadiusPadding;
+        }
+        _externalRadiusPadding = _;
+        return _chart;
+    };
+
+    /**
     #### .innerRadius([innerRadius])
     Get or set the inner radius of the pie chart. If the inner radius is greater than 0px then the
     pie chart will be rendered as a doughnut chart. Default inner radius is 0px.
@@ -306,7 +321,7 @@ dc.pieChart = function (parent, chartGroup) {
     };
 
     function buildArcs() {
-        return d3.svg.arc().outerRadius(_radius).innerRadius(_innerRadius);
+        return d3.svg.arc().outerRadius(_radius - _externalRadiusPadding).innerRadius(_innerRadius);
     }
 
     function isSelectedSlice(d) {
@@ -413,8 +428,8 @@ dc.pieChart = function (parent, chartGroup) {
         var centroid;
         if (_externalLabelRadius) {
             centroid = d3.svg.arc()
-                .outerRadius(_radius + _externalLabelRadius)
-                .innerRadius(_radius + _externalLabelRadius)
+                .outerRadius(_radius - _externalRadiusPadding + _externalLabelRadius)
+                .innerRadius(_radius - _externalRadiusPadding + _externalLabelRadius)
                 .centroid(d);
         } else {
             centroid = arc.centroid(d);


### PR DESCRIPTION
If you have the width/height of the chart filling it's parent, there is no proper way to reduce the external radius of pie chart while keeping it centered (at least with some really hacky margin work).  This solves that issue.