### PR TITLE
Add call to xAxisPaddingUnit for stack-mixin when calculating max/min

### DIFF
--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -949,7 +949,43 @@ describe('dc.barChart', function () {
             });
         });
     });
+    describe('with elasticX and x-axis padding', function() {
+        var date = makeDate(2012, 5, 1);
+        beforeEach(function () {
 
+            var rows = [
+              {x: date, y: 4},
+            ];
+            data = crossfilter(rows);
+            dimension = data.dimension(function (d) {
+              return d.x;
+            });
+            group = dimension.group().reduceSum(function (d) {
+              return d.y;
+            });
+            chart = dc.barChart('#' + id);
+            chart.width(500)
+              .transitionDuration(0)
+              .x(d3.time.scale())
+              .elasticY(true).elasticX(true)
+              .dimension(dimension)
+              .group(group)
+            chart.render();
+        });
+        it ('should render the right xAxisMax/Min when no padding', function () {
+            expect(chart.xAxisMin()).toEqual(date);
+            expect(chart.xAxisMax()).toEqual(date);
+        })
+        it ('should render the right xAxisMax/Min when 10 day padding', function () {
+          chart.xAxisPadding(10)
+          let expectedStartDate = d3.time.day.offset(date, -10);
+          let expectedEndDate = d3.time.day.offset(date, 10);
+          expect(chart.xAxisMin()).toEqual(expectedStartDate);
+          expect(chart.xAxisMax()).toEqual(expectedEndDate);
+        });
+
+        it ('should render the right ')
+    });
     describe('with changing number of bars and elasticX', function () {
         beforeEach(function () {
             var rows1 = [
@@ -997,6 +1033,7 @@ describe('dc.barChart', function () {
             });
         });
     });
+
 
     describe('with changing number of ordinal bars and elasticX', function () {
         beforeEach(function () {

--- a/src/stack-mixin.js
+++ b/src/stack-mixin.js
@@ -195,12 +195,12 @@ dc.stackMixin = function (_chart) {
 
     _chart.xAxisMin = function () {
         var min = d3.min(flattenStack(), dc.pluck('x'));
-        return dc.utils.subtract(min, _chart.xAxisPadding());
+        return dc.utils.subtract(min, _chart.xAxisPadding(), _chart.xAxisPaddingUnit());
     };
 
     _chart.xAxisMax = function () {
         var max = d3.max(flattenStack(), dc.pluck('x'));
-        return dc.utils.add(max, _chart.xAxisPadding());
+        return dc.utils.add(max, _chart.xAxisPadding(), _chart.xAxisPaddingUnit());
     };
 
     /**


### PR DESCRIPTION
Hi!

We need to get xAxisPaddingUnit when calculating max/min for stack-mixin in order to get xAxisPadding with other units than day to work. 

Extends: ea511e06b2acd3fa62723de3ec7337b2b449a0bc
Reference: #892