### PR TITLE
Heatmaps seem to be empty after crossfilter reloads data

### DIFF
--- a/src/heatmap.js
+++ b/src/heatmap.js
@@ -228,10 +228,10 @@ dc.heatMap = function (parent, chartGroup) {
 
         if (_chart.renderTitle()) {
             gEnter.append('title');
-            boxes.selectAll('title').text(_chart.title());
+            boxes.select('title').text(_chart.title());
         }
 
-        dc.transition(boxes.selectAll('rect'), _chart.transitionDuration())
+        dc.transition(boxes.select('rect'), _chart.transitionDuration())
             .attr('x', function (d, i) { return cols(_chart.keyAccessor()(d, i)); })
             .attr('y', function (d, i) { return rows(_chart.valueAccessor()(d, i)); })
             .attr('rx', _xBorderRadius)


### PR DESCRIPTION
`selectAll` does not inherit data from its parent. This means that if the underlying crossfilter gets new data the selection of `g.box-group` will see the new data, the children `title` and `rect` will not. The optical result of that is a seemingly empty heatmap although the data has changed.
