### PR TITLE
Fixes bubble chart filtering issues

### DIFF
--- a/spec/bubble-chart-spec.js
+++ b/spec/bubble-chart-spec.js
@@ -232,10 +232,10 @@ describe('dc.bubbleChart', function () {
         it('creates correct label for each bubble', function () {
             chart.selectAll('g.node title').each(function (d, i) {
                 if (i === 0) {
-                    expect(d3.select(this).text()).toBe('F: {count:0,value:0}');
+                    expect(d3.select(this).text()).toBe('T: {count:2,value:77}');
                 }
                 if (i === 1) {
-                    expect(d3.select(this).text()).toBe('T: {count:2,value:77}');
+                    expect(d3.select(this).text()).toBe('F: {count:0,value:0}');
                 }
             });
         });
@@ -243,10 +243,10 @@ describe('dc.bubbleChart', function () {
         it('fills bubbles with correct colors', function () {
             chart.selectAll('circle.bubble').each(function (d, i) {
                 if (i === 0) {
-                    expect(d3.select(this).attr('fill')).toBe('#a60000');
+                    expect(d3.select(this).attr('fill')).toBe('#ff4040');
                 }
                 if (i === 1) {
-                    expect(d3.select(this).attr('fill')).toBe('#ff4040');
+                    expect(d3.select(this).attr('fill')).toBe('#a60000');
                 }
             });
         });

--- a/src/bubble-chart.js
+++ b/src/bubble-chart.js
@@ -60,8 +60,14 @@ dc.bubbleChart = function (parent, chartGroup) {
 
         _chart.r().range([_chart.MIN_RADIUS, _chart.xAxisLength() * _chart.maxBubbleRelativeSize()]);
 
+        // sort descending so smaller bubbles are on top
+        var data = _chart.data(),
+            radiusAccessor = _chart.radiusValueAccessor();
+        data.sort(function (a, b) { return d3.descending(radiusAccessor(a), radiusAccessor(b)); });
         var bubbleG = _chart.chartBodyG().selectAll('g.' + _chart.BUBBLE_NODE_CLASS)
-            .data(_chart.data(), function (d) { return d.key; });
+            .data(data, function (d) { return d.key; });
+        // Call order here to update dom order based on sort
+        bubbleG.order();
 
         renderNodes(bubbleG);
 

--- a/src/bubble-mixin.js
+++ b/src/bubble-mixin.js
@@ -103,8 +103,8 @@ dc.bubbleMixin = function (_chart) {
         return shouldLabel(d) ? 1 : 0;
     };
 
-    var labelDisplay = function (d) {
-        return shouldLabel(d) ? 'block' : 'none';
+    var labelPointerEvent = function (d) {
+        return shouldLabel(d) ? 'all' : 'none';
     };
 
     _chart._doRenderLabel = function (bubbleGEnter) {
@@ -120,29 +120,20 @@ dc.bubbleMixin = function (_chart) {
 
             label
                 .attr('opacity', 0)
-                .text(labelFunction)
-                .style('display', 'none');
+                .attr('pointer-events', labelPointerEvent)
+                .text(labelFunction);
             dc.transition(label, _chart.transitionDuration())
-                .attr('opacity', labelOpacity)
-                .call(dc.afterTransition, label.style.bind(label, 'display', labelDisplay));
+                .attr('opacity', labelOpacity);
         }
     };
 
     _chart.doUpdateLabels = function (bubbleGEnter) {
         if (_chart.renderLabel()) {
             var labels = bubbleGEnter.selectAll('text')
-                .text(labelFunction)
-                .style('display', function (d) {
-                    // On update, we can't fade in if it's hidden...
-                    var current = d3.select(this).style('display');
-                    if (current === 'none' && shouldLabel(d)) {
-                        return 'block';
-                    }
-                    return current;
-                });
+                .attr('pointer-events', labelPointerEvent)
+                .text(labelFunction);
             dc.transition(labels, _chart.transitionDuration())
-                .attr('opacity', labelOpacity)
-                .call(dc.afterTransition, labels.style.bind(labels, 'display', labelDisplay));
+                .attr('opacity', labelOpacity);
         }
     };
 

--- a/src/core.js
+++ b/src/core.js
@@ -212,6 +212,22 @@ dc.optionalTransition = function (enable, duration, callback, name) {
     }
 };
 
+// See http://stackoverflow.com/a/20773846
+dc.afterTransition = function (transition, callback) {
+    if (transition.empty() || !transition.duration) {
+        callback.call(transition);
+    } else {
+        var n = 0;
+        transition
+            .each(function () { ++n; })
+            .each('end', function () {
+                if (!--n) {
+                    callback.call(transition);
+                }
+            });
+    }
+};
+
 /**
  * @name units
  * @memberof dc


### PR DESCRIPTION
Bubble charts have a label, that is not always visible given a particular radius.  It's hidden by setting `opacity=0`.  Unfortunately this still allows you **click** the text, and filter the bubble.  This is problematic as a user can select a bubble that may be close to another bubble and filter the wrong one, because the label was long or the bubbles overlap...  Adding a `style='display: none/block'` update to the selection does work, but to prevent any interaction with the `opacity` working properly, it needs to happen **after** the transition.  Thus, `dc.afterTransition` was added.

The other issue with bubble charts, small bubbles may be hidden behind large bubbles.  Sorting the data descending by radius before hand, ensures that larger bubbles are first in the data and thus higher in the DOM, behind smaller bubbles.  A call to [d3.selection.order](https://github.com/mbostock/d3/wiki/Selections#order) is required for them to properly be sorted.