### PR TITLE
Ref #1096, #1097, #1099, #1100: Fix some outstanding issues with HTML JSDoc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 ## 2.0.0 beta 26
 * Apply pie chart labels before transition, so they are easier to manipulate with the pretransition hook. Added example of showing percentages in pie chart labels. (Workaround for [#703](https://github.com/dc-js/dc.js/issues/703))
 * Documentation of chart registry, by Jasmine Hegman ([#676](https://github.com/dc-js/dc.js/issues/676) / [#1082](https://github.com/dc-js/dc.js/pull/1082))
-* HTML documentation generation, by Matt Traynham. There are still some kinks to be worked out here, but in principle it should be more robust than the gigantic markdown file we are generating. ([#1086](https://github.com/dc-js/dc.js/pull/1086)
+* HTML documentation generation, by Matt Traynham. There are still some kinks to be worked out here, but in principle it should be more robust than the gigantic markdown file we are generating. ([#1086](https://github.com/dc-js/dc.js/pull/1086))
 * Document that you need to use a `RangedFilter` when filtering a range, by koefoed ([#1090](https://github.com/dc-js/dc.js/pull/1090))
 * Fix links to box plot examples, by Yuval Greenfield ([#1094](https://github.com/dc-js/dc.js/pull/1094))
 * [Sparkline example](http://dc-js.github.io/dc.js/examples/sparkline.html) ([#1013](https://github.com/dc-js/dc.js/issues/1013))

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -220,7 +220,7 @@ module.exports = function (grunt) {
                 options: {
                     destination: 'web/docs/html',
                     template: 'node_modules/ink-docstrap/template',
-                    configure: 'node_modules/ink-docstrap/template/jsdoc.conf.json'
+                    configure: 'jsdoc.conf.json'
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -216,7 +216,7 @@ module.exports = function (grunt) {
         },
         jsdoc: {
             dist: {
-                src: 'dc.js',
+                src: ['<%= conf.src %>/**/*.js', '!<%= conf.src %>/{banner,footer}.js'],
                 options: {
                     destination: 'web/docs/html',
                     template: 'node_modules/ink-docstrap/template',

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,28 @@
+{
+  "tags": {
+    "allowUnknownTags": true
+  },
+  "plugins": ["plugins/markdown"],
+  "templates": {
+    "logoFile": "",
+    "cleverLinks": false,
+    "monospaceLinks": false,
+    "dateFormat": "ddd MMM Do YYYY",
+    "outputSourceFiles": true,
+    "outputSourcePath": true,
+    "systemName": "dc.js",
+    "footer": "",
+    "copyright": "dc.js Copyright © 2012-2016 Copyright 2012-2016 Nick Zhu & the dc.js Developers",
+    "navType": "vertical",
+    "theme": "cosmo",
+    "linenums": true,
+    "collapseSymbols": false,
+    "inverseNav": true,
+    "protocol": "html://",
+    "methodHeadingReturns": false
+  },
+  "markdown": {
+    "parser": "gfm",
+    "hardwrap": true
+  }
+}

--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -4,7 +4,7 @@
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
  * - {@link http://dc-js.github.com/dc.js/crime/index.html Canadian City Crime Stats}
- * @namespace barChart
+ * @class barChart
  * @memberof dc
  * @mixes dc.stackMixin
  * @mixes dc.coordinateGridMixin

--- a/src/box-plot.js
+++ b/src/box-plot.js
@@ -4,7 +4,7 @@
  * Examples:
  * - {@link http://dc-js.github.io/dc.js/examples/box-plot-time.html Box plot time example}
  * - {@link http://dc-js.github.io/dc.js/examples/box-plot.html Box plot example}
- * @namespace boxPlot
+ * @class boxPlot
  * @memberof dc
  * @mixes dc.coordinateGridMixin
  * @example

--- a/src/bubble-chart.js
+++ b/src/bubble-chart.js
@@ -9,7 +9,7 @@
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
  * - {@link http://dc-js.github.com/dc.js/vc/index.html US Venture Capital Landscape 2011}
- * @namespace bubbleChart
+ * @class bubbleChart
  * @memberof dc
  * @mixes dc.bubbleMixin
  * @mixes dc.coordinateGridMixin

--- a/src/bubble-overlay.js
+++ b/src/bubble-overlay.js
@@ -6,7 +6,7 @@
  *
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/crime/index.html Canadian City Crime Stats}
- * @namespace bubbleOverlay
+ * @class bubbleOverlay
  * @memberof dc
  * @mixes dc.bubbleMixin
  * @mixes dc.baseMixin

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -2,7 +2,7 @@
  * Composite charts are a special kind of chart that render multiple charts on the same Coordinate
  * Grid. You can overlay (compose) different bar/line/area charts in a single composite chart to
  * achieve some quite flexible charting effects.
- * @namespace compositeChart
+ * @class compositeChart
  * @memberof dc
  * @mixes dc.coordinateGridMixin
  * @example

--- a/src/data-count.js
+++ b/src/data-count.js
@@ -8,7 +8,7 @@
  *
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
- * @namespace dataCount
+ * @class dataCount
  * @memberof dc
  * @mixes dc.baseMixin
  * @example

--- a/src/data-grid.js
+++ b/src/data-grid.js
@@ -8,7 +8,7 @@
  *
  * Examples:
  * - {@link http://europarl.me/dc.js/web/ep/index.html List of members of the european parliament}
- * @namespace dataGrid
+ * @class dataGrid
  * @memberof dc
  * @mixes dc.baseMixin
  * @param {String|node|d3.selection} parent - Any valid

--- a/src/data-table.js
+++ b/src/data-table.js
@@ -15,7 +15,7 @@
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
  * - {@link http://dc-js.github.io/dc.js/examples/table-on-aggregated-data.html dataTable on a crossfilter group}
  * ({@link https://github.com/dc-js/dc.js/blob/develop/web/examples/table-on-aggregated-data.html source})
- * @namespace dataTable
+ * @class dataTable
  * @memberof dc
  * @mixes dc.baseMixin
  * @param {String|node|d3.selection} parent - Any valid

--- a/src/geo-choropleth-chart.js
+++ b/src/geo-choropleth-chart.js
@@ -5,7 +5,7 @@
  *
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/vc/index.html US Venture Capital Landscape 2011}
- * @namespace geoChoroplethChart
+ * @class geoChoroplethChart
  * @memberof dc
  * @mixes dc.colorMixin
  * @mixes dc.baseMixin

--- a/src/heatmap.js
+++ b/src/heatmap.js
@@ -1,6 +1,6 @@
 /**
  * A heat map is matrix that represents the values of two dimensions of data using colors.
- * @namespace heatMap
+ * @class heatMap
  * @memberof dc
  * @mixes dc.colorMixin
  * @mixes dc.marginMixin

--- a/src/legend.js
+++ b/src/legend.js
@@ -5,7 +5,7 @@
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
  * - {@link http://dc-js.github.com/dc.js/crime/index.html Canadian City Crime Stats}
- * @namespace legend
+ * @class legend
  * @memberof dc
  * @example
  * chart.legend(dc.legend().x(400).y(10).itemHeight(13).gap(5))

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -4,7 +4,7 @@
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
  * - {@link http://dc-js.github.com/dc.js/crime/index.html Canadian City Crime Stats}
- * @namespace lineChart
+ * @class lineChart
  * @memberof dc
  * @mixes dc.stackMixin
  * @mixes dc.coordinateGridMixin

--- a/src/number-display.js
+++ b/src/number-display.js
@@ -2,7 +2,7 @@
  * A display of a single numeric value.
  * Unlike other charts, you do not need to set a dimension. Instead a group object must be provided and
  * a valueAccessor that returns a single value.
- * @namespace numberDisplay
+ * @class numberDisplay
  * @memberof dc
  * @mixes dc.baseMixin
  * @example

--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -6,7 +6,7 @@
  *
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
- * @namespace pieChart
+ * @class pieChart
  * @memberof dc
  * @mixes dc.capMixin
  * @mixes dc.colorMixin

--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -3,7 +3,7 @@
  *
  * Examples:
  * - {@link http://dc-js.github.com/dc.js/ Nasdaq 100 Index}
- * @namespace rowChart
+ * @class rowChart
  * @memberof dc
  * @mixes dc.capMixin
  * @mixes dc.marginMixin

--- a/src/scatter-plot.js
+++ b/src/scatter-plot.js
@@ -4,7 +4,7 @@
  * Examples:
  * - {@link http://dc-js.github.io/dc.js/examples/scatter.html Scatter Chart}
  * - {@link http://dc-js.github.io/dc.js/examples/multi-scatter.html Multi-Scatter Chart}
- * @namespace scatterPlot
+ * @class scatterPlot
  * @memberof dc
  * @mixes dc.coordinateGridMixin
  * @example

--- a/src/series-chart.js
+++ b/src/series-chart.js
@@ -5,7 +5,7 @@
  *
  * Examples:
  * - {@link http://dc-js.github.io/dc.js/examples/series.html Series Chart}
- * @namespace seriesChart
+ * @class seriesChart
  * @memberof dc
  * @mixes dc.compositeChart
  * @example


### PR DESCRIPTION
Should resolve #1096, #1097, #1099, #1100.

For #1099, I tried splitting up the files and it seemingly fixed the paths, which also resolves #1100...

Minor caveat on #1097 (the classes).  Both jsdoc2md and grunt-jsdoc (with docstrap) add the "new" keyword to these classes.  Most of the documentation doesn't use it, but dc.js will work with/without the keyword...