### PR TITLE
make sure _labelOffsetY doesn't become Infinity

### DIFF
--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -172,7 +172,7 @@ dc.rowChart = function (parent, chartGroup) {
         }
 
         // vertically align label in center unless they override the value via property setter
-        if (!_hasLabelOffsetY) {
+        if (!_hasLabelOffsetY && height !== Infinity) {
             _labelOffsetY = height / 2;
         }
 


### PR DESCRIPTION
make sure _labelOffsetY doesn't become Infinity and spew a ton of errors to the console.

height becomes Infinity when `n == 0`, meaning any time the chart is rendered with no data.