### PR TITLE
fix calculateBarWidth

### DIFF
--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -63,8 +63,6 @@ dc.barChart = function (parent, chartGroup) {
         var layers = _chart.chartBodyG().selectAll('g.stack')
             .data(_chart.data());
 
-        calculateBarWidth();
-
         layers
             .enter()
             .append('g')
@@ -84,6 +82,8 @@ dc.barChart = function (parent, chartGroup) {
     }
 
     function renderBars(layer, layerIndex, d) {
+        calculateBarWidth(d.values.length);
+
         var bars = layer.selectAll('rect.bar')
             .data(d.values, dc.pluck('x'));
 
@@ -134,10 +134,8 @@ dc.barChart = function (parent, chartGroup) {
             .remove();
     }
 
-    function calculateBarWidth() {
+    function calculateBarWidth(numberOfBars) {
         if (_barWidth === undefined) {
-            var numberOfBars = _chart.xUnitCount();
-
             // please can't we always use rangeBands for bar charts?
             if (_chart.isOrdinal() && _gap === undefined) {
                 _barWidth = Math.floor(_chart.x().rangeBand());


### PR DESCRIPTION
The function calculateBarWidth calls xUnitCount() to populate the variable numberOfBars. When using a non-ordinal scale, xUnitCount does not return the number of bars. Instead, xUnitCount returns the range of the scale. This causes all of the math with the gap and barPadding values to be funky. 
The pull request changes the function calculateBarWidth to take a parameter specifying the number of bars in the layer. All of the demos work great but the changes break 12 tests and I am not sure how to fix those.
