### PR TITLE
jslint and jshint clean

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
             source: {
                 src: [
                     '<%= conf.src %>/**/*.js',
-                    '!<%= conf.src %>/{banner,footer}.js',
+                    '!<%= conf.src %>/{banner,footer,d3v3-compat}.js',
                     '<%= conf.spec %>/**/*.js',
                     'Gruntfile.js',
                     'grunt/*.js',
@@ -89,7 +89,7 @@ module.exports = function (grunt) {
             source: {
                 src: [
                     '<%= conf.src %>/**/*.js',
-                    '!<%= conf.src %>/{banner,footer}.js',
+                    '!<%= conf.src %>/{banner,footer,d3v3-compat}.js',
                     '<%= conf.spec %>/**/*.js',
                     'Gruntfile.js',
                     'grunt/*.js',

--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate, cleanDateRange */
+/* global appendChartID, loadDateFixture, makeDate, cleanDateRange, setupEventForBrushing */
 describe('dc.barChart', function () {
     var id, chart, data;
     var dimension, group;

--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -73,12 +73,11 @@ describe('dc.baseMixin', function () {
             var renderlet = jasmine.createSpy().and.callFake(function (callbackChart) {
                 expect(callbackChart).toBe(chart);
                 count++;
-                if(count === 2){
+                if (count === 2) {
                     done();
                 }
             });
-            var firstRenderlet = renderlet,
-                secondRenderlet = firstRenderlet;
+            var firstRenderlet = renderlet;
             chart.renderlet(firstRenderlet);
             chart.renderlet(firstRenderlet);
             chart.render();
@@ -91,12 +90,11 @@ describe('dc.baseMixin', function () {
             var renderlet = jasmine.createSpy().and.callFake(function (callbackChart) {
                 expect(callbackChart).toBe(chart);
                 count++;
-                if(count === 2){
+                if (count === 2) {
                     done();
                 }
             });
-            var firstRenderlet = renderlet,
-                secondRenderlet = firstRenderlet;
+            var firstRenderlet = renderlet;
             chart.renderlet(firstRenderlet);
             chart.renderlet(firstRenderlet);
             chart.redraw();

--- a/spec/composite-chart-spec.js
+++ b/spec/composite-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate */
+/* global appendChartID, loadDateFixture, makeDate, setupEventForBrushing */
 describe('dc.compositeChart', function () {
     var id, chart, data, dateDimension, dateValueSumGroup, dateValueNegativeSumGroup,
         dateIdSumGroup, dateIdNegativeSumGroup, dateGroup;
@@ -243,7 +243,7 @@ describe('dc.compositeChart', function () {
                             .toMatchPath('M-0.5,36.666666666666664A6,6 0 0 0 -6.5,42.666666666666664V67.33333333333333A6,' +
                                 '6 0 0 0 -0.5,73.33333333333333ZM-2.5,44.666666666666664V65.33333333333333M-4.5,' +
                                 '44.666666666666664V65.33333333333333');
-                     } else {
+                    } else {
                         expect(d3.select(this).attr('d'))
                             .toMatchPath('M0.5,36.666666666666664A6,6 0 0 1 6.5,42.666666666666664V67.33333333333333A6,' +
                                 '6 0 0 1 0.5,73.33333333333333ZM2.5,44.666666666666664V65.33333333333333M4.5,' +

--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate, cleanDateRange */
+/* global appendChartID, loadDateFixture, makeDate, cleanDateRange, setupEventForBrushing */
 describe('dc.coordinateGridChart', function () {
     var chart, id;
     var data, dimension, group;
@@ -648,7 +648,7 @@ describe('dc.coordinateGridChart', function () {
             // expect(chart.getBrushSelection()).toEqual(filter);
             var brushSelectionRect = chart.select('g.brush rect.selection');
             expect(brushSelectionRect.attr('x')).toBeCloseTo(chart.x()(filter[0]), 1);
-            expect(+brushSelectionRect.attr('x') + +brushSelectionRect.attr('width'))
+            expect((+brushSelectionRect.attr('x')) + (+brushSelectionRect.attr('width')))
                 .toBeCloseTo(chart.x()(filter[1]), 1);
         });
     });

--- a/spec/helpers/custom_matchers.js
+++ b/spec/helpers/custom_matchers.js
@@ -194,7 +194,7 @@ beforeEach(function () {
                        http://localhost:8888/spec/?random=true#composite-chart-clip
                        http://localhost:8888/spec/##composite-chart-clip
                      */
-                    var cleanURL = function(u) {
+                    var cleanURL = function (u) {
                         var matches = u.match(/url\((.*)\)/);
                         if (matches) {
                             u = matches[1];
@@ -225,7 +225,7 @@ beforeEach(function () {
             return {
                 compare: function (actual, expected) {
                     // Colors can be rgb(0, 0, 0), #000000 or black
-                    var normalizeColor = function(c){
+                    var normalizeColor = function (c) {
                         // will convert to rgb(0, 0, 0)
                         return d3.color(c).toString();
                     };

--- a/spec/helpers/spec-helper.js
+++ b/spec/helpers/spec-helper.js
@@ -1,4 +1,8 @@
 /* global parseTranslate */
+
+/*exported appendChartID, coordsFromTranslate, makeDate, cleanDateRange, flushAllD3Transitions */
+/*exported setupEventForBrushing, setupEventFor2DBrushing */
+
 beforeEach(function () {
     jasmine.clock().install();
 
@@ -18,7 +22,6 @@ afterEach(function () {
     jasmine.clock().uninstall();
 });
 
-/* jshint -W098 */
 function appendChartID (id) {
     return d3.select('#test-content').append('div').attr('id', id);
 }
@@ -74,5 +77,3 @@ var setupEventFor2DBrushing = function (chart, domainSelection) {
         selection: scaledSelection
     };
 };
-
-/* jshint +W098 */

--- a/spec/scatter-plot-spec.js
+++ b/spec/scatter-plot-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, comparePaths, loadDateFixture, makeDate */
+/* global appendChartID, comparePaths, loadDateFixture, makeDate, setupEventFor2DBrushing */
 describe('dc.scatterPlot', function () {
     var id, chart;
     var data, group, dimension;
@@ -242,11 +242,11 @@ describe('dc.scatterPlot', function () {
                 expect(otherDimension.top(Infinity).length).toBe(3);
             });
 
-/* D3v4 - no easy replacement, dropping this case
+            /* D3v4 - no easy replacement, dropping this case
             it('should set the height of the brush to the height implied by the extent', function () {
                 expect(chart.select('g.brush rect.extent').attr('height')).toBe('46');
             });
-*/
+            */
 
             it('should not add handles to the brush', function () {
                 expect(chart.select('.resize path').empty()).toBeTruthy();

--- a/src/composite-chart.js
+++ b/src/composite-chart.js
@@ -73,7 +73,7 @@ dc.compositeChart = function (parent, chartGroup) {
         // Avoids infinite recursion
         // To ensure that when it is called because of brush.move there is no d3.event.sourceEvent
         d3.event = null;
-        if (!event.sourceEvent) return;
+        if (!event.sourceEvent) { return; }
         var selection = event.selection;
         if (selection) {
             selection = selection.map(_chart.x().invert);

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -400,7 +400,7 @@ dc.coordinateGridMixin = function (_chart) {
     _chart.xUnitCount = function () {
         if (_unitCount === undefined) {
             var units;
-            if(_chart.xUnits() === dc.units.ordinal) {
+            if (_chart.xUnits() === dc.units.ordinal) {
                 // In this case it number of items in domain
                 units = _chart.x().domain();
             } else {
@@ -996,7 +996,7 @@ dc.coordinateGridMixin = function (_chart) {
      * @method brush
      * @memberof dc.coordinateGridMixin
      * @instance
-     * @param {d3.brush} [brush]
+     * @param {d3.brush} [_]
      * @returns {d3.brush|dc.coordinateGridMixin}
      */
     _chart.brush = function (_) {
@@ -1007,11 +1007,11 @@ dc.coordinateGridMixin = function (_chart) {
         return _chart;
     };
 
-    function brushHeight() {
+    function brushHeight () {
         return _chart.effectiveHeight();
     }
 
-    function brushWidth() {
+    function brushWidth () {
         return _chart.effectiveWidth();
     }
 
@@ -1035,12 +1035,12 @@ dc.coordinateGridMixin = function (_chart) {
     };
 
     _chart.setHandlePaths = function (gBrush) {
-        _brushHandles = gBrush.selectAll('.handle--custom').data([{type: "w"}, {type: "e"}]);
+        _brushHandles = gBrush.selectAll('.handle--custom').data([{type: 'w'}, {type: 'e'}]);
 
         _brushHandles = _brushHandles
             .enter()
             .append('path')
-            .attr("class", "handle--custom")
+            .attr('class', 'handle--custom')
             .attr('d', _chart.resizeHandlePath)
             .merge(_brushHandles);
     };
@@ -1062,7 +1062,7 @@ dc.coordinateGridMixin = function (_chart) {
         // Avoids infinite recursion
         // To ensure that when it is called because of brush.move there is no d3.event.sourceEvent
         d3.event = null;
-        if (!event.sourceEvent) return;
+        if (!event.sourceEvent) { return; }
         var selection = event.selection;
         if (selection) {
             selection = selection.map(_chart.x().invert);
@@ -1093,15 +1093,15 @@ dc.coordinateGridMixin = function (_chart) {
                 _brush.move(_gBrush, null);
 
                 _brushHandles
-                    .attr("display", "none");
+                    .attr('display', 'none');
             } else {
                 var scaledSelection = [_x(selection[0]), _x(selection[1])];
                 _brush.move(_gBrush, scaledSelection);
 
                 _brushHandles
-                    .attr("display", null)
-                    .attr("transform", function (d, i) {
-                        return "translate(" + _x(selection[i]) + ", 0)";
+                    .attr('display', null)
+                    .attr('transform', function (d, i) {
+                        return 'translate(' + _x(selection[i]) + ', 0)';
                     });
             }
         }
@@ -1280,7 +1280,7 @@ dc.coordinateGridMixin = function (_chart) {
     }
 
     function onZoom () {
-        if (!d3.event.sourceEvent && d3.event.sourceEvent.type !== "zoom") return;
+        if (!d3.event.sourceEvent && d3.event.sourceEvent.type !== 'zoom') { return; }
 
         _chart.x(d3.event.transform.rescaleX(_origX));
 
@@ -1356,7 +1356,7 @@ dc.coordinateGridMixin = function (_chart) {
         return _chart;
     };
 
-    function rangesEqual(range1, range2) {
+    function rangesEqual (range1, range2) {
         if (!range1 && !range2) {
             return true;
         } else if (!range1 || !range2) {

--- a/src/heatmap.js
+++ b/src/heatmap.js
@@ -240,7 +240,6 @@ dc.heatMap = function (parent, chartGroup) {
             .attr('width', boxWidth)
             .attr('height', boxHeight);
 
-
         var gCols = _chartBody.select('g.cols');
         if (gCols.empty()) {
             gCols = _chartBody.append('g').attr('class', 'cols axis');
@@ -266,7 +265,6 @@ dc.heatMap = function (parent, chartGroup) {
                .text(_chart.colsLabel())
                .attr('x', function (d) { return cols(d) + boxWidth / 2; })
                .attr('y', _chart.effectiveHeight());
-
 
         var gRows = _chartBody.select('g.rows');
         if (gRows.empty()) {

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -203,7 +203,7 @@ dc.lineChart = function (parent, chartGroup) {
 
     // Behavior of interpolator has changed in D3v4
     var _interpolateWithTension = function () {
-        return typeof _interpolate.tension === "function" ?
+        return typeof _interpolate.tension === 'function' ?
             _interpolate.tension(_tension) : _interpolate;
     };
 

--- a/src/scatter-plot.js
+++ b/src/scatter-plot.js
@@ -409,7 +409,7 @@ dc.scatterPlot = function (parent, chartGroup) {
         // Avoids infinite recursion
         // To ensure that when it is called because of brush.move there is no d3.event.sourceEvent
         d3.event = null;
-        if (!event.sourceEvent) return;
+        if (!event.sourceEvent) { return; }
         var selection = event.selection;
 
         // Testing with pixels is more reliable
@@ -421,7 +421,7 @@ dc.scatterPlot = function (parent, chartGroup) {
                     var scale = i === 0 ? _chart.x() : _chart.y();
                     return scale.invert(coord);
                 });
-            })
+            });
         }
         selection = _chart.extendBrush(selection);
 
@@ -456,7 +456,7 @@ dc.scatterPlot = function (parent, chartGroup) {
                         var scale = i === 0 ? _chart.x() : _chart.y();
                         return scale(coord);
                     });
-                })
+                });
             }
 
             _brush.move(_gBrush, selection);


### PR DESCRIPTION
I have excluded `src/d3v3-compat.js` from the checks - did not want to change external code. Also handled little differently unused functions warning in ` spec/coordinate-grid-chart-spec.js`

Thanks for your suggestion - now lint in run before commit.