### PR TITLE
#934 - Removing top from cap mixin

### DIFF
--- a/src/cap-mixin.js
+++ b/src/cap-mixin.js
@@ -46,12 +46,38 @@ dc.capMixin = function (_chart) {
         return _chart.valueAccessor()(d, i);
     };
 
+    /**
+     * Base function orders by crossfilter's group.all.
+     * This returns all groups, in ascending order, by value.
+     *
+     * This function is expected to return items in the same direction,
+     * ascending but the N biggest where N is cap.
+     *
+     * Since computeOrderedGroups is using crossfilter's quicksort, the
+     * sorted items will always be in ascending order.
+     *
+     * This means if we cap, we need to take from N to the end of the array.
+     *
+     *  Index
+     *  0-------N-------length
+     *
+     *  Value
+     *  small -> big
+     *
+     */
     _chart.data(function (group) {
         if (_cap === Infinity) {
             return _chart._computeOrderedGroups(group.all());
         } else {
-            var topRows = group.top(_cap); // ordered by crossfilter group order (default value)
+            var topRows = group.all(); // ordered by crossfilter group order (default value)
+
             topRows = _chart._computeOrderedGroups(topRows); // re-order using ordering (default key)
+
+            if (_cap) {
+              var start = Math.max(0, topRows.length - _cap);
+              topRows = topRows.slice(start, topRows.length);
+            }
+
             if (_othersGrouper) {
                 return _othersGrouper(topRows);
             }


### PR DESCRIPTION
Before, the cap mixin used crossfilter.group.top(_cap) before applying the ordering function. This produced really strange results when you use a non-default ordering function.

The order of group.all by default is ascending value.  The order of dcjs's ordering function is ascending key by default.  So if you left ordering default, you would get fairly expected results. The largest value groups, sorted by key.  

But if you use your own ordering function, you get very strange results, because your ordering function does not take affect until the biggest set has already been determined by group.all().top(). 

Added a new test which fails with current capping logic because of this problem. Changed implementation of data function in cap which resolves this new test.  Changed existing tests which tested for incorrect results that used to be produced.
