### PR TITLE
Box Plot: Fix keyAccessor, extent filtering, x domain change

### DIFF
--- a/src/box-plot.js
+++ b/src/box-plot.js
@@ -158,7 +158,7 @@ dc.boxPlot = function (parent, chartGroup) {
             .attr('transform', boxTransform)
             .call(_box)
             .on('click', function (d) {
-                _chart.filter(d.key);
+                _chart.filter(_chart.keyAccessor()(d));
                 _chart.redrawGroup();
             });
     }
@@ -190,8 +190,10 @@ dc.boxPlot = function (parent, chartGroup) {
                 var extent = _chart.brush().extent();
                 var start = extent[0];
                 var end = extent[1];
+                var keyAccessor = _chart.keyAccessor();
                 _chart.g().selectAll('g.box').each(function (d) {
-                    if (d.key < start || d.key >= end) {
+                    var key = keyAccessor(d);
+                    if (key < start || key >= end) {
                         _chart.fadeDeselected(this);
                     } else {
                         _chart.highlightSelected(this);
@@ -206,7 +208,7 @@ dc.boxPlot = function (parent, chartGroup) {
     };
 
     _chart.isSelectedNode = function (d) {
-        return _chart.hasFilter(d.key);
+        return _chart.hasFilter(_chart.keyAccessor()(d));
     };
 
     _chart.yAxisMin = function () {

--- a/src/box-plot.js
+++ b/src/box-plot.js
@@ -141,7 +141,7 @@ dc.boxPlot = function (parent, chartGroup) {
             .duration(_chart.transitionDuration())
             .tickFormat(_tickFormat);
 
-        var boxesG = _chart.chartBodyG().selectAll('g.box').data(_chart.data(), function (d) { return d.key; });
+        var boxesG = _chart.chartBodyG().selectAll('g.box').data(_chart.data(), _chart.keyAccessor());
 
         renderBoxes(boxesG);
         updateBoxes(boxesG);
@@ -178,13 +178,26 @@ dc.boxPlot = function (parent, chartGroup) {
 
     _chart.fadeDeselectedArea = function () {
         if (_chart.hasFilter()) {
-            _chart.g().selectAll('g.box').each(function (d) {
-                if (_chart.isSelectedNode(d)) {
-                    _chart.highlightSelected(this);
-                } else {
-                    _chart.fadeDeselected(this);
-                }
-            });
+            if (_chart.isOrdinal()) {
+                _chart.g().selectAll('g.box').each(function (d) {
+                    if (_chart.isSelectedNode(d)) {
+                        _chart.highlightSelected(this);
+                    } else {
+                        _chart.fadeDeselected(this);
+                    }
+                });
+            } else {
+                var extent = _chart.brush().extent();
+                var start = extent[0];
+                var end = extent[1];
+                _chart.g().selectAll('g.box').each(function (d) {
+                    if (d.key < start || d.key >= end) {
+                        _chart.fadeDeselected(this);
+                    } else {
+                        _chart.highlightSelected(this);
+                    }
+                });
+            }
         } else {
             _chart.g().selectAll('g.box').each(function () {
                 _chart.resetHighlight(this);

--- a/src/d3.box.js
+++ b/src/d3.box.js
@@ -71,6 +71,8 @@
                 center.transition()
                     .duration(duration)
                     .style('opacity', 1)
+                    .attr('x1', width / 2)
+                    .attr('x2', width / 2)
                     .attr('y1', function (d) { return x1(d[0]); })
                     .attr('y2', function (d) { return x1(d[1]); });
 
@@ -98,6 +100,7 @@
 
                 box.transition()
                     .duration(duration)
+                    .attr('width', width)
                     .attr('y', function (d) { return x1(d[2]); })
                     .attr('height', function (d) { return x1(d[0]) - x1(d[2]); });
 
@@ -118,6 +121,8 @@
 
                 medianLine.transition()
                     .duration(duration)
+                    .attr('x1', 0)
+                    .attr('x2', width)
                     .attr('y1', x1)
                     .attr('y2', x1);
 
@@ -140,6 +145,8 @@
 
                 whisker.transition()
                     .duration(duration)
+                    .attr('x1', 0)
+                    .attr('x2', width)
                     .attr('y1', x1)
                     .attr('y2', x1)
                     .style('opacity', 1);
@@ -168,6 +175,7 @@
 
                 outlier.transition()
                     .duration(duration)
+                    .attr('cx', width / 2)
                     .attr('cy', function (i) { return x1(d[i]); })
                     .style('opacity', 1);
 
@@ -199,6 +207,7 @@
                 boxTick.transition()
                     .duration(duration)
                     .text(format)
+                    .attr('x', function (d, i) { return i & 1 ? width : 0; })
                     .attr('y', x1);
 
                 // Update whisker ticks. These are handled separately from the box
@@ -223,6 +232,7 @@
                 whiskerTick.transition()
                     .duration(duration)
                     .text(format)
+                    .attr('x', width)
                     .attr('y', x1)
                     .style('opacity', 1);
 


### PR DESCRIPTION
This fixes the data binding between the `g.box` SVG nodes and datum keys.  It should be using the keyAccessor, but it just happens to work here because Crossfilter always has datums with a `key` field.  There are a few other places `dc` does this...

This also fixes filtering with X domains that are not ordinal and use brushing.  The issue can be seen in the examples page, [here](http://dc-js.github.io/dc.js/examples/box-plot-time.html).
