### PR TITLE
Include 0 as max in elastic axis if all values are negative

### DIFF
--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -495,11 +495,11 @@ describe('dc.barChart', function () {
                 });
             });
 
-            describe('with negative data', function () {
+            describe('with mixed data', function () {
                 beforeEach(function () {
-                    var negativeGroup = dimension.group().reduceSum(function (d) { return d.nvalue; });
+                    var mixedGroup = dimension.group().reduceSum(function (d) { return d.nvalue; });
 
-                    chart.group(negativeGroup).stack(negativeGroup).stack(negativeGroup);
+                    chart.group(mixedGroup).stack(mixedGroup).stack(mixedGroup);
                     chart.x(d3.time.scale.utc().domain([makeDate(2012, 4, 20), makeDate(2012, 7, 15)]));
 
                     chart.margins({top: 30, right: 50, bottom: 30, left: 30})
@@ -552,11 +552,36 @@ describe('dc.barChart', function () {
                 });
 
                 it('should generate y axis domain dynamically', function () {
-                    var nthText = function (n) { return d3.select(chart.selectAll('g.y text')[0][n]); };
+                    var nthText = function (n) { return d3.select(chart.selectAll('g.axis.y .tick text')[0][n]); };
 
                     expect(nthText(0).text()).toBe('-20');
                     expect(nthText(1).text()).toBe('0');
                     expect(nthText(2).text()).toBe('20');
+                });
+            });
+
+            describe('with negative data', function () {
+                beforeEach(function () {
+                    var negativeGroup = dimension.group().reduceSum(function (d) { return -Math.abs(d.nvalue); });
+
+                    chart.group(negativeGroup).stack(negativeGroup).stack(negativeGroup);
+                    chart.x(d3.time.scale.utc().domain([makeDate(2012, 4, 20), makeDate(2012, 7, 15)]));
+
+                    chart.margins({top: 30, right: 50, bottom: 30, left: 30})
+                        .elasticY(true)
+                        .xUnits(d3.time.days.utc)
+                        .yAxis().ticks(3);
+
+                    chart.render();
+                });
+
+                it('should generate y axis domain dynamically', function () {
+                    var nthText = function (n) { return d3.select(chart.selectAll('g.axis.y .tick text')[0][n]); };
+
+                    expect(nthText(0).text()).toBe('-30');
+                    expect(nthText(1).text()).toBe('-20');
+                    expect(nthText(2).text()).toBe('-10');
+                    expect(nthText(3).text()).toBe('0');
                 });
             });
         });

--- a/spec/line-chart-spec.js
+++ b/spec/line-chart-spec.js
@@ -497,11 +497,11 @@ describe('dc.lineChart', function () {
                 });
             });
 
