### PR TITLE
Updates to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "index.js",
     "package.json",
     "README.md",
+    "LICENSE_BANNER",
     "docs",
     "regression",
     "scripts",

--- a/bower.json
+++ b/bower.json
@@ -3,15 +3,20 @@
   "version": "2.0.0-alpha.2",
   "main": ["dc.js", "dc.css"],
   "ignore": [
-    ".gitignore",
-    ".travis.yml",
-    "build.xml",
-    "globals.js",
+    "**/.*"
+    "AUTHORS",
+    "Changelog.md",
+    "CONTRIBUTING.md",
+    "Gruntfile.js",
     "index.js",
-    "make",
     "package.json",
-    "test",
-    "src"
+    "README.md",
+    "docs",
+    "regression",
+    "scripts",
+    "spec",
+    "src",
+    "web"
   ],
   "dependencies": {
     "d3": "3.x",

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,16 @@
   "name": "dcjs",
   "version": "2.0.0-beta.9",
   "main": ["dc.js", "dc.css"],
+  "keywords": [
+    "visualization",
+    "svg",
+    "animation",
+    "canvas",
+    "chart",
+    "dimensional",
+    "crossfilter",
+    "d3"
+  ],
   "ignore": [
     "**/.*"
     "AUTHORS",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "dcjs",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-beta.9",
   "main": ["dc.js", "dc.css"],
   "ignore": [
     "**/.*"


### PR DESCRIPTION
No need to include anything but the LICENSE and dc.* files for bower downloads.  Drastically decreases download time.