### PR TITLE
Fix heatmap x axis label position on redraw

### DIFF
--- a/src/heatmap.js
+++ b/src/heatmap.js
@@ -228,7 +228,8 @@ dc.heatMap = function (parent, chartGroup) {
               .text(_chart.colsLabel());
         dc.transition(gColsText, _chart.transitionDuration())
                .text(_chart.colsLabel())
-               .attr('x', function (d) { return cols(d) + boxWidth / 2; });
+               .attr('x', function (d) { return cols(d) + boxWidth / 2; })
+               .attr('y', _chart.effectiveHeight());
         gColsText.exit().remove();
         var gRows = _chartBody.selectAll('g.rows');
         if (gRows.empty()) {


### PR DESCRIPTION
Small issue with heatmap: when heatmap is updated using _doRedraw, the 'y' position of x axis label does not get updated in transition. E.g. If I resize the heatmap and make it taller, the x axis label should move down.