### PR TITLE
Fix elasticY with evadeDomainFilter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -458,7 +458,7 @@ dc.coordinateGridMixin = function (_chart) {
 
     function compareDomains (d1, d2) {
         return !d1 || !d2 || d1.length !== d2.length ||
-            d1.some(function (elem, i) { return (elem && d2[i]) ? elem.toString() !== d2[i].toString() : elem === d2[i]; });
+            d1.some(function (elem, i) { return (elem && d2[i]) ? elem.toString() !== d2[i].toString() : elem !== d2[i]; });
     }
 
     function prepareXAxis (g, render) {

--- a/src/stack-mixin.js
+++ b/src/stack-mixin.js
@@ -11,7 +11,7 @@ dc.stackMixin = function (_chart) {
     function prepareValues (layer, layerIdx) {
         var valAccessor = layer.accessor || _chart.valueAccessor();
         layer.name = String(layer.name || layerIdx);
-        layer.values = layer.group.all().map(function (d, i) {
+        var allValues = layer.group.all().map(function (d, i) {
             return {
                 x: _chart.keyAccessor()(d, i),
                 y: layer.hidden ? null : valAccessor(d, i),
@@ -21,7 +21,8 @@ dc.stackMixin = function (_chart) {
             };
         });
 
-        layer.values = layer.values.filter(domainFilter());
+        layer.domainValues = allValues.filter(domainFilter());
+        layer.values = _chart.evadeDomainFilter() ? allValues : layer.domainValues;
         return layer.values;
     }
 
@@ -35,7 +36,7 @@ dc.stackMixin = function (_chart) {
     var _evadeDomainFilter = false;
 
     function domainFilter () {
-        if (!_chart.x() || _evadeDomainFilter) {
+        if (!_chart.x()) {
             return d3.functor(true);
         }
         var xDomain = _chart.x().domain();
@@ -188,7 +189,7 @@ dc.stackMixin = function (_chart) {
     };
 
     function flattenStack () {
-        var valueses = _chart.data().map(function (layer) { return layer.values; });
+        var valueses = _chart.data().map(function (layer) { return layer.domainValues; });
         return Array.prototype.concat.apply([], valueses);
     }
 


### PR DESCRIPTION
Fixes that `evadeDomainFilter`, introduced by 77d22ba221f697e40cf3a63fb26a1098422ba0aa for #949, doesn't work with `elasticY(true)`. The fix requires access to the domain-filtered values separate from all values needed to render the chart.

Bonus fix: `x().domain()` transitions from `[0, _]` to `[x, _]`, as in the [bar transitions demo](http://dc-js.github.io/dc.js/transitions/bar-transitions.html) with "right" selected, will now `rescale()` correctly.