### PR TITLE
added bullet chart

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
                 src: ['<%= conf.src %>/**/*.js', 'Gruntfile.js', '<%= conf.web %>/stock.js'],
                 options: {
                     jshintrc: '.jshintrc',
-                    ignores: ['<%= conf.src %>/banner.js', '<%= conf.src %>/footer.js']
+                    ignores: ['<%= conf.src %>/banner.js', '<%= conf.src %>/footer.js', '<%= conf.src %>/d3.bullet.js']
                 }
             }
         },
@@ -415,5 +415,7 @@ module.exports.jsFiles = [
     'src/heatmap.js',
     'src/d3.box.js',
     'src/box-plot.js',
+    'src/d3.bullet.js',
+    'src/bullet-chart.js',
     'src/footer.js'  // NOTE: keep this last
 ];

--- a/src/bullet-chart.js
+++ b/src/bullet-chart.js
@@ -1,0 +1,162 @@
+/**
+## Bullet Chart
+Includes: [Color Mixin](#color-mixin), [Margin Mixin](#margin-mixin), [Base Mixin](#base-mixin)
+
+Concrete bullet chart implementation.
+
+Inspired by:
+
+* [Mike Bostock's bullet chart](http://bl.ocks.org/mbostock/4061961)
+
+Examples:
+
+* ToDO
+
+#### dc.bulletChart(parent[, chartGroup])
+Create a bullet chart instance and attach it to the given parent element.
+
+Parameters:
+* parent : string | node | selection | compositeChart - any valid
+ [d3 single selector](https://github.com/mbostock/d3/wiki/Selections#selecting-elements) specifying
+ a dom block element such as a div; or a dom element or d3 selection.
+* chartGroup : string (optional) - name of the chart group this chart instance should be placed in.
+ Interaction with a chart will only trigger events and redraws within the chart's group.
+
+Returns:
+A newly created bullet chart instance
+
+```js
+// create a bullet chart under #chart-container1 element using the default global chart group
+var chart1 = dc.bulletChart('#chart-container1');
+// create a bullet chart under #chart-container2 element using chart group A
+var chart2 = dc.bulletChart('#chart-container2', 'chartGroupA');
+// create a sub-chart under a composite parent chart
+var chart3 = dc.bulletChart(compositeChart);
+```
+
+**/
+dc.bulletChart = function (parent, chartGroup) {
+  var _chart = dc.marginMixin(dc.baseMixin({}));
+
+  // from http://bl.ocks.org/mbostock/4061961
+  var _bulletMargin = {top: 5, right: 40, bottom: 20, left:120},
+      _bulletWidth = 960 - _bulletMargin.left - _bulletMargin.right,
+      _bulletHeight = 50 - _bulletMargin.top  - _bulletMargin.bottom,
+      _bulletOrient = 'left',
+      _titleTranslate = [-6, _bulletHeight / 2]; // see default from titleTranslate()
+
+  // HELPERS
+  function titleTranslate(orient) {
+    if (!arguments.length) {
+      return _titleTranslate;
+    }
+    
+    if (_bulletOrient === 'left' || _bulletOrient === 'right') {
+      return [-6, _bulletHeight / 2];
+    }
+    else if (_bulletOrient === 'bottom' || _bulletOrient === 'top') {
+      return [_bulletWidth, _bulletHeight + 20];
+    }
+
+    return [-6, _bulletHeight / 2];
+  }
+
+  _chart._doRender = function () {
+    var _bullet = d3.bullet()
+      .width(_bulletWidth)
+      .height(_bulletHeight)
+      .orient(_bulletOrient);
+
+    var svg = _chart.root().selectAll('svg')
+        .data(_chart.data())
+      .enter().append('svg')
+        .attr('class', 'bullet')
+        .attr('width', _bulletWidth + _bulletMargin.left + _bulletMargin.right)
+        .attr('height', _bulletHeight + _bulletMargin.top  + _bulletMargin.bottom)
+      .append('g')
+        .attr('transform', 'translate(' + _bulletMargin.left + ',' + _bulletMargin.top + ')')
+        .call(_bullet);
+
+
+    var title = svg.append('g')
+        .style('text-anchor', 'end')
+        .attr('transform', 'translate(' + _titleTranslate[0] + ',' + _titleTranslate[1] + ')');
+
+    title.append('text')
+        .attr('class', 'title')
+        .text(function(d) {
+          return d.title;
+        });
+
+    title.append('text')
+        .attr('class', 'subtitle')
+        .attr('dy', '1em')
+        .text(function(d) {
+          return d.subtitle;
+        });
+
+    return _chart;
+  };
+
+  _chart._doRedraw = function () {
+    _chart._doRender();
+    return _chart;
+  };
+
+
+  // SPECIFIC API
+  /**
+  #### .bulletWidth([value])
+  Set or get the bullet width.
+
+  **/
+  _chart.bulletWidth = function (_) {
+      if (!arguments.length) {
+          return _bulletWidth;
+      }
+      _bulletWidth = +_;
+      return _chart;
+  };
+
+  /**
+  #### .bulletHeight([value])
+  Set or get the bullet height.
+
+  **/
+  _chart.bulletHeight = function (_) {
+      if (!arguments.length) {
+          return _bulletHeight;
+      }
+      _bulletHeight = +_;
+      return _chart;
+  };
+
+  /**
+  #### .bulletMargin([value])
+  Set or get the bullet margin, i.e. `{top: 5, right: 40, bottom: 50, left:120}`.
+
+  **/
+  _chart.bulletMargin = function (_) {
+      if (!arguments.length) {
+          return _bulletMargin;
+      }
+      _bulletMargin = _;
+      return _chart;
+  };
+
+  /**
+  #### .orient([value])
+  Set or get the bullet orientation (one of `"left"`, `"right"`, `"top"` or `"bottom"`).
+
+  **/
+  _chart.orient = function (_) {
+      if (!arguments.length) {
+          return _bulletOrient;
+      }
+      _bulletOrient = _;
+      _titleTranslate = titleTranslate(_bulletOrient);
+      return _chart;
+  };
+
+  return _chart.anchor(parent, chartGroup);
+};

