### PR TITLE
use valid sans-serif value

### DIFF
--- a/style/dc.scss
+++ b/style/dc.scss
@@ -11,7 +11,7 @@ $color_boston_blue: #3182bd;
 $color_blue: #00f;
 
 //fonts
-$font_sans_serif: 'sans-serif';
+$font_sans_serif: sans-serif;
 
 @mixin no-select {
   -webkit-touch-callout: none;


### PR DESCRIPTION
Because `$font_sans_serif` was defined as a string in `dc.scss` the browser would look for a font called "sans-serif" instead of using a system sans-serif typeface. We recently discovered this [after bumping our dc.js version](https://github.com/metabase/metabase/commit/8c65b571e703c854666c43bb23ceb55713a6817d#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) and noticed our axis labels had changed in metabase/metabase#4115
