### PR TITLE
Don't try to interpolate random data in label paths 

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -214,8 +214,9 @@ dc.pieChart = function (parent, chartGroup) {
         polyline.exit().remove();
         dc.transition(polyline, _chart.transitionDuration())
             .attrTween('points', function (d) {
-                this._current = this._current || d;
-                var interpolate = d3.interpolate(this._current, d);
+                var current = this._current || d;
+                current = {startAngle: current.startAngle, endAngle: current.endAngle};
+                var interpolate = d3.interpolate(current, d);
                 this._current = interpolate(0);
                 return function (t) {
                     var arc2 = d3.svg.arc()


### PR DESCRIPTION
At the moment when there is no data available for the pie chart dc.js will provide the value 1 as default, along with the emptyTitle (which can be set). I've experienced a problem when I have objects assigned as "value" in dc.js, with a value accessor that digs more deeply inside that object to find a value. When I then change filter so that it returns an empty set of data it will try to interpolate with my object (e.g. { value: 1}) and the empty value (e.g. 1). Interpolating between an object and a number will return NaN which will cause the charts to become unusable until refresh of webpage.

This PR gives you the possibility to set the value that should be used when no data is available after filtering. Then you can set it to an object which can be correctly interpolated to and from.

Another problem while developing this was that the key and value accessors for charts inheriting from the capMixin (cappedKeyAccessor/cappedValueAccessor) bothers with the others field in the object. Before this PR we automatically set it to an array containing the emptyTitle-variable. In order to be able to have the value accessed with the value accessor I also added the possibility to set "emptyOthers" to be used in the others field.

Added TC for emptyValue with both a number and an object. I was unable to create a good test case for the others field since it basically never happens since we have no data, so all cap options that I tried wouldn't trigger it to show the others tags; it always resulted in emptyTitle.

Another solution to this could be to combine title, value and others in an object and make it possible to set this object via only one method (instead of three as it is in this PR)
