### PR TITLE
fixed extra quote in filter-count Reset All anchor

### DIFF
--- a/web/stock.js
+++ b/web/stock.js
@@ -487,7 +487,7 @@ d3.csv('ndx.csv', function (data) {
         // `%filter-count` and `%total-count` are replaced with the values obtained.
         .html({
             some: '<strong>%filter-count</strong> selected out of <strong>%total-count</strong> records' +
-                ' | <a href=\'javascript:dc.filterAll(); dc.renderAll();\'\'>Reset All</a>',
+                ' | <a href=\'javascript:dc.filterAll(); dc.renderAll();\'>Reset All</a>',
             all: 'All records selected. Please click on the graph to apply filters.'
         });
 


### PR DESCRIPTION
Having an extra quote in anchor tag was making a page not well-formed.