### PR TITLE
specified first two elements of d.key to pass to isFiltered()

### DIFF
--- a/dc.js
+++ b/dc.js
@@ -9046,7 +9046,8 @@ dc.scatterPlot = function (parent, chartGroup) {
             .attr('transform', _locator);
 
         symbols.each(function (d, i) {
-            _filtered[i] = !_chart.filter() || _chart.filter().isFiltered(d.key);
+            //_filtered[i] = !_chart.filter() || _chart.filter().isFiltered(d.key);
+            _filtered[i] = !_chart.filter() || _chart.filter().isFiltered([d.key[0], d.key[1]]);
         });
 
         dc.transition(symbols, _chart.transitionDuration())


### PR DESCRIPTION
Needed when length of `d.key` > 2 (for example, it can contain a colour index) because `dc.filters.RangedTwoDimensionalFilter` returns false if `value.length !== 2` (see line 954).