### PR TITLE
Fix row chart x axis position on resizing

### DIFF
--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -66,9 +66,10 @@ dc.rowChart = function (parent, chartGroup) {
         calculateAxisScale();
 
         if (axisG.empty()) {
-            axisG = _g.append('g').attr('class', 'axis')
-                .attr('transform', 'translate(0, ' + _chart.effectiveHeight() + ')');
+            axisG = _g.append('g').attr('class', 'axis');
         }
+        
+        axisG.attr('transform', 'translate(0, ' + _chart.effectiveHeight() + ')');
 
         dc.transition(axisG, _chart.transitionDuration())
             .call(_xAxis);


### PR DESCRIPTION
Another small problem with resizing:
For row chart, when the chart is resized and redrawn, the x-axis position needs to be updated.