### PR TITLE
Use crossfilter2 in footer, on the AMD path.

### DIFF
--- a/src/footer.js
+++ b/src/footer.js
@@ -15,7 +15,7 @@ dc.crossfilter = crossfilter;
 
 return dc;}
     if(typeof define === "function" && define.amd) {
-        define(["d3", "crossfilter"], _dc);
+        define(["d3", "crossfilter2"], _dc);
     } else if(typeof module === "object" && module.exports) {
         var _d3 = require('d3');
         var _crossfilter = require('crossfilter2');


### PR DESCRIPTION
I've tried to use current DC inside react, using https://github.com/facebookincubator/create-react-app, and DC could not find crossfilter. Looks like 'crossfilter' was changed to 'crossfilter2' on one path, but not another. I have no idea why react build process uses AMD modules, but this patch fixes the error.
