### PR TITLE
Using d3.svg.axis instead of custom axis implementation on heatmap

### DIFF
--- a/dc.css
+++ b/dc.css
@@ -305,6 +305,11 @@ div.dc-chart {
     stroke: none;
 }
 
+.dc-chart .heatmap .axis .domain,
+.dc-chart .heatmap .axis .tick line {
+    opacity: 0;
+}
+
 .dc-chart .heatmap .box-group.deselected rect {
     stroke: none;
     fill-opacity: .5;


### PR DESCRIPTION
This is probably the more desired change to the heatmap, which is to use `d3.svg.axis` instead of a one off implementation.  I imagine our original heatmap implementation was borrowed from: http://bl.ocks.org/tjdecke/5558084
which also doesn't use d3.svg.axis.

The domain line and ticks have been set to `opacity: 0` for consistency of look and feel.

Also as a one off, this properly uses the ordinal scales `rangeBand()` function to give the correct width/height of a heatmap box.

Broke some tests though :(