### PR TITLE
 Tests and tweaks to the select menu widget

### DIFF
--- a/spec/select-menu-spec.js
+++ b/spec/select-menu-spec.js
@@ -96,22 +96,22 @@ describe('dc.selectMenu', function () {
     describe('regular single select', function () {
         describe('selecting an option', function () {
             it('filters dimension based on selected option\'s value', function () {
-                chart.onChange(stateGroup.all()[0].key);
+                chart.onChange([stateGroup.all()[0].key]);
                 expect(chart.filter()).toEqual('California');
             });
             it('replaces filter on second selection', function () {
-                chart.onChange(stateGroup.all()[0].key);
-                chart.onChange(stateGroup.all()[1].key);
+                chart.onChange([stateGroup.all()[0].key]);
+                chart.onChange([stateGroup.all()[1].key]);
                 expect(chart.filter()).toEqual('Colorado');
                 expect(chart.filters().length).toEqual(1);
             });
             it('actually filters dimension', function () {
-                chart.onChange(stateGroup.all()[0].key);
+                chart.onChange([stateGroup.all()[0].key]);
                 expect(regionGroup.all()[0].value).toEqual(0);
                 expect(regionGroup.all()[3].value).toEqual(2);
             });
             it('removes filter when prompt option is selected', function () {
-                chart.onChange(null);
+                chart.onChange(['']);
                 expect(chart.hasFilter()).not.toBeTruthy();
                 expect(regionGroup.all()[0].value).toEqual(1);
             });
@@ -119,7 +119,7 @@ describe('dc.selectMenu', function () {
 
         describe('redraw with existing filter', function () {
             it('selects option corresponding to active filter', function () {
-                chart.onChange(stateGroup.all()[0].key);
+                chart.onChange([stateGroup.all()[0].key]);
                 chart.redraw();
                 expect(chart.selectAll('select')[0][0].value).toEqual('California');
             });
@@ -143,11 +143,33 @@ describe('dc.selectMenu', function () {
             expect(regionGroup.all()[3].value).toEqual(2);
             expect(regionGroup.all()[4].value).toEqual(2);
         });
+
         it('removes all filters when prompt option is selected', function () {
-            chart.onChange(null);
+            chart.onChange(['']);
             expect(chart.hasFilter()).not.toBeTruthy();
             expect(regionGroup.all()[0].value).toEqual(1);
         });
+
+        it('filters out empty prompt option when other selections present', function () {
+            chart.onChange(['', stateGroup.all()[0].key, stateGroup.all()[1].key]);
+            expect(chart.filters()).toEqual(['California', 'Colorado']);
+            expect(chart.filters().length).toEqual(2);
+        });
+
+        describe('with a single selection', function () {
+            beforeEach(function () {
+                chart.onChange([stateGroup.all()[0].key]);
+            });
+            it('can be used with a single selection', function () {
+                expect(chart.filter()).toEqual('California');
+                expect(chart.filters().length).toEqual(1);
+            });
+            it('with a single selection correctly filters dimension', function () {
+                expect(regionGroup.all()[0].value).toEqual(0);
+                expect(regionGroup.all()[3].value).toEqual(2);
+            });
+        });
+
         it('selects all options corresponding to active filters on redraw', function () {
             var selectedOptions = chart.selectAll('select').selectAll('option')[0].filter(function (d) {
                 // IE returns an extra option with value '', not sure what it means
@@ -156,6 +178,7 @@ describe('dc.selectMenu', function () {
             expect(selectedOptions.length).toEqual(2);
             expect(selectedOptions.map(function (d) { return d.value; })).toEqual(['California', 'Colorado']);
         });
+
         it('does not deselect previously filtered options when new option is added', function () {
             chart.onChange([stateGroup.all()[0].key, stateGroup.all()[1].key, stateGroup.all()[5].key]);
 

--- a/src/select-menu.js
+++ b/src/select-menu.js
@@ -102,28 +102,24 @@ dc.selectMenu = function (parent, chartGroup) {
             });
         } else { // IE and other browsers do not support selectedOptions
             // adapted from this polyfill: https://gist.github.com/brettz9/4212217
-            var options = [].slice.call(d3.event.target.options);
+            var options = [].slice.call(target.options);
             values = options.filter(function (option) {
                 return option.selected;
             }).map(function (option) {
                 return option.value;
             });
         }
-        // console.log(values);
-        // check if only prompt option is selected
-        if (values.length === 1 && values[0] === '') {
-            values = null;
-        } else if (!_multiple && values.length === 1) {
-            values = values[0];
-        }
+        // console.log("VALUES", values);
         _chart.onChange(values);
     }
 
     _chart.onChange = function (val) {
-        if (val && _multiple) {
+        if (val && val instanceof Array) {
+            // filter out empty values
+            val = val.filter(function (option) {
+                return !!option;
+            });
             _chart.replaceFilter([val]);
-        } else if (val) {
-            _chart.replaceFilter(val);
         } else {
             _chart.filterAll();
         }


### PR DESCRIPTION
 There are now tests for the no-values, one-value, and multiple-values case in multiple select mode. 

Also improved / refactored some implementation details. @gordonwoodhull, as per your suggestions I changed the implementation of `_chart.onChange` to always call `replaceFilter` with an array containing the array of filters reflecting the current selections. This works for both the single and multiple select mode. 

Additionally the empty option (prompt option) is always filtered out, so when the prompt option is the *only* one selected, then the array will be empty, i.e. the select is re-set. 

The demo under `web/examples/select.html` was very helpful :) I was wondering about was the behavior in multiple mode where the prompt option can be selected along with other options. Would the correct / expected behavior here be to override and deselect everything when that option is selected?

<img width="475" alt="screen shot 2015-09-28 at 8 39 58 pm" src="https://cloud.githubusercontent.com/assets/30317/10154833/2b6fded6-6621-11e5-8fe4-74bb526e8867.png">

In any case, the actual `onChange` callback's only responsibility is now to forward the selected options from the DOM element (and sort out browser differences). This also seems to make the `_chart.onChange` method more testable since one can easily call the method with different combinations of selections. I've left in the option to send `null` into `_chart.onChange`, which is mostly a convenience in tests, but maybe confusing. Let me know if I should remove it.