### PR TITLE
Fixed numberDisplay tweening getting stuck on Infinity values

### DIFF
--- a/src/number-display.js
+++ b/src/number-display.js
@@ -99,7 +99,9 @@ dc.numberDisplay = function (parent, chartGroup) {
             .duration(_chart.transitionDuration())
             .ease('quad-out-in')
             .tween('text', function () {
-                var interp = d3.interpolateNumber(this.lastValue || 0, newValue);
+                // [XA] don't try and interpolate from Infinity, else this breaks.
+                var interpStart = isFinite(this.lastValue) ? this.lastValue : 0;
+                var interp = d3.interpolateNumber(interpStart || 0, newValue);
                 this.lastValue = newValue;
                 return function (t) {
                     var html = null, num = _chart.formatNumber()(interp(t));


### PR DESCRIPTION
Closes #1176. Basically just added `-Infinity` and `Infinity` to the list of values to alias to zero (along with all "falsy" types) for the first parameter of the `d3.interpolateNumber` call. Works like a charm.