--- a/src/d3.bullet.js
+++ b/src/d3.bullet.js
@@ -1,0 +1,180 @@
+(function() {
+
+// Chart design based on the recommendations of Stephen Few. Implementation
+// based on the work of Clint Ivy, Jamie Love, and Jason Davies.
+// http://projects.instantcognition.com/protovis/bulletchart/
+d3.bullet = function() {
+  var orient = "left",
+      reverse = false,
+      vertical = false,
+      ranges = bulletRanges,
+      markers = bulletMarkers,
+      measures = bulletMeasures,
+      width = 380,
+      height = 30,
+      xAxis = d3.svg.axis();
+
+  // For each small multiple…
+  function bullet(g) {
+    g.each(function(d, i) {
+      var rangez = ranges.call(this, d, i).slice().sort(d3.descending),
+          markerz = markers.call(this, d, i).slice().sort(d3.descending),
+          measurez = measures.call(this, d, i).slice().sort(d3.descending),
+          g = d3.select(this),
+          extentX,
+          extentY;
+
+      var wrap = g.select("g.wrap");
+      if (wrap.empty()) wrap = g.append("g").attr("class", "wrap");
+
+      if (vertical) {
+        extentX = height, extentY = width;
+        wrap.attr("transform", "rotate(90)translate(0," + -width + ")");
+      } else {
+        extentX = width, extentY = height;
+        wrap.attr("transform", "translate(0)");
+      }
+
+      // Compute the new x-scale.
+      var x1 = d3.scale.linear()
+          .domain([0, Math.max(rangez[0], markerz[0], measurez[0])])
+          .range(reverse ? [extentX, 0] : [0, extentX]);
+
+      // Retrieve the old x-scale, if this is an update.
+      var x0 = this.__chart__ || d3.scale.linear()
+          .domain([0, Infinity])
+          .range(x1.range());
+
+      // Stash the new scale.
+      this.__chart__ = x1;
+
+      // Derive width-scales from the x-scales.
+      var w0 = bulletWidth(x0),
+          w1 = bulletWidth(x1);
+
+      // Update the range rects.
+      var range = wrap.selectAll("rect.range")
+          .data(rangez);
+
+      range.enter().append("rect")
+          .attr("class", function(d, i) { return "range s" + i; })
+          .attr("width", w0)
+          .attr("height", extentY)
+          .attr("x", reverse ? x0 : 0)
+
+      d3.transition(range)
+          .attr("x", reverse ? x1 : 0)
+          .attr("width", w1)
+          .attr("height", extentY);
+
+      // Update the measure rects.
+      var measure = wrap.selectAll("rect.measure")
+          .data(measurez);
+
+      measure.enter().append("rect")
+          .attr("class", function(d, i) { return "measure s" + i; })
+          .attr("width", w0)
+          .attr("height", extentY / 3)
+          .attr("x", reverse ? x0 : 0)
+          .attr("y", extentY / 3);
+
+      d3.transition(measure)
+          .attr("width", w1)
+          .attr("height", extentY / 3)
+          .attr("x", reverse ? x1 : 0)
+          .attr("y", extentY / 3);
+
+      // Update the marker lines.
+      var marker = wrap.selectAll("line.marker")
+          .data(markerz);
+
+      marker.enter().append("line")
+          .attr("class", "marker")
+          .attr("x1", x0)
+          .attr("x2", x0)
+          .attr("y1", extentY / 6)
+          .attr("y2", extentY * 5 / 6);
+
+      d3.transition(marker)
+          .attr("x1", x1)
+          .attr("x2", x1)
+          .attr("y1", extentY / 6)
+          .attr("y2", extentY * 5 / 6);
+
+      var axis = g.selectAll("g.axis").data([0]);
+      axis.enter().append("g").attr("class", "axis");
+
+      if (!vertical) {
+        axis.attr("transform", "translate(0," + height + ")");
+      }
+
+      axis.call(xAxis.scale(x1));
+    });
+    d3.timer.flush();
+  }
+
+  // left, right, top, bottom
+  bullet.orient = function(_) {
+    if (!arguments.length) return orient;
+    orient = _ + "";
+    reverse = orient == "right" || orient == "bottom";
+    xAxis.orient((vertical = orient == "top" || orient == "bottom") ? "left" : "bottom");
+    return bullet;
+  };
+
+  // ranges (bad, satisfactory, good)
+  bullet.ranges = function(_) {
+    if (!arguments.length) return ranges;
+    ranges = _;
+    return bullet;
+  };
+
+  // markers (previous, goal)
+  bullet.markers = function(_) {
+    if (!arguments.length) return markers;
+    markers = _;
+    return bullet;
+  };
+
+  // measures (actual, forecast)
+  bullet.measures = function(_) {
+    if (!arguments.length) return measures;
+    measures = _;
+    return bullet;
+  };
+
+  bullet.width = function(_) {
+    if (!arguments.length) return width;
+    width = +_;
+    return bullet;
+  };
+
+  bullet.height = function(_) {
+    if (!arguments.length) return height;
+    height = +_;
+    return bullet;
+  };
+
+  return d3.rebind(bullet, xAxis, "tickFormat");
+};
+
+function bulletRanges(d) {
+  return d.ranges;
+}
+
+function bulletMarkers(d) {
+  return d.markers;
+}
+
+function bulletMeasures(d) {
+  return d.measures;
+}
+
+function bulletWidth(x) {
+  var x0 = x(0);
+  return function(d) {
+    return Math.abs(x(d) - x0);
+  };
+}
+
+})();

