### PR TITLE
Transition line-chart dots along with the lines

### DIFF
--- a/spec/line-chart-spec.js
+++ b/spec/line-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate */
+/* global appendChartID, flushAllD3Transitions, loadDateFixture, makeDate */
 describe('dc.lineChart', function () {
     var id, chart, data;
     var dimension, group;
@@ -224,6 +224,7 @@ describe('dc.lineChart', function () {
                     describe('for vertical ref lines', function () {
                         var x;
                         beforeEach(function () {
+                            flushAllD3Transitions();
                             var dot = chart.select('circle.dot');
                             dot.on('mousemove').call(dot[0][0]);
                             x = dot.attr('cx');
@@ -240,6 +241,7 @@ describe('dc.lineChart', function () {
                         describe('for a left y-axis chart', function () {
                             var x;
                             beforeEach(function () {
+                                flushAllD3Transitions();
                                 var dot = chart.select('circle.dot');
                                 dot.on('mousemove').call(dot[0][0]);
                                 x = dot.attr('cx');
@@ -256,6 +258,7 @@ describe('dc.lineChart', function () {
                             var x;
                             beforeEach(function () {
                                 chart.useRightYAxis(true).render();
+                                flushAllD3Transitions();
                                 var dot = chart.select('circle.dot');
                                 dot.on('mousemove').call(dot[0][0]);
                                 x = dot.attr('cx');

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -288,6 +288,7 @@ dc.lineChart = function (parent, chartGroup) {
                     .attr('r', getDotRadius())
                     .style('fill-opacity', _dataPointFillOpacity)
                     .style('stroke-opacity', _dataPointStrokeOpacity)
+                    .attr('fill', _chart.getColor)
                     .on('mousemove', function () {
                         var dot = d3.select(this);
                         showDot(dot);
@@ -299,15 +300,16 @@ dc.lineChart = function (parent, chartGroup) {
                         hideRefLines(g);
                     });
 
-                dots
+                dots.call(renderTitle, d)
+                    .transition()
+                    .duration(_chart.transitionDuration())
                     .attr('cx', function (d) {
                         return dc.utils.safeNumber(_chart.x()(d.x));
                     })
                     .attr('cy', function (d) {
                         return dc.utils.safeNumber(_chart.y()(d.y + d.y0));
                     })
-                    .attr('fill', _chart.getColor)
-                    .call(renderTitle, d);
+                    .attr('fill', _chart.getColor);
 
                 dots.exit().remove();
             });


### PR DESCRIPTION
When updating data for line-charts, the line updates using a d3.transition(). The dots (if enabled) do not use a transition. This PR adds transitions to dots. See the updated series example.

I'm not exactly sure what test to write. Maybe check location, d3.timer.flush(), check location is different?
Also, probably should not update the example, but leaving in for now as a demo for anyone reviewing this.