### PR TITLE
Bubble Chart: selectAll should be select when manipulating a enter/update selection

### DIFF
--- a/src/bubble-chart.js
+++ b/src/bubble-chart.js
@@ -117,7 +117,7 @@ dc.bubbleChart = function (parent, chartGroup) {
             .attr('fill', _chart.getColor)
             .attr('r', 0);
         dc.transition(bubbleG, _chart.transitionDuration(), _chart.transitionDelay())
-            .selectAll('circle.' + _chart.BUBBLE_CLASS)
+            .select('circle.' + _chart.BUBBLE_CLASS)
             .attr('r', function (d) {
                 return _chart.bubbleR(d);
             })
@@ -133,7 +133,7 @@ dc.bubbleChart = function (parent, chartGroup) {
     function updateNodes (bubbleG) {
         dc.transition(bubbleG, _chart.transitionDuration(), _chart.transitionDelay())
             .attr('transform', bubbleLocator)
-            .selectAll('circle.' + _chart.BUBBLE_CLASS)
+            .select('circle.' + _chart.BUBBLE_CLASS)
             .attr('fill', _chart.getColor)
             .attr('r', function (d) {
                 return _chart.bubbleR(d);

--- a/src/bubble-mixin.js
+++ b/src/bubble-mixin.js
@@ -130,7 +130,7 @@ dc.bubbleMixin = function (_chart) {
 
     _chart.doUpdateLabels = function (bubbleGEnter) {
         if (_chart.renderLabel()) {
-            var labels = bubbleGEnter.selectAll('text')
+            var labels = bubbleGEnter.select('text')
                 .attr('pointer-events', labelPointerEvent)
                 .text(labelFunction);
             dc.transition(labels, _chart.transitionDuration(), _chart.transitionDelay())
@@ -154,7 +154,7 @@ dc.bubbleMixin = function (_chart) {
 
     _chart.doUpdateTitles = function (g) {
         if (_chart.renderTitle()) {
-            g.selectAll('title').text(titleFunction);
+            g.select('title').text(titleFunction);
         }
     };
 


### PR DESCRIPTION
`selectAll` in these cases is going to screw up the current enter/update selection, which results in some nodes not getting updated.  These should really be `select`.  I feel like this has come up before, but I can't seem to find the particular PR or conversation about it.