### PR TITLE
Added ability to render custom legend text per item

### DIFF
--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -160,6 +160,23 @@ describe("dc.legend", function() {
             legendItem(0).on("click").call(legendItem(0)[0][0], legendItem(0).datum());
             expect(chart.selectAll("path.line").size()).toBe(3);
         });
+
+        describe('with .legendText()', function() {
+            beforeEach(function() {
+                chart.legend(dc.legend().legendText(function(d, i) {
+                    var _i = i + 1;
+
+                    return _i + '. ' + d.name;
+                }));
+                chart.render();
+            });
+
+            it('should label the legend items with the names of their associated stacks', function() {
+                expect(legendLabel(0).text()).toBe("1. Id Sum");
+                expect(legendLabel(1).text()).toBe("2. Value Sum");
+                expect(legendLabel(2).text()).toBe("3. Fixed");
+            });
+        });
     });
 
     describe('legends with dashed lines', function () {

--- a/src/legend.js
+++ b/src/legend.js
@@ -24,7 +24,8 @@ dc.legend = function () {
         _horizontal = false,
         _legendWidth = 560,
         _itemWidth = 70,
-        _autoItemWidth = false;
+        _autoItemWidth = false,
+        _legendText = dc.pluck('name');
 
     var _g;
 
@@ -82,7 +83,7 @@ dc.legend = function () {
         }
 
         itemEnter.append('text')
-                .text(dc.pluck('name'))
+                .text(_legendText)
                 .attr('x', _itemHeight + LABEL_GAP)
                 .attr('y', function () {
                     return _itemHeight / 2 + (this.clientHeight ? this.clientHeight : 13) / 2 - 2;
@@ -207,6 +208,30 @@ dc.legend = function () {
             return _autoItemWidth;
         }
         _autoItemWidth = _;
+        return _legend;
+    };
+
+    /**
+    #### .legendText([legendTextFunction])
+    Set or get the legend text function. The legend widget uses this function to render
+    the legend text on each item. If no function is specified the legend widget will display
+    the names associated with each group.
+
+    Default: dc.pluck('name')
+
+    ```js
+    // create numbered legend items
+    chart.legend(dc.legend().legendText(function(d, i) { return i + '. ' + d.name; }))
+
+    // create legend displaying group counts
+    chart.legend(dc.legend().legendText(function(d) { return d.name + ': ' d.data; }))
+    ```
+    **/
+    _legend.legendText = function (_) {
+        if (!arguments.length) {
+            return _legendText;
+        }
+        _legendText = _;
         return _legend;
     };
 


### PR DESCRIPTION
I needed the ability to create legends with more data than just the group name so I edited the legends widget to support that functionality. You can now dynamically generate legend text much like you would for labels or titles. You pass in a legendText function that returns the text you want to render, e.g.  chart.legend(dc.legend().legendText(function(d) { return d.name + ': ' + d.data })) to create labels with counts on them if you have grouped data reduced by count.