### PR TITLE
Fix Pie Chart tweening breaking on object-valued groups #1085

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -431,6 +431,9 @@ dc.pieChart = function (parent, chartGroup) {
         var current = this._current;
         if (isOffCanvas(current)) {
             current = {startAngle: 0, endAngle: 0};
+        } else {
+            // only interpolate startAngle & endAngle, not the whole data object
+            current = {startAngle: current.startAngle, endAngle: current.endAngle};
         }
         var i = d3.interpolate(current, b);
         this._current = i(0);


### PR DESCRIPTION
See https://github.com/dc-js/dc.js/issues/1085 -- Pie tweening could sometimes cause d3.interpolate to throw an error, particularly when using the 'cap' feature.