### PR TITLE
Remove grunt-debug-task

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "grunt-contrib-jshint": "~0.11.0",
     "grunt-contrib-uglify": "~0.9.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-debug-task": "~0.1.5",
     "grunt-docco2": "~0.2.0",
     "grunt-fileindex": "^0.1.0",
     "grunt-gh-pages": "~0.10.0",


### PR DESCRIPTION
This removes the grunt-debug-task npm dependency:

Reasons:
- Not used within the codebase
- [Deprecated](https://www.npmjs.com/package/grunt-debug-task) - suggests to use node-inspector directly
- Prevents contributors from using Node V4 (caused by an old Nan dependency at [node-inspector](https://github.com/node-inspector/node-inspector/blob/master/package.json) -> [v8-debug](https://github.com/node-inspector/v8-debug/blob/master/package.json) -> [nan: "^2.0.4"](https://github.com/nodejs/nan).  See https://github.com/nodejs/node/issues/2798.