### PR TITLE
Fixes filtering on render

### DIFF
--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -1018,6 +1018,7 @@ dc.coordinateGridMixin = function (_chart) {
         } else {
             _chart.redrawBrush(_chart.g());
         }
+        _chart.fadeDeselectedArea();
     }
 
     function configureMouseZoom () {


### PR DESCRIPTION
After a render, an ordinal coordinate grid doesn't retain its faded area.  Simple fix.