### PR TITLE
Hidable support for series charts

### DIFF
--- a/spec/series-chart-spec.js
+++ b/spec/series-chart-spec.js
@@ -133,4 +133,50 @@ describe('dc.seriesChart', function() {
             expect(dots[0].length).toEqual(6);
         });
     });
+
+    describe('legends with hidable stacks', function () {
+        beforeEach(function () {
+            chart
+                .chart(function(c) { return dc.lineChart(c).hidableStacks(true); })
+                .legend(dc.legend().x(10).y(10).itemHeight(13).gap(5))
+                .render();
+        });
+
+        describe('clicking on a legend item', function () {
+            beforeEach(function () {
+                legendItem(0).on('click').call(legendItem(0)[0][0], legendItem(0).datum());
+            });
+
+            it('should fade out the legend item', function() {
+                expect(legendItem(0).classed('fadeout')).toBeTruthy();
+            });
+
+            it('should hide its associated stack', function() {
+                expect(chart.selectAll('path.line').size()).toEqual(1);
+            });
+
+            it('disable hover highlighting for that legend item', function() {
+                legendItem(0).on('mouseover')(legendItem(0).datum());
+                expect(chart.selectAll('path.line').classed('fadeout')).toBeFalsy();
+            });
+
+            describe('clicking on a faded out legend item', function () {
+                beforeEach(function () {
+                    legendItem(0).on('click').call(legendItem(0)[0][0], legendItem(0).datum());
+                });
+
+                it('should unfade the legend item', function() {
+                    expect(legendItem(0).classed('fadeout')).toBeFalsy();
+                });
+
+                it('should unfade its associated stack', function() {
+                    expect(chart.selectAll('path.line').size()).toEqual(2);
+                });
+            });
+        });
+    });
+
+    function legendItem(n) {
+        return d3.select(chart.selectAll('g.dc-legend g.dc-legend-item')[0][n]);
+    }
 });

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -143,6 +143,10 @@ dc.compositeChart = function (parent, chartGroup) {
         for (var i = 0; i < _children.length; ++i) {
             var child = _children[i];
 
+            if (child.isLegendableHidden()) {
+                continue;
+            }
+
             if (!child.g()) {
                 generateChildG(child, i);
             }
@@ -319,13 +323,13 @@ dc.compositeChart = function (parent, chartGroup) {
 
     function leftYAxisChildren() {
         return _children.filter(function (child) {
-            return !child.useRightYAxis();
+            return !child.isLegendableHidden() && !child.useRightYAxis();
         });
     }
 
     function rightYAxisChildren() {
         return _children.filter(function (child) {
-            return child.useRightYAxis();
+            return !child.isLegendableHidden() && child.useRightYAxis();
         });
     }
 

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -394,9 +394,11 @@ dc.compositeChart = function (parent, chartGroup) {
     };
 
     _chart.legendHighlight = function (d) {
-        for (var j = 0; j < _children.length; ++j) {
-            var child = _children[j];
-            child.legendHighlight(d);
+        if (!d.chart.isLegendableHidden()) {
+            for (var j = 0; j < _children.length; ++j) {
+                var child = _children[j];
+                child.legendHighlight(d);
+            }
         }
     };
 

--- a/src/stack-mixin.js
+++ b/src/stack-mixin.js
@@ -29,6 +29,7 @@ dc.stackMixin = function (_chart) {
     var _titles = {};
 
     var _hidableStacks = false;
+    var _hidden = false;
 
     function domainFilter() {
         if (!_chart.x()) {
@@ -267,18 +268,25 @@ dc.stackMixin = function (_chart) {
     };
 
     _chart.isLegendableHidden = function (d) {
-        var layer = findLayerByName(d.name);
-        return layer ? layer.hidden : false;
+        if (d && _stack.length > 1) {
+            var layer = findLayerByName(d.name);
+            return layer ? layer.hidden : false;
+        } else {
+            return _hidden;
+        }
     };
 
     _chart.legendToggle = function (d) {
         if (_hidableStacks) {
-            if (_chart.isLegendableHidden(d)) {
-                _chart.showStack(d.name);
+            if (d && _stack.length > 1) {
+                if (_chart.isLegendableHidden(d)) {
+                    _chart.showStack(d.name);
+                } else {
+                    _chart.hideStack(d.name);
+                }
             } else {
-                _chart.hideStack(d.name);
+                _hidden = !_hidden;
             }
-            //_chart.redraw();
             _chart.renderGroup();
         }
     };

--- a/web/examples/index.html
+++ b/web/examples/index.html
@@ -34,6 +34,7 @@ here</a>.</p>
     <td><a href="scatter-series.html">scatter-series.html</a></td>
     <td><a href="scatter.html">scatter.html</a></td>
     <td><a href="series.html">series.html</a></td>
+    <td><a href="stack.html">stack.html</a></td>
 <tr>
 </table>
 </div></body></html>

--- a/web/examples/series.html
+++ b/web/examples/series.html
@@ -22,31 +22,31 @@ var ndx, runDimension, runGroup;
 
 d3.csv("morley.csv", function(error, experiments) {
 
-  ndx = crossfilter(experiments);
-  runDimension = ndx.dimension(function(d) {return [+d.Expt, +d.Run]; });
-  runGroup = runDimension.group().reduceSum(function(d) { return +d.Speed; });
+    ndx = crossfilter(experiments);
+    runDimension = ndx.dimension(function(d) {return [+d.Expt, +d.Run]; });
+    runGroup = runDimension.group().reduceSum(function(d) { return +d.Speed; });
 
-  chart
-    .width(768)
-    .height(480)
-    .chart(function(c) { return dc.lineChart(c).interpolate('basis').hidableStacks(true); })
-    .x(d3.scale.linear().domain([0,20]))
-    .brushOn(false)
-    .yAxisLabel("Measured Speed km/s")
-    .xAxisLabel("Run")
-    .clipPadding(10)
-    .elasticY(true)
-    .dimension(runDimension)
-    .group(runGroup)
-    .mouseZoomable(true)
-    .seriesAccessor(function(d) {return "Expt: " + d.key[0];})
-    .keyAccessor(function(d) {return +d.key[1];})
-    .valueAccessor(function(d) {return +d.value - 500;})
-    .legend(dc.legend().x(350).y(350).itemHeight(13).gap(5).horizontal(1).legendWidth(140).itemWidth(70));
-  chart.yAxis().tickFormat(function(d) {return d3.format(',d')(d+299500);});
-  chart.margins().left += 40;
+    chart
+        .width(768)
+        .height(480)
+        .chart(function(c) { return dc.lineChart(c).interpolate('basis').hidableStacks(true); })
+        .x(d3.scale.linear().domain([0,20]))
+        .brushOn(false)
+        .yAxisLabel("Measured Speed km/s")
+        .xAxisLabel("Run")
+        .clipPadding(10)
+        .elasticY(true)
+        .dimension(runDimension)
+        .group(runGroup)
+        .mouseZoomable(true)
+        .seriesAccessor(function(d) {return "Expt: " + d.key[0];})
+        .keyAccessor(function(d) {return +d.key[1];})
+        .valueAccessor(function(d) {return +d.value - 500;})
+        .legend(dc.legend().x(350).y(350).itemHeight(13).gap(5).horizontal(1).legendWidth(140).itemWidth(70));
+    chart.yAxis().tickFormat(function(d) {return d3.format(',d')(d+299500);});
+    chart.margins().left += 40;
 
-  dc.renderAll();
+    dc.renderAll();
 
 });
 

--- a/web/examples/series.html
+++ b/web/examples/series.html
@@ -29,7 +29,7 @@ d3.csv("morley.csv", function(error, experiments) {
   chart
     .width(768)
     .height(480)
-    .chart(function(c) { return dc.lineChart(c).interpolate('basis'); })
+    .chart(function(c) { return dc.lineChart(c).interpolate('basis').hidableStacks(true); })
     .x(d3.scale.linear().domain([0,20]))
     .brushOn(false)
     .yAxisLabel("Measured Speed km/s")

--- a/web/examples/stack.html
+++ b/web/examples/stack.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>dc.js - Composite Chart Example</title>
+    <title>dc.js - Stacked Area Chart Example</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="../css/dc.css"/>
 </head>
@@ -15,7 +15,7 @@
 <script type="text/javascript" src="../js/dc.js"></script>
 <script type="text/javascript">
 
-var composite = dc.compositeChart("#test_composed");
+var lineChart = dc.lineChart("#test_composed");
 
 var q = queue()
     .defer(d3.csv, "morley.csv")
@@ -35,28 +35,19 @@ q.await(function(error, exp1, exp2) {
         grp1 = dim.group().reduceSum(dc.pluck('y1')),
         grp2 = dim.group().reduceSum(dc.pluck('y2'));
 
-    composite
+    lineChart
         .width(768)
         .height(480)
         .x(d3.scale.linear().domain([0,20]))
         .yAxisLabel("The Y Axis")
         .legend(dc.legend().x(80).y(20).itemHeight(13).gap(5))
         .renderHorizontalGridLines(true)
-        .compose([
-            dc.lineChart(composite)
-                .dimension(dim)
-                .colors('red')
-                .group(grp1, "Top Line")
-                .hidableStacks(true)
-                .dashStyle([2,2]),
-            dc.lineChart(composite)
-                .dimension(dim)
-                .colors('blue')
-                .group(grp2, "Bottom Line")
-                .hidableStacks(true)
-                .dashStyle([5,5])
-            ])
+        .dimension(dim)
+        .group(grp1, "Bottom Line")
+        .stack(grp2, "Top Line")
         .brushOn(false)
+        .renderArea(true)
+        .hidableStacks(true)
         .render();
 
 });


### PR DESCRIPTION
In an effort to address #582, I've made some changes to "stack-mixin" to make it aware of series charts through the fact that the `_stack` has only one element. This is necessary because when series charts are redrawn, the `_stack` of each underlying chart is rebuilt. Therefore, any changes to the `hidden` attribute are not persisted.

I also updated "composite-chart" so that it filters hidden children in a few key locations.

I updated a few examples so that they demonstrate the hidable legends and added a stacked line (area) chart example.

If this seems like a reasonable solution, let me know and I'll add some specs. I've tried my best to follow the contribution guidelines, but this is my first time so please let me know if I've made any mistakes.
