### PR TITLE
fix weird transition on barChart exit() #822

### DIFF
--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -121,7 +121,8 @@ dc.barChart = function (parent, chartGroup) {
             });
 
         dc.transition(labels.exit(), _chart.transitionDuration())
-            .attr('height', 0)
+            .attr('x', function(d) { return _chart.x()(d.x); })
+            .attr('width', _barWidth * 0.9)
             .remove();
     }
 


### PR DESCRIPTION
the transition to `height(0)` was making the bar "fly away", now we keep its y and height, but transition it towards where it "should be". trimming a little bit of the width gives nicer results imho so that a small ap is preserved between bars. But it's something that can be removed if you prefer to keep it simple.

(see previous PR #1145 where I had edited `dc.js` instead of `src/`)