### PR TITLE
Subscribe to rangeChart's filtered event with a namespace

### DIFF
--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -800,6 +800,24 @@ describe('dc.coordinateGridChart', function () {
             rangeChart.render();
         });
 
+        it('range filter should execute filtered listener and zoom focus chart', function() {
+            spyOn(chart, 'focus').and.callThrough();
+            var expectedCallbackSignature = function (callbackChart, callbackFilter) {
+                expect(callbackChart).toBe(rangeChart);
+                expect(callbackFilter).toEqual(selectedRange);
+            };
+            var filteredCallback = jasmine.createSpy().and.callFake(expectedCallbackSignature);
+            rangeChart.on('filtered', filteredCallback);
+            expect(filteredCallback).not.toHaveBeenCalled();
+
+            rangeChart.filter(selectedRange);
+            expect(filteredCallback).toHaveBeenCalled();
+
+            expect(chart.focus).toHaveBeenCalled();
+            var focus = cleanDateRange(chart.focus.calls.argsFor(0)[0]);
+            expect(focus).toEqual(selectedRange);
+        });
+
         it('should zoom the focus chart when range chart is brushed', function () {
             spyOn(chart, 'focus').and.callThrough();
             simulateChartBrushing(rangeChart, selectedRange);

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -1414,7 +1414,7 @@ dc.coordinateGridMixin = function (_chart) {
             return _focusChart;
         }
         _focusChart = c;
-        _chart.on('filtered', function (chart) {
+        _chart.on('filtered.rangeChart', function (chart) {
             if (!chart.filter()) {
                 dc.events.trigger(function () {
                     _focusChart.x().domain(_focusChart.xOriginalDomain(), true);


### PR DESCRIPTION
Fixes #842. It's trivial to change, but for now I've chosen a more specific namespace than `.dcjs`, considering the possibility of internal conflicts. I couldn't find any other examples of internal event subscriptions.