-            describe('with negative data', function () {
+            describe('with mixed data', function () {
                 beforeEach(function () {
-                    var negativeGroup = dimension.group().reduceSum(function (d) { return d.nvalue; });
+                    var mixedGroup = dimension.group().reduceSum(function (d) { return d.nvalue; });
 
-                    chart.group(negativeGroup).stack(negativeGroup).stack(negativeGroup);
+                    chart.group(mixedGroup).stack(mixedGroup).stack(mixedGroup);
                     chart.x(d3.time.scale.utc().domain([makeDate(2012, 4, 20), makeDate(2012, 7, 15)]));
 
                     chart.margins({top: 30, right: 50, bottom: 30, left: 30})
@@ -531,7 +531,7 @@ describe('dc.lineChart', function () {
                 });
 
                 it('should generate y axis domain dynamically', function () {
-                    var nthText = function (n) { return d3.select(chart.selectAll('g.y text')[0][n]); };
+                    var nthText = function (n) { return d3.select(chart.selectAll('g.axis.y .tick text')[0][n]); };
 
                     expect(nthText(0).text()).toBe('-20');
                     expect(nthText(1).text()).toBe('0');
@@ -546,6 +546,31 @@ describe('dc.lineChart', function () {
 
                     it('should generate a label for each datum', lineLabelCount);
                     it('should generate labels with positions corresponding to their data', lineLabelPositions);
+                });
+            });
+
+            describe('with negative data', function () {
+                beforeEach(function () {
+                    var negativeGroup = dimension.group().reduceSum(function (d) { return -Math.abs(d.nvalue); });
+
+                    chart.group(negativeGroup).stack(negativeGroup).stack(negativeGroup);
+                    chart.x(d3.time.scale.utc().domain([makeDate(2012, 4, 20), makeDate(2012, 7, 15)]));
+
+                    chart.margins({top: 30, right: 50, bottom: 30, left: 30})
+                        .elasticY(true)
+                        .xUnits(d3.time.days.utc)
+                        .yAxis().ticks(3);
+
+                    chart.render();
+                });
+
+                it('should generate y axis domain dynamically', function () {
+                    var nthText = function (n) { return d3.select(chart.selectAll('g.axis.y .tick text')[0][n]); };
+
+                    expect(nthText(0).text()).toBe('-30');
+                    expect(nthText(1).text()).toBe('-20');
+                    expect(nthText(2).text()).toBe('-10');
+                    expect(nthText(3).text()).toBe('0');
                 });
             });
         });

--- a/spec/row-chart-spec.js
+++ b/spec/row-chart-spec.js
@@ -91,7 +91,7 @@ describe('dc.rowChart', function () {
         });
     });
 
-    function itShouldBehaveLikeARowChartWithGroup (groupHolder, N) {
+    function itShouldBehaveLikeARowChartWithGroup (groupHolder, N, xAxisTicks) {
         describe('for ' + groupHolder.groupType + ' data', function () {
             beforeEach(function () {
                 chart.group(groupHolder.group);
@@ -352,11 +352,30 @@ describe('dc.rowChart', function () {
                     });
                 });
             });
+
+            if (xAxisTicks) {
+                describe('with elasticX', function () {
+                    beforeEach(function () {
+                        chart.elasticX(true)
+                            .xAxis().ticks(3);
+
+                        chart.render();
+                    });
+
+                    it('should generate x axis domain dynamically', function () {
+                        var nthText = function (n) { return d3.select(chart.selectAll('g.axis .tick text')[0][n]); };
+
+                        for (let i = 0; i < xAxisTicks.length; i++) {
+                            expect(nthText(i).text()).toBe(xAxisTicks[i]);
+                        }
+                    });
+                });
+            }
         });
     }
 
-    itShouldBehaveLikeARowChartWithGroup(positiveGroupHolder, 5);
-    itShouldBehaveLikeARowChartWithGroup(negativeGroupHolder, 5);
-    itShouldBehaveLikeARowChartWithGroup(mixedGroupHolder, 5);
+    itShouldBehaveLikeARowChartWithGroup(positiveGroupHolder, 5, ['0', '5', '10']);
+    itShouldBehaveLikeARowChartWithGroup(negativeGroupHolder, 5, ['-10', '-5', '0']);
+    itShouldBehaveLikeARowChartWithGroup(mixedGroupHolder, 5, ['-5', '0', '5']);
     itShouldBehaveLikeARowChartWithGroup(largerGroupHolder, 7);
 });

--- a/src/row-chart.js
+++ b/src/row-chart.js
@@ -56,6 +56,9 @@ dc.rowChart = function (parent, chartGroup) {
             if (extent[0] > 0) {
                 extent[0] = 0;
             }
+            if (extent[1] < 0) {
+                extent[1] = 0;
+            }
             _x = d3.scale.linear().domain(extent)
                 .range([0, _chart.effectiveWidth()]);
         }

--- a/src/stack-mixin.js
+++ b/src/stack-mixin.js
@@ -182,7 +182,7 @@ dc.stackMixin = function (_chart) {
 
     _chart.yAxisMax = function () {
         var max = d3.max(flattenStack(), function (p) {
-            return p.y + p.y0;
+            return (p.y + p.y0 > p.y0) ? (p.y + p.y0) : p.y0;
         });
 
         return dc.utils.add(max, _chart.yAxisPadding());


### PR DESCRIPTION
For Row chart and charts using Stack mixin, use the corresponding method for determining the max value for the y axis as used for min value:

> `yAxisMin`, current behaviour: If all values are _positive,_ use 0 as y axis _min._
> `yAxisMax`, new behaviour: If all values are _negative,_ use 0 as y axis _max._

Should fix issue #879.

Two Jasmine tests are currently failing, both related to Composite chart and its `alignYAxes`. As far as I can tell, it seems to be related to the calculations in [`calculateYAxisRanges`](https://github.com/dc-js/dc.js/blob/develop/src/composite-chart.js#L109) that does something magic with the y axis ranges if there are two y axes and `alignYAxes` are set. I am at loss here what to do, all suggestions are welcome!

[jasmine-failing-tests.txt](https://github.com/dc-js/dc.js/files/302730/jasmine-failing-tests.txt)

