### PR TITLE
Added ability to slice data-grid results for pagination; fix data-grid docs

### DIFF
--- a/spec/data-grid-spec.js
+++ b/spec/data-grid-spec.js
@@ -63,6 +63,24 @@ describe('dc.dataGrid', function() {
         });
     });
 
+    describe('slicing entries', function() {
+        beforeEach(function() {
+            chart.beginSlice(1);
+            chart.redraw();
+        });
+
+        it('slice beginning', function() {
+            expect(chart.selectAll(".dc-grid-item")[0].length).toEqual(2);
+        });
+
+        it('slice beginning and end', function() {
+            chart.endSlice(2);
+            chart.redraw();
+
+            expect(chart.selectAll(".dc-grid-item")[0].length).toEqual(1);
+        });
+    });
+
     describe('external filter', function() {
         beforeEach(function() {
             countryDimension.filter("CA");

--- a/src/data-grid.js
+++ b/src/data-grid.js
@@ -6,6 +6,10 @@
  Data grid is a simple widget designed to list the filtered records, providing
  a simple way to define how the items are displayed.
 
+ Note: Unlike other charts, a data grid chart uses the group attribute as a keying function
+ for [nesting](https://github.com/mbostock/d3/wiki/Arrays#-nest) the data together in groups.
+ Do not pass in a crossfilter group as this will not work.
+
  Examples:
  * [List of members of the european parliament](http://europarl.me/dc.js/web/ep/index.html)
 
@@ -38,6 +42,8 @@ dc.dataGrid = function (parent, chartGroup) {
         return d;
     };
     var _order = d3.ascending;
+    var _beginSlice = 0;
+    var _endSlice;
 
     var _htmlGroup = function (d) {
         return '<div class=\'' + GROUP_CSS_CLASS + '\'><h1 class=\'' + LABEL_CSS_CLASS + '\'>' +
@@ -82,7 +88,7 @@ dc.dataGrid = function (parent, chartGroup) {
             .sortKeys(_order)
             .entries(entries.sort(function (a, b) {
                 return _order(_sortBy(a), _sortBy(b));
-            }));
+            }).slice(_beginSlice, _endSlice));
     }
 
     function renderItems(groups) {
@@ -106,6 +112,34 @@ dc.dataGrid = function (parent, chartGroup) {
 
     _chart._doRedraw = function () {
         return _chart._doRender();
+    };
+
+    /**
+     #### .beginSlice([index])
+     Get or set the index of the beginning slice which determines which entries get displayed by the widget
+     Useful when implementing pagination.
+
+     **/
+    _chart.beginSlice = function (_) {
+        if (!arguments.length) {
+            return _beginSlice;
+        }
+        _beginSlice = _;
+        return _chart;
+    };
+
+    /**
+     #### .endSlice([index])
+     Get or set the index of the end slice which determines which entries get displayed by the widget
+     Useful when implementing pagination.
+
+     **/
+    _chart.endSlice = function (_) {
+        if (!arguments.length) {
+            return _endSlice;
+        }
+        _endSlice = _;
+        return _chart;
     };
 
     /**


### PR DESCRIPTION
There was no way to create pagination for datagrid results with the current API. This was a huge feature request as grid items are based on html and with large datasets dc.js would be rendering a huge number of DOM nodes that were not relevant to the user. Using .top() to filter was not enough as most users expect to be able to see the next available page.

Because of this limitation I added the ability to specify a slicing range. I am slicing the entries array to achieve this. With the beginSlice and endSlice attributes it is fairly simple to implement pagination using datagrids. Updating these parameters and then redrawing the graph also for very simple and efficient pagination, eliminating the need to draw possible hundreds of thousands of DOM nodes.

I also added a comment that notes the difference between how dataGrid uses .group() versus the other charts. DataGrid actually wants a keying function, not a crossfilter function. This was very confusing to myself and other developers, so I explicitly call out this discrepancy in the documentation.