### PR TITLE
fix weird transition on barChart exit() #822

### DIFF
--- a/dc.js
+++ b/dc.js
@@ -5433,7 +5433,8 @@ dc.barChart = function (parent, chartGroup) {
             .select('title').text(dc.pluck('data', _chart.title(d.name)));
 
         dc.transition(bars.exit(), _chart.transitionDuration())
-            .attr('height', 0)
+            .attr('x', function(d) { return _chart.x()(d.x); })
+            .attr('width', _barWidth * 0.9)
             .remove();
     }
 


### PR DESCRIPTION
the transition to `height(0)` was making the bar "fly away", now we keep its y and height, but transition it towards where it "should be". trimming a little bit of the width gives nicer results imho so that a small ap is preserved between bars. But it's something that can be removed if you prefer to keep it simple.