### PR TITLE
Add browser: dc.js to package.json for Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,6 @@
         "dc.js.map"
       ]
     }
-  ]
+  ],
+  "browser": "dc.js"
 }


### PR DESCRIPTION
This will make Browserify skip bundling the scripts intended to run on
CommonJS platforms and instead make it bundle dc.js directly. This fixes
problems where Browserify is unable to find jsdom because it is not listed
in the dependencies (and is not required on browser anyway). Resolves #1005.