### PR TITLE
Checkbox/radio button filtering

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -479,5 +479,6 @@ module.exports.jsFiles = [
     'src/d3.box.js',
     'src/box-plot.js',
     'src/select-menu.js',
+    'src/cbox-menu.js',
     'src/footer.js'  // NOTE: keep this last
 ];

--- a/spec/cbox-menu-spec.js
+++ b/spec/cbox-menu-spec.js
@@ -38,73 +38,63 @@ describe('dc.cboxMenu', function () {
         it('creates an unordered list', function () {
             expect(chart.selectAll('ul')[0].length).toEqual(1);
         });
-        it('creates li elements for each item', function () {
-            console.log('chart.selectAll("li"):');
-            console.log(chart.selectAll('li'));
+        it('creates .dc-cbox-item class elements for each item', function () {
+            expect(chart.selectAll('li.dc-cbox-item')[0].length).toEqual(stateGroup.all().length);
+        });
+        it('creates an extra item for the select all option', function () {
             expect(chart.selectAll('li')[0].length).toEqual(stateGroup.all().length + 1);
         });
         it('creates input elements within each list item', function () {
             expect(chart.selectAll('li input')[0].length).toEqual(stateGroup.all().length + 1);
         });
-        //         it('creates cbox tag', function () {
-        //             expect(chart.selectAll('input[type=radio]').length).toEqual(1);
-        //         });
-        it('radio buttons are created by default', function () {
-            expect(chart.selectAll('input[type=checkbox]')[0].length).toEqual(0);
-            expect(chart.selectAll('input[type=radio]')[0].length).toEqual(stateGroup.all().length + 1);
+        // check labels and IDs
+        it('creates input elements with IDs and labels with the corresponding "for" attribute', function () {
+            var str = chart.selectAll('input')[0].map(function (e) {
+                return e.id;
+            }).join('--');
+            expect(str).toMatch(/^(input_\d+_\d+--)+input_\d+_all$/);
+            expect(str).toEqual(chart.selectAll('label')[0].map(function (e) {
+                return e.getAttribute('for');
+            }).join('--'));
         });
-        //         it('has a select all option in single mode', function () {
-        //             expect( chart.selectAll('input[type=reset]')[0].length ).toEqual(1);
-        //         });
+
+        // Single select
+        it('creates radio buttons by default', function () {
+            expect(chart.selectAll('input[type=checkbox]')[0].length).toEqual(0);
+            expect(chart.selectAll('.dc-cbox-item input[type=radio]')[0].length).toEqual(stateGroup.all().length);
+        });
         it('uses a radio button for the select all option', function () {
             expect(chart.selectAll('input[type=radio]')[0].length).toEqual(stateGroup.all().length + 1);
         });
+        // select all:
+        it('creates a select all option with default prompt text', function () {
+            var option = chart.selectAll('li label')[0].pop();
+            expect(option.textContent).toEqual('Select all');
+        });
+        it('creates a select all option with no value', function () {
+            var option = chart.selectAll('li input')[0].pop();
+            expect(option.name).toMatch(/^domain_\d+$/);
+            expect(option.getAttribute('value')).toBeNull();
+        });
+        // multiple select
         it('can be made into a multiple', function () {
-            console.log('Running make into a multiple');
             chart.multiple(true).redraw();
-            console.log('make multiple: chart.selectAll("li input"):');
-            console.log(chart.selectAll('li input'));
-            expect(chart.selectAll('input[type=checkbox]')[0].length).toEqual(stateGroup.all().length);
+            expect(chart.selectAll('.dc-cbox-item input[type=checkbox]')[0].length).toEqual(stateGroup.all().length);
         });
         it('does not use radio buttons for multiples', function () {
             chart.multiple(true).redraw();
-            expect(chart.selectAll('input[type=radio]')[0].length).toEqual(0);
-        });
-        it('creates correct number of options', function () {
-            expect(chart.selectAll('.dc-cbox-item')[0].length).toEqual(stateGroup.all().length);
-        });
-        //         it('select tag does not have size by default', function () {
-        //             expect(chart.selectAll('select').attr('size')).toBeNull();
-        //         });
-        //         it('can have size set', function () {
-        //             chart.numberVisible(10).redraw();
-        //             expect(chart.selectAll('select').attr('size')).toEqual('10');
-        //         });
-        // select all:
-        it('creates prompt option with empty value', function () {
-            var option = chart.selectAll('li input')[0].pop();
-            console.log(option);
-            expect(option).not.toBeNull();
-            expect(option.name).toMatch(/^domain_\d+$/);
-            expect(option.value).toEqual('on');
-        });
-        it('creates prompt option with default prompt text', function () {
-            var option = chart.selectAll('li label')[0].pop();
-            console.log(option);
-            expect(option.textContent).toEqual('Select all');
+            expect(chart.selectAll('.dc-cbox-item input[type=radio]')[0].length).toEqual(0);
         });
         // select all multiple:
         it('has a reset button in multiple mode', function () {
             chart.multiple(true).redraw();
             var option = chart.selectAll('li input')[0].pop();
-            console.log(option);
             expect(option.type).toEqual('reset');
             expect(chart.selectAll('input[type=reset]')[0].length).toEqual(1);
         });
         it('creates prompt option with default prompt text', function () {
             chart.multiple(true).redraw();
             var option = chart.selectAll('li input')[0].pop();
-            console.log(option);
             expect(option.textContent).toEqual('Select all');
         });
 
@@ -215,9 +205,6 @@ describe('dc.cboxMenu', function () {
             regionDimension.filter('South');
             chart.redraw();
             expect(chart.selectAll('.dc-cbox-item')[0].length).toEqual(1);
-
-            console.log(getOption(chart, 0).textContent);
-
             expect(getOption(chart, 0).textContent).toEqual('California: 2');
         });
         it('can be overridden', function () {

--- a/spec/cbox-menu-spec.js
+++ b/spec/cbox-menu-spec.js
@@ -1,0 +1,249 @@
+/* global appendChartID, loadDateFixture */
+describe('dc.cboxMenu', function () {
+    var id, chart;
+    var data, regionDimension, regionGroup;
+    var stateDimension, stateGroup;
+
+    beforeEach(function () {
+        data = crossfilter(loadDateFixture());
+        regionDimension = data.dimension(function (d) { return d.region; });
+        stateDimension = data.dimension(function (d) { return d.state; });
+
+        regionGroup = regionDimension.group();
+        stateGroup = stateDimension.group();
+
+        id = 'cbox-menu';
+        appendChartID(id);
+
+        chart = dc.cboxMenu('#' + id);
+        chart.dimension(stateDimension)
+            .group(stateGroup)
+            .transitionDuration(0);
+        chart.render();
+    });
+
+    describe('generation', function () {
+        it('we get something', function () {
+            expect(chart).not.toBeNull();
+        });
+        it('should be registered', function () {
+            expect(dc.hasChart(chart)).toBeTruthy();
+        });
+        it('sets order', function () {
+            expect(chart.order()).toBeDefined();
+        });
+        it('sets prompt text', function () {
+            expect(chart.promptText()).toBe('Select all');
+        });
+        it('creates an unordered list', function () {
+            expect(chart.selectAll('ul')[0].length).toEqual(1);
+        });
+        it('creates li elements for each item', function () {
+            console.log('chart.selectAll("li"):');
+            console.log(chart.selectAll('li'));
+            expect(chart.selectAll('li')[0].length).toEqual(stateGroup.all().length + 1);
+        });
+        it('creates input elements within each list item', function () {
+            expect(chart.selectAll('li input')[0].length).toEqual(stateGroup.all().length + 1);
+        });
+        //         it('creates cbox tag', function () {
+        //             expect(chart.selectAll('input[type=radio]').length).toEqual(1);
+        //         });
+        it('radio buttons are created by default', function () {
+            expect(chart.selectAll('input[type=checkbox]')[0].length).toEqual(0);
+            expect(chart.selectAll('input[type=radio]')[0].length).toEqual(stateGroup.all().length + 1);
+        });
+        //         it('has a select all option in single mode', function () {
+        //             expect( chart.selectAll('input[type=reset]')[0].length ).toEqual(1);
+        //         });
+        it('uses a radio button for the select all option', function () {
+            expect(chart.selectAll('input[type=radio]')[0].length).toEqual(stateGroup.all().length + 1);
+        });
+        it('can be made into a multiple', function () {
+            console.log('Running make into a multiple');
+            chart.multiple(true).redraw();
+            console.log('make multiple: chart.selectAll("li input"):');
+            console.log(chart.selectAll('li input'));
+            expect(chart.selectAll('input[type=checkbox]')[0].length).toEqual(stateGroup.all().length);
+        });
+        it('does not use radio buttons for multiples', function () {
+            chart.multiple(true).redraw();
+            expect(chart.selectAll('input[type=radio]')[0].length).toEqual(0);
+        });
+        it('creates correct number of options', function () {
+            expect(chart.selectAll('.dc-cbox-item')[0].length).toEqual(stateGroup.all().length);
+        });
+        //         it('select tag does not have size by default', function () {
+        //             expect(chart.selectAll('select').attr('size')).toBeNull();
+        //         });
+        //         it('can have size set', function () {
+        //             chart.numberVisible(10).redraw();
+        //             expect(chart.selectAll('select').attr('size')).toEqual('10');
+        //         });
+        // select all:
+        it('creates prompt option with empty value', function () {
+            var option = chart.selectAll('li input')[0].pop();
+            console.log(option);
+            expect(option).not.toBeNull();
+            expect(option.name).toMatch(/^domain_\d+$/);
+            expect(option.value).toEqual('on');
+        });
+        it('creates prompt option with default prompt text', function () {
+            var option = chart.selectAll('li label')[0].pop();
+            console.log(option);
+            expect(option.textContent).toEqual('Select all');
+        });
+        // select all multiple:
+        it('has a reset button in multiple mode', function () {
+            chart.multiple(true).redraw();
+            var option = chart.selectAll('li input')[0].pop();
+            console.log(option);
+            expect(option.type).toEqual('reset');
+            expect(chart.selectAll('input[type=reset]')[0].length).toEqual(1);
+        });
+        it('creates prompt option with default prompt text', function () {
+            chart.multiple(true).redraw();
+            var option = chart.selectAll('li input')[0].pop();
+            console.log(option);
+            expect(option.textContent).toEqual('Select all');
+        });
+
+    });
+
+    describe('select options', function () {
+        var firstOption, lastOption, lastIndex;
+        beforeEach(function () {
+            lastIndex = stateGroup.all().length - 1;
+            firstOption = getOption(chart, 0);
+            lastOption = getOption(chart, lastIndex);
+        });
+        it('display title as default option text', function () {
+            expect(firstOption.textContent).toEqual('California: 3');
+        });
+        it('text property can be changed by changing title', function () {
+            chart.title(function (d) { return d.key; }).redraw();
+            firstOption = getOption(chart, 0);
+            expect(firstOption.textContent).toEqual('California');
+        });
+        it('are ordered by ascending group key by default', function () {
+            expect(firstOption.textContent).toEqual('California: 3');
+            expect(lastOption.textContent).toEqual('Ontario: 2');
+        });
+        it('order can be changed by changing order function', function () {
+            chart.order(function (a, b) { return a.key.length - b.key.length; });
+            chart.redraw();
+            lastOption = getOption(chart, lastIndex);
+            expect(lastOption.textContent).toEqual('Mississippi: 2');
+        });
+    });
+
+    describe('regular single select', function () {
+        describe('selecting an option', function () {
+            it('filters dimension based on selected option\'s value', function () {
+                chart.onChange(stateGroup.all()[0].key);
+                expect(chart.filter()).toEqual('California');
+            });
+            it('replaces filter on second selection', function () {
+                chart.onChange(stateGroup.all()[0].key);
+                chart.onChange(stateGroup.all()[1].key);
+                expect(chart.filter()).toEqual('Colorado');
+                expect(chart.filters().length).toEqual(1);
+            });
+            it('actually filters dimension', function () {
+                chart.onChange(stateGroup.all()[0].key);
+                expect(regionGroup.all()[0].value).toEqual(0);
+                expect(regionGroup.all()[3].value).toEqual(2);
+            });
+            it('removes filter when prompt option is selected', function () {
+                chart.onChange(null);
+                expect(chart.hasFilter()).not.toBeTruthy();
+                expect(regionGroup.all()[0].value).toEqual(1);
+            });
+        });
+
+        describe('redraw with existing filter', function () {
+            it('selects option corresponding to active filter', function () {
+                chart.onChange(stateGroup.all()[0].key);
+                chart.redraw();
+                expect(chart.selectAll('input')[0][0].value).toEqual('California');
+            });
+        });
+
+        afterEach(function () {
+            chart.onChange(null);
+        });
+    });
+
+    describe('multiple select', function () {
+        beforeEach(function () {
+            chart.multiple(true);
+            chart.onChange([stateGroup.all()[0].key, stateGroup.all()[1].key]);
+        });
+        it('adds filters based on selections', function () {
+            expect(chart.filters()).toEqual(['California', 'Colorado']);
+            expect(chart.filters().length).toEqual(2);
+        });
+        it('actually filters dimension', function () {
+            expect(regionGroup.all()[3].value).toEqual(2);
+            expect(regionGroup.all()[4].value).toEqual(2);
+        });
+        it('removes all filters when prompt option is selected', function () {
+            chart.onChange(null);
+            expect(chart.hasFilter()).not.toBeTruthy();
+            expect(regionGroup.all()[0].value).toEqual(1);
+        });
+        it('selects all options corresponding to active filters on redraw', function () {
+            var selectedOptions = getSelectedOptions(chart);
+            expect(selectedOptions.length).toEqual(2);
+            expect(selectedOptions.map(function (d) { return d.value; })).toEqual(['California', 'Colorado']);
+        });
+        it('does not deselect previously filtered options when new option is added', function () {
+            chart.onChange([stateGroup.all()[0].key, stateGroup.all()[1].key, stateGroup.all()[5].key]);
+
+            var selectedOptions = getSelectedOptions(chart);
+            expect(selectedOptions.length).toEqual(3);
+            expect(selectedOptions.map(function (d) { return d.value; })).toEqual(['California', 'Colorado', 'Ontario']);
+        });
+
+        afterEach(function () {
+            chart.onChange(null);
+        });
+    });
+
+    describe('filterDisplayed', function () {
+        it('only displays options whose value > 0 by default', function () {
+            regionDimension.filter('South');
+            chart.redraw();
+            expect(chart.selectAll('.dc-cbox-item')[0].length).toEqual(1);
+
+            console.log(getOption(chart, 0).textContent);
+
+            expect(getOption(chart, 0).textContent).toEqual('California: 2');
+        });
+        it('can be overridden', function () {
+            regionDimension.filter('South');
+            chart.filterDisplayed(function (d) { return true; }).redraw();
+            expect(chart.selectAll('.dc-cbox-item')[0].length).toEqual(stateGroup.all().length);
+            expect(getOption(chart, stateGroup.all().length - 1).textContent).toEqual('Ontario: 0');
+        });
+        it('retains order with filtered options', function () {
+            regionDimension.filter('Central');
+            chart.redraw();
+            expect(getOption(chart, 0).textContent).toEqual('Mississippi: 2');
+            expect(getOption(chart, 1).textContent).toEqual('Ontario: 1');
+        });
+        afterEach(function () {
+            regionDimension.filterAll();
+        });
+    });
+
+    function getSelectedOptions (chart) {
+        return chart.selectAll('.dc-cbox-item input')[0].filter(function (d) {
+                return d.value && d.checked;
+            });
+    }
+
+    function getOption (chart, i) {
+        return chart.selectAll('.dc-cbox-item label')[0][i];
+    }
+});

--- a/src/cbox-menu.js
+++ b/src/cbox-menu.js
@@ -1,0 +1,285 @@
+/**
+ * The cboxMenu is a simple widget designed to filter a dimension by
+ * selecting option(s) from a set of HTML `<input />` elements. The menu can be
+ * made into a set of radio buttons (single select) or checkboxes (multiple).
+ * @class cboxMenu
+ * @memberof dc
+ * @mixes dc.baseMixin
+ * @example
+ * // create a cboxMenu under #cbox-container using the default global chart group
+ * var cbox = dc.cboxMenu('#cbox-container')
+ *                .dimension(states)
+ *                .group(stateGroup);
+ * // the option text can be set via the title() function
+ * // by default the option text is '`key`: `value`'
+ * cbox.title(function (d){
+ *     return 'STATE: ' + d.key;
+ * })
+ * @param {String|node|d3.selection|dc.compositeChart} parent - Any valid
+ * [d3 single selector](https://github.com/mbostock/d3/wiki/Selections#selecting-elements) specifying
+ * a dom block element such as a div; or a dom element or d3 selection.
+ * @param {String} [chartGroup] - The name of the chart group this widget should be placed in.
+ * Interaction with the widget will only trigger events and redraws within its group.
+ * @returns {cboxMenu}
+ **/
+dc.cboxMenu = function (parent, chartGroup) {
+    var GROUP_CSS_CLASS = 'dc-cbox-group';
+    var ITEM_CSS_CLASS = 'dc-cbox-item';
+
+    var _chart = dc.baseMixin({});
+
+    var _cbox;
+    var _promptText = 'Select all';
+    var _multiple = false;
+    var _inputType = 'radio';
+    var _promptValue = null;
+    // generate a random number to use as an ID
+    var _randVal = Math.floor(Math.random() * (100000)) + 1;
+    var _order = function (a, b) {
+        return _chart.keyAccessor()(a) > _chart.keyAccessor()(b) ?
+             1 : _chart.keyAccessor()(b) > _chart.keyAccessor()(a) ?
+            -1 : 0;
+    };
+
+    var _filterDisplayed = function (d) {
+        return _chart.valueAccessor()(d) > 0;
+    };
+
+    _chart.data(function (group) {
+        return group.all().filter(_filterDisplayed);
+    });
+
+    _chart._doRender = function () {
+        return _chart._doRedraw();
+    };
+    /*
+    // IS THIS NEEDED?
+    // Fixing IE 11 crash when redrawing the chart
+    // see here for list of IE user Agents :
+    // http://www.useragentstring.com/pages/useragentstring.php?name=Internet+Explorer
+    var ua = window.navigator.userAgent;
+    // test for IE 11 but not a lower version (which contains MSIE in UA)
+    if (ua.indexOf('Trident/') > 0 && ua.indexOf('MSIE') === -1) {
+        _chart.redraw = _chart.render;
+    }
+    */
+    _chart._doRedraw = function () {
+        _chart.select('ul').remove();
+        _cbox = _chart.root()
+            .append('ul')
+            .classed(GROUP_CSS_CLASS, true);
+        renderOptions();
+
+        // select the option(s) corresponding to current filter(s)
+        if (_chart.hasFilter() && _multiple) {
+            _cbox.selectAll('input')
+                 .property('checked', function (d) {
+                    return d && _chart.filters().indexOf(String(_chart.keyAccessor()(d))) >= 0;
+                });
+        } else if (_chart.hasFilter()) {
+            _cbox.select('input[value="' + _chart.filter() + '"]')
+                .property('checked', true);
+        }
+        return _chart;
+    };
+
+    function renderOptions () {
+        var options = _cbox
+        .selectAll('li.' + ITEM_CSS_CLASS)
+            .data(_chart.data(), function (d) {
+            return _chart.keyAccessor()(d);
+        });
+
+        options.enter()
+        .append('li')
+            .classed(ITEM_CSS_CLASS, true);
+        options
+            .append('input')
+            .attr('type', _inputType)
+            .attr('value', function (d) { return _chart.keyAccessor()(d); })
+            .attr('name', 'domain_' + _randVal)
+            .attr('id', function (d, i) {
+                return 'input_' + _randVal + '_' + i;
+            });
+        options
+            .append('label')
+            .attr('for', function (d, i) {
+                return 'input_' + _randVal + '_' + i;
+            })
+            .text(_chart.title());
+
+        if (_multiple) {
+            _cbox
+            .append('li')
+            .append('input')
+            .attr('type', 'reset')
+            .text(_promptText)
+            .on('click', onChange);
+        } else {
+            // 'all' option
+            var li = _cbox.append('li');
+            li.append('input')
+                .attr('type', _inputType)
+                .attr('value', _promptValue)
+                .attr('name', 'domain_' + _randVal)
+                .attr('id', function (d, i) {
+                    return 'input_' + _randVal + '_all';
+                })
+                .property('checked', true);
+            li.append('label')
+                .attr('for', function (d, i) {
+                    return 'input_' + _randVal + '_all';
+                })
+                .text(_promptText);
+        }
+
+        options.exit().remove();
+        _cbox
+            .selectAll('li.' + ITEM_CSS_CLASS)
+            .sort(_order);
+
+        _cbox.on('change', onChange);
+        return options;
+    }
+
+    function onChange (d, i) {
+        var values,
+        target = d3.select(d3.event.target),
+        options;
+        if (!target.datum()) {
+            values = _promptValue || null;
+        } else {
+            options = d3.select(this).selectAll('input')
+            .filter(function (o) {
+                if (o) {
+                    return this.checked;
+                }
+            });
+            values = options[0].map(function (option) {
+                return option.value;
+            });
+            // check if only prompt option is selected
+            if (!_multiple && values.length === 1) {
+                values = values[0];
+            }
+        }
+        _chart.onChange(values);
+    }
+
+    _chart.onChange = function (val) {
+        if (val && _multiple) {
+            _chart.replaceFilter([val]);
+        } else if (val) {
+            _chart.replaceFilter(val);
+        } else {
+            _chart.filterAll();
+        }
+        dc.events.trigger(function () {
+            _chart.redrawGroup();
+        });
+    };
+
+    /**
+     * Get or set the function that controls the ordering of option tags in the
+     * cbox menu. By default options are ordered by the group key in ascending
+     * order.
+     * @name order
+     * @memberof dc.cboxMenu
+     * @instance
+     * @param {Function} [order]
+     * @example
+     * // order by the group's value
+     * chart.order(function (a,b) {
+     *     return a.value > b.value ? 1 : b.value > a.value ? -1 : 0;
+     * });
+     **/
+    _chart.order = function (order) {
+        if (!arguments.length) {
+            return _order;
+        }
+        _order = order;
+        return _chart;
+    };
+
+    /**
+     * Get or set the text displayed in the options used to prompt selection.
+     * @name promptText
+     * @memberof dc.cboxMenu
+     * @instance
+     * @param {String} [promptText='Select all']
+     * @example
+     * chart.promptText('All states');
+     **/
+    _chart.promptText = function (_) {
+        if (!arguments.length) {
+            return _promptText;
+        }
+        _promptText = _;
+        return _chart;
+    };
+
+    /**
+     * Get or set the function that filters options prior to display. By default options
+     * with a value of < 1 are not displayed.
+     * @name filterDisplayed
+     * @memberof dc.cboxMenu
+     * @instance
+     * @param {function} [filterDisplayed]
+     * @example
+     * // display all options override the `filterDisplayed` function:
+     * chart.filterDisplayed(function () {
+     *     return true;
+     * });
+     **/
+    _chart.filterDisplayed = function (filterDisplayed) {
+        if (!arguments.length) {
+            return _filterDisplayed;
+        }
+        _filterDisplayed = filterDisplayed;
+        return _chart;
+    };
+
+    /**
+     * Controls the type of input element. Setting it to true converts
+     * the HTML `input` tags from radio buttons to checkboxes.
+     * @name multiple
+     * @memberof dc.cboxMenu
+     * @instance
+     * @param {boolean} [multiple=false]
+     * @example
+     * chart.multiple(true);
+     **/
+    _chart.multiple = function (multiple) {
+        if (!arguments.length) {
+            return _multiple;
+        }
+        _multiple = multiple;
+        if (_multiple) {
+            _inputType = 'checkbox';
+        } else {
+            _inputType = 'radio';
+        }
+        return _chart;
+    };
+
+    /**
+     * Controls the default value to be used for
+     * [dimension.filter](https://github.com/crossfilter/crossfilter/wiki/API-Reference#dimension_filter)
+     * when only the prompt value is selected. If `null` (the default), no filtering will occur when
+     * just the prompt is selected.
+     * @name promptValue
+     * @memberof dc.cboxMenu
+     * @instance
+     * @param {?*} [promptValue=null]
+     **/
+    _chart.promptValue = function (promptValue) {
+        if (!arguments.length) {
+            return _promptValue;
+        }
+        _promptValue = promptValue;
+
+        return _chart;
+    };
+
+    return _chart.anchor(parent, chartGroup);
+};

--- a/src/cbox-menu.js
+++ b/src/cbox-menu.js
@@ -70,7 +70,6 @@ dc.cboxMenu = function (parent, chartGroup) {
             .classed(GROUP_CSS_CLASS, true);
         renderOptions();
 
-        // select the option(s) corresponding to current filter(s)
         if (_chart.hasFilter() && _multiple) {
             _cbox.selectAll('input')
                  .property('checked', function (d) {
@@ -108,6 +107,7 @@ dc.cboxMenu = function (parent, chartGroup) {
             })
             .text(_chart.title());
 
+        // 'all' option
         if (_multiple) {
             _cbox
             .append('li')
@@ -116,7 +116,6 @@ dc.cboxMenu = function (parent, chartGroup) {
             .text(_promptText)
             .on('click', onChange);
         } else {
-            // 'all' option
             var li = _cbox.append('li');
             li.append('input')
                 .attr('type', _inputType)

--- a/web/examples/cbox-menu.html
+++ b/web/examples/cbox-menu.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>dc.js - cbox Menu Example</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="../css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="../css/dc.css"/>
+</head>
+<body>
+
+<div class="container">
+<script type="text/javascript" src="header.js"></script>
+  <p>A meaningless example of multiple cboxMenus on some random data...</p>
+  <div id="cbox1">
+    <div>
+      <a class='reset'
+         href='javascript:cbox1.filterAll();dc.redrawAll();'
+         style='visibility: hidden;'>reset</a>
+    </div>
+  </div>
+  <div id="cbox2">
+    <div>
+      <a class='reset'
+         href='javascript:cbox2.filterAll();dc.redrawAll();'
+         style='visibility: hidden;'>reset</a>
+    </div>
+  </div>
+  <div id="cbox3">
+    <div>
+      <a class='reset'
+         href='javascript:cbox3.filterAll();dc.redrawAll();'
+         style='visibility: hidden;'>reset</a>
+    </div>
+  </div>
+<div style="clear: both"></div>
+<div id="datatable"></div>
+
+
+<script type="text/javascript" src="../js/d3.js"></script>
+<script type="text/javascript" src="../js/crossfilter.js"></script>
+<script type="text/javascript" src="../js/dc.js"></script>
+
+<style type="text/css">
+  .dc-chart th {
+    text-align: left
+  }
+  .dc-chart th,.dc-chart td {
+      padding-left: 10px;
+  }
+  .dc-chart tr.dc-table-group td {
+      padding-top: 4px;
+      border-bottom: 1px solid black;
+  }
+  .dc-chart li {
+      width: 15rem;
+  }
+  .dc-cbox-group {
+    list-style-type: none;
+    margin-left: 0;
+  }
+  .dc-cbox-group label {
+    display: inline-block;
+  }
+  .dc-cbox-group input[type=checkbox], .dc-cbox-group input[type=radio] {
+    margin: 0 5px 5px 5px;
+  }
+
+</style>
+
+<script type="text/javascript">
+
+  var cbox1 = dc.cboxMenu('#cbox1'),
+      cbox2 = dc.cboxMenu('#cbox2'),
+      cbox3 = dc.cboxMenu('#cbox3'),
+      datatable = dc.dataTable('#datatable');
+
+  // create a bunch of crosslinked categorical data
+
+  var letters = [];
+  for(var i = 0; i < 26; ++i)
+      letters.push(String.fromCharCode(i+65));
+
+  var colors = ["AliceBlue","AntiqueWhite","Aqua","Aquamarine","Azure","Beige","Bisque","Black","BlanchedAlmond","Blue","BlueViolet","Brown","BurlyWood","CadetBlue","Chartreuse","Chocolate","Coral","CornflowerBlue","Cornsilk","Crimson","Cyan","DarkBlue","DarkCyan","DarkGoldenRod","DarkGray","DarkGrey","DarkGreen","DarkKhaki","DarkMagenta","DarkOliveGreen","Darkorange","DarkOrchid","DarkRed","DarkSalmon","DarkSeaGreen","DarkSlateBlue","DarkSlateGray","DarkSlateGrey","DarkTurquoise","DarkViolet","DeepPink","DeepSkyBlue","DimGray","DimGrey","DodgerBlue","FireBrick","FloralWhite","ForestGreen","Fuchsia","Gainsboro","GhostWhite","Gold","GoldenRod","Gray","Grey","Green","GreenYellow","HoneyDew","HotPink","IndianRed","Indigo","Ivory","Khaki","Lavender","LavenderBlush","LawnGreen","LemonChiffon","LightBlue","LightCoral","LightCyan","LightGoldenRodYellow","LightGray","LightGrey","LightGreen","LightPink","LightSalmon","LightSeaGreen","LightSkyBlue","LightSlateGray","LightSlateGrey","LightSteelBlue","LightYellow","Lime","LimeGreen","Linen","Magenta","Maroon","MediumAquaMarine","MediumBlue","MediumOrchid","MediumPurple","MediumSeaGreen","MediumSlateBlue","MediumSpringGreen","MediumTurquoise","MediumVioletRed","MidnightBlue","MintCream","MistyRose","Moccasin","NavajoWhite","Navy","OldLace","Olive","OliveDrab","Orange","OrangeRed","Orchid","PaleGoldenRod","PaleGreen","PaleTurquoise","PaleVioletRed","PapayaWhip","PeachPuff","Peru","Pink","Plum","PowderBlue","Purple","Red","RosyBrown","RoyalBlue","SaddleBrown","Salmon","SandyBrown","SeaGreen","SeaShell","Sienna","Silver","SkyBlue","SlateBlue","SlateGray","SlateGrey","Snow","SpringGreen","SteelBlue","Tan","Teal","Thistle","Tomato","Turquoise","Violet","Wheat","White","WhiteSmoke","Yellow","YellowGreen"];
+
+  var states = new Array("AK","AL","AR","AZ","CA","CO","CT","DC","DE","FL","GA","GU","HI","IA","ID", "IL","IN","KS","KY","LA","MA","MD","ME","MH","MI","MN","MO","MS","MT","NC","ND","NE","NH","NJ","NM","NV","NY", "OH","OK","OR","PA","PR","PW","RI","SC","SD","TN","TX","UT","VA","VI","VT","WA","WI","WV","WY");
+
+  var data = [], SIZE = 500;
+
+  function rnd(a) {
+      return a[Math.floor(Math.random()*a.length)];
+  }
+
+  for(i = 0; i < SIZE; ++i)
+      data.push({letter: rnd(letters), color: rnd(colors), state: rnd(states)});
+
+  var ndx = crossfilter(data),
+      letterDimension = ndx.dimension(function(d) { return d.letter; }),
+      colorDimension = ndx.dimension(function(d) { return d.color; }),
+      stateDimension = ndx.dimension(function(d) { return d.state; }),
+      letterDimension2 = ndx.dimension(function(d) { return d.letter; });
+
+
+  cbox1
+    .dimension(letterDimension)
+    .group(letterDimension.group())
+    .controlsUseVisibility(true);
+  cbox2
+    .dimension(colorDimension)
+    .group(colorDimension.group())
+    .multiple(true)
+//    .numberVisible(10)
+    .controlsUseVisibility(true);
+  cbox3.dimension(stateDimension)
+    .group(stateDimension.group())
+    .multiple(true)
+//    .numberVisible(10)
+    .controlsUseVisibility(true);
+
+  datatable
+    .dimension(letterDimension2)
+    .group(function(d) { return d.letter; })
+    .columns(['color', 'state'])
+    .size(data.length);
+
+  dc.renderAll();
+
+</script>
+</div>
+</body>
+</html>


### PR DESCRIPTION
I'm a fan of checkbox and radio button-styled filters, so I've added `dc.cboxMenu`, which functions similarly to `dc.selectMenu` but uses either radio buttons (for single selection) or checkboxes (multiple selection) instead of the `select` element. 