--- a/web/docs/api-latest.md
+++ b/web/docs/api-latest.md
@@ -26,6 +26,7 @@
   * [Number Display Widget](#number-display-widget)
   * [Heat Map](#heat-map)
   * [Box Plot](#box-plot)
+  * [Bullet Chart](#bullet-chart)
 
 #### Version 2.1.0-dev
 The entire dc.js library is scoped under the **dc** name space. It does not introduce anything else
@@ -2023,3 +2024,50 @@ integer formatting.
 // format ticks to 2 decimal places
 chart.tickFormat(d3.format('.2f'));
 ```
+
+## Bullet Chart
+Includes: [Color Mixin](#color-mixin), [Margin Mixin](#margin-mixin), [Base Mixin](#base-mixin)
+
+Concrete bullet chart implementation.
+
+Inspired by:
+
+* [Mike Bostock's bullet chart](http://bl.ocks.org/mbostock/4061961)
+
+Examples:
+
+* ToDO
+
+#### dc.bulletChart(parent[, chartGroup])
+Create a bullet chart instance and attach it to the given parent element.
+
+Parameters:
+* parent : string | node | selection | compositeChart - any valid
+[d3 single selector](https://github.com/mbostock/d3/wiki/Selections#selecting-elements) specifying
+a dom block element such as a div; or a dom element or d3 selection.
+* chartGroup : string (optional) - name of the chart group this chart instance should be placed in.
+Interaction with a chart will only trigger events and redraws within the chart's group.
+
+Returns:
+A newly created bullet chart instance
+
+```js
+// create a bullet chart under #chart-container1 element using the default global chart group
+var chart1 = dc.bulletChart('#chart-container1');
+// create a bullet chart under #chart-container2 element using chart group A
+var chart2 = dc.bulletChart('#chart-container2', 'chartGroupA');
+// create a sub-chart under a composite parent chart
+var chart3 = dc.bulletChart(compositeChart);
+```
+
+#### .bulletWidth([value])
+Set or get the bullet width.
+
+#### .bulletHeight([value])
+Set or get the bullet height.
+
+#### .bulletMargin([value])
+Set or get the bullet margin, i.e. `{top: 5, right: 40, bottom: 50, left:120}`.
+
+#### .orient([value])
+Set or get the bullet orientation (one of `"left"`, `"right"`, `"top"` or `"bottom"`).

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -141,6 +141,7 @@
 <li><a href="#number-display-widget">Number Display Widget</a></li>
 <li><a href="#heat-map">Heat Map</a></li>
 <li><a href="#box-plot">Box Plot</a></li>
+<li><a href="#bullet-chart">Bullet Chart</a></li>
 </ul>
 <h4 id="version-2-1-0-dev">Version 2.1.0-dev</h4>
 <p>The entire dc.js library is scoped under the <strong>dc</strong> name space. It does not introduce anything else
@@ -1746,6 +1747,44 @@ integer formatting.</p>
 <pre><code class="lang-js"><span class="hljs-comment">// format ticks to 2 decimal places</span>
 chart.tickFormat(d3.format(<span class="hljs-string">'.2f'</span>));
 </code></pre>
+<h2 id="bullet-chart">Bullet Chart</h2>
+<p>Includes: <a href="#color-mixin">Color Mixin</a>, <a href="#margin-mixin">Margin Mixin</a>, <a href="#base-mixin">Base Mixin</a></p>
+<p>Concrete bullet chart implementation.</p>
+<p>Inspired by:</p>
+<ul>
+<li><a href="http://bl.ocks.org/mbostock/4061961">Mike Bostock’s bullet chart</a></li>
+</ul>
+<p>Examples:</p>
+<ul>
+<li>ToDO</li>
+</ul>
+<h4 id="dc-bulletchart-parent-chartgroup-">dc.bulletChart(parent[, chartGroup])</h4>
+<p>Create a bullet chart instance and attach it to the given parent element.</p>
+<p>Parameters:</p>
+<ul>
+<li>parent : string | node | selection | compositeChart - any valid
+<a href="https://github.com/mbostock/d3/wiki/Selections#selecting-elements">d3 single selector</a> specifying
+a dom block element such as a div; or a dom element or d3 selection.</li>
+<li>chartGroup : string (optional) - name of the chart group this chart instance should be placed in.
+Interaction with a chart will only trigger events and redraws within the chart’s group.</li>
+</ul>
+<p>Returns:
+A newly created bullet chart instance</p>
+<pre><code class="lang-js"><span class="hljs-comment">// create a bullet chart under #chart-container1 element using the default global chart group</span>
+<span class="hljs-keyword">var</span> chart1 = dc.bulletChart(<span class="hljs-string">'#chart-container1'</span>);
+<span class="hljs-comment">// create a bullet chart under #chart-container2 element using chart group A</span>
+<span class="hljs-keyword">var</span> chart2 = dc.bulletChart(<span class="hljs-string">'#chart-container2'</span>, <span class="hljs-string">'chartGroupA'</span>);
+<span class="hljs-comment">// create a sub-chart under a composite parent chart</span>
+<span class="hljs-keyword">var</span> chart3 = dc.bulletChart(compositeChart);
+</code></pre>
+<h4 id="-bulletwidth-value-">.bulletWidth([value])</h4>
+<p>Set or get the bullet width.</p>
+<h4 id="-bulletheight-value-">.bulletHeight([value])</h4>
+<p>Set or get the bullet height.</p>
+<h4 id="-bulletmargin-value-">.bulletMargin([value])</h4>
+<p>Set or get the bullet margin, i.e. <code>{top: 5, right: 40, bottom: 50, left:120}</code>.</p>
+<h4 id="-orient-value-">.orient([value])</h4>
+<p>Set or get the bullet orientation (one of <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code>, <code>&quot;top&quot;</code> or <code>&quot;bottom&quot;</code>).</p>
 
   </body>
 </html>

--- a/web/examples/bullet.html
+++ b/web/examples/bullet.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>dc.js - Bullet Chart Example</title>
+	<meta charset="UTF-8">
+	<link rel="stylesheet" type="text/css" href="../css/dc.css"/>
+</head>
+<style>
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  margin: auto;
+  padding-top: 40px;
+  position: relative;
+  width: 960px;
+}
+
+button {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}
+
+.bullet { font: 10px sans-serif; }
+.bullet .marker { stroke: #000; stroke-width: 2px; }
+.bullet .tick line { stroke: #666; stroke-width: .5px;}
+.bullet .range.s0 { fill: #eee; }
+.bullet .range.s1 { fill: #ddd; }
+.bullet .range.s2 { fill: #ccc; }
+.bullet .measure.s0 { fill: lightsteelblue; }
+.bullet .measure.s1 { fill: steelblue; }
+.bullet .title { font-size: 14px; font-weight: bold; }
+.bullet .subtitle { fill: #999; }
+
+.bullet .axis line, .bullet .axis path { opacity: 0.5; }
+</style>
+
+<script type="text/javascript" src="../js/d3.js"></script>
+<script type="text/javascript" src="../js/crossfilter.js"></script>
+<script type="text/javascript" src="../js/dc.js"></script>
+
+<div id="test-horizontal"></div>
+<div id="test-vertical"></div>
+
+<script type="text/javascript">
+
+var chart1 = dc.bulletChart("#test-horizontal");
+var chart2 = dc.bulletChart("#test-vertical");
+
+// included second marker for "Revenue" (not in original gists)
+// NOTE: the bullet d3.plugin does not support different symbols for the different markers
+var data = [
+  {"title":"Revenue","subtitle":"US$, in thousands","ranges":[150,225,300],"measures":[220,270],"markers":[210, 250]},
+  {"title":"Profit","subtitle":"%","ranges":[20,25,30],"measures":[21,23],"markers":[26]},
+  {"title":"Order Size","subtitle":"US$, average","ranges":[350,500,600],"measures":[100,320],"markers":[550]},
+  {"title":"New Customers","subtitle":"count","ranges":[1400,2000,2500],"measures":[1000,1650],"markers":[2100]},
+  {"title":"Satisfaction","subtitle":"out of 5","ranges":[3.5,4.25,5],"measures":[3.2,4.7],"markers":[4.4]}
+];
+
+var ndx        = crossfilter(data),
+    titleDimension = ndx.dimension(function(d) {return d.title;}),
+    statusGroup    = {
+      all: function(){
+        return data;
+    }};
+
+// dims from Mike Bostock's bl.ock, http://bl.ocks.org/mbostock/4061961
+chart1
+  .width(960)
+  .height(450)
+  .bulletMargin({top: 5, right: 40, bottom: 20, left: 120})
+  .bulletWidth(960 - 120 - 40)
+  .bulletHeight(50 - 5 - 20)
+  .orient("left")
+  .dimension(titleDimension)
+  .group(statusGroup);
+
+chart1.render();
+
+// dims from Jason Davies's bl.ock, http://bl.ocks.org/jasondavies/5452290
+chart2
+  .width(185)
+  .height(450)
+  .bulletMargin({top: 5, right: 40, bottom: 50, left: 120})
+  .bulletWidth(185 - 120 - 40)
+  .bulletHeight(450 - 5 - 50)
+  .orient("top")
+  .dimension(titleDimension)
+  .group(statusGroup);
+
+chart2.render();
+</script>
+</html>

--- a/web/examples/index.html
+++ b/web/examples/index.html
@@ -5,7 +5,7 @@
 <p>An attempt to present a simple example of each chart type.
 <a href="https://github.com/dc-js/dc.js/blob/master/CONTRIBUTING.md">
 Contributions welcome</a>.</p>
-<p>Source <a href="https://github.com/dc-js/dc.js/tree/master/web/examples">
+<p>Source <a href="https://github.com/dc-js/dc.js/tree/master/<%= conf.web %>/examples">
 here</a>.</p>
 <table class="table">
   <tr>
@@ -13,23 +13,24 @@ here</a>.</p>
     <td><a href="bar.html">bar.html</a></td>
     <td><a href="box-plot-time.html">box-plot-time.html</a></td>
     <td><a href="box-plot.html">box-plot.html</a></td>
-    <td><a href="composite.html">composite.html</a></td>
+    <td><a href="bullet.html">bullet.html</a></td>
 <tr>
   <tr>
+    <td><a href="composite.html">composite.html</a></td>
     <td><a href="cust.html">cust.html</a></td>
     <td><a href="heat.html">heat.html</a></td>
     <td><a href="heatmap-filtering.html">heatmap-filtering.html</a></td>
     <td><a href="line.html">line.html</a></td>
-    <td><a href="multi-focus.html">multi-focus.html</a></td>
 <tr>
   <tr>
+    <td><a href="multi-focus.html">multi-focus.html</a></td>
     <td><a href="multi-scatter.html">multi-scatter.html</a></td>
     <td><a href="number.html">number.html</a></td>
     <td><a href="ord.html">ord.html</a></td>
     <td><a href="pie.html">pie.html</a></td>
-    <td><a href="right-axis.html">right-axis.html</a></td>
 <tr>
   <tr>
+    <td><a href="right-axis.html">right-axis.html</a></td>
     <td><a href="scatter-brushing.html">scatter-brushing.html</a></td>
     <td><a href="scatter-series.html">scatter-series.html</a></td>
     <td><a href="scatter.html">scatter.html</a></td>


### PR DESCRIPTION
Added a new chart: bullet chart, a must for dashboards!

See it live [here](http://bl.ocks.org/espinielli/e7625ce617e4d9c87cae)

It is based on the [bullet chart d3-plugin](https://github.com/d3/d3-plugins/tree/master/bullet) with a fix as described in the d3/d3-plugins#130

*Note* I explicitly ignored the "original" bullet chart file in the `lint` grunt task: this is code copied from another repo and should stay equal to the original so as to ease future inclusion of newer version (and so be able to see what has changed. Just my humble opinion.)