### PR TITLE
Add the possibility to select specs with the command line

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,7 +102,7 @@ module.exports = function (grunt) {
                 options: {
                     display: 'short',
                     summary: true,
-                    specs:  '<%= conf.spec %>/*-spec.js',
+                    specs:  grunt.option('specs') || '<%= conf.spec %>/*-spec.js',
                     helpers: '<%= conf.spec %>/helpers/*.js',
                     version: '2.0.0',
                     outfile: '<%= conf.spec %>/index.html',
@@ -139,7 +139,7 @@ module.exports = function (grunt) {
                 options: {
                     display: 'short',
                     summary: true,
-                    specs:  '<%= conf.spec %>/*-spec.js',
+                    specs:  grunt.option('specs') || '<%= conf.spec %>/*-spec.js',
                     helpers: '<%= conf.spec %>/helpers/*.js',
                     version: '2.0.0',
                     outfile: '<%= conf.spec %>/index-browserify.html',


### PR DESCRIPTION
Hi,

Correct if I am wrong but trying the tests I saw that each time you want to run a test with `grunt test`, you have to run all the spec files. The same happens with `grunt watch`. So, I propose this change in the Gruntfile that allows to specify the test pattern you want to run, e.g.:

`grunt test --specs spec/color-spec.js`

Thus saving time. Of course, if you don't give any option, grunt acts as usual. Hope it helps.