### PR TITLE
Coordinate grid xDomain change

### DIFF
--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -393,7 +393,8 @@ dc.coordinateGridMixin = function (_chart) {
 
         // has the domain changed?
         var xdom = _x.domain();
-        if (!_lastXDomain || xdom.some(function (elem, i) { return elem !== _lastXDomain[i]; })) {
+        if (!_lastXDomain || _lastXDomain.length !== xdom.length ||
+            xdom.some(function (elem, i) { return elem !== _lastXDomain[i]; })) {
             _chart.rescale();
         }
         _lastXDomain = xdom;

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -379,7 +379,7 @@ dc.coordinateGridMixin = function (_chart) {
         return groups.map(_chart.keyAccessor());
     };
 
-    function prepareXAxis(g) {
+    function prepareXAxis(g, render) {
         if (!_chart.isOrdinal()) {
             if (_chart.elasticX()) {
                 _x.domain([_chart.xAxisMin(), _chart.xAxisMax()]);
@@ -393,7 +393,7 @@ dc.coordinateGridMixin = function (_chart) {
 
         // has the domain changed?
         var xdom = _x.domain();
-        if (!_lastXDomain || _lastXDomain.length !== xdom.length ||
+        if (render || !_lastXDomain || _lastXDomain.length !== xdom.length ||
             xdom.some(function (elem, i) { return elem !== _lastXDomain[i]; })) {
             _chart.rescale();
         }
@@ -1001,7 +1001,7 @@ dc.coordinateGridMixin = function (_chart) {
             _brushOn = false;
         }
 
-        prepareXAxis(_chart.g());
+        prepareXAxis(_chart.g(), render);
         _chart._prepareYAxis(_chart.g());
 
         _chart.plotData();


### PR DESCRIPTION
Crossfilter always provides every row, even if the measure value is 0.  When not using Crossfilter, this will almost never be the case.

This check ensures that the xAxis is updated if the previous domain length is not equal to that of the new domain.