### PR TITLE
Remove schemeCategory20c

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 3.0.0 alpha 10
+* `dc.config.defalutColors` as a mechanism to change default color scheme for all ordinal charts, By Deepak Kumar ([#1409](https://github.com/dc-js/dc.js/pull/1409)).
+* deprecate use of default color scheme `d3.schemeCategory20c`, which has been [removed in D3v5](https://github.com/d3/d3/blob/master/CHANGES.md#changes-in-d3-50). The defaults will change in DCv3.1. By Deepak Kumar ([#1409](https://github.com/dc-js/dc.js/pull/1409)).
+
 ## 3.0.0 alpha 9
 * `numberDisplay` uses [d3.easeQuad](https://github.com/d3/d3-ease/blob/master/README.md#easeQuad) instead of [quad-out-in](https://github.com/d3/d3-3.x-api-reference/blob/master/Transitions.md#d3_ease), which didn't make sense. ([#1413](https://github.com/dc-js/dc.js/pull/1413))
 * `dc.units.ordinal` is now purely a placeholder or magic value, and not called as a function. Previously dc.js would call the `xUnits` function with three arguments: the start, end, and domain array, but this was not compliant with d3 range functions. Now these functions are called with only the start and end, and `dc.units.ordinal` is detected with `===`. ([#1410](https://github.com/dc-js/dc.js/pull/1410))

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -489,6 +489,7 @@ module.exports.jsFiles = [
     'src/errors.js',
     'src/utils.js',
     'src/logger.js',
+    'src/config.js',
     'src/events.js',
     'src/filters.js',
     'src/base-mixin.js',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -471,7 +471,7 @@ module.exports = function (grunt) {
     grunt.registerTask('build', ['concat', 'sass', 'uglify', 'cssmin']);
     grunt.registerTask('docs', ['build', 'copy', 'jsdoc', 'jsdoc2md', 'docco', 'fileindex']);
     grunt.registerTask('web', ['docs', 'gh-pages']);
-    grunt.registerTask('server', ['docs', 'fileindex', 'connect:server', 'watch:scripts-sass-docs']);
+    grunt.registerTask('server', ['docs', 'fileindex', 'jasmine:specs:build', 'connect:server', 'watch:scripts-sass-docs']);
     grunt.registerTask('test', ['build', 'copy', 'karma:unit']);
     // grunt.registerTask('test-browserify', ['build', 'copy', 'browserify', 'jasmine:browserify']);
     grunt.registerTask('coverage', ['build', 'copy', 'karma:coverage']);

--- a/spec/color-spec.js
+++ b/spec/color-spec.js
@@ -7,6 +7,25 @@ describe('dc.colorMixin', function () {
 
     function identity (d) { return d; }
 
+    describe('deprecation', function () {
+        it('issues a one time warning when using default color scheme', function () {
+            spyOn(dc.logger, 'warnOnce');
+
+            dc.colorMixin({});
+
+            expect(dc.logger.warnOnce).toHaveBeenCalled();
+        });
+
+        it('does not issue a warning when default color scheme has been changed', function () {
+            spyOn(dc.logger, 'warnOnce');
+
+            dc.config.defaultColors(d3.schemeSet1);
+            dc.colorMixin({});
+
+            expect(dc.logger.warnOnce).not.toHaveBeenCalled();
+        });
+    });
+
     describe('with ordinal domain' , function () {
         var chart, domain;
 

--- a/spec/color-spec.js
+++ b/spec/color-spec.js
@@ -1,4 +1,4 @@
-/* global loadDateFixture */
+/* global loadDateFixture, standardColors */
 describe('dc.colorMixin', function () {
     function colorTest (chart, domain, test) {
         chart.colorDomain(domain);
@@ -17,7 +17,9 @@ describe('dc.colorMixin', function () {
         });
 
         it('default', function () {
-            expect(colorTest(chart, domain)).toMatchColors(['#3182bd','#6baed6','#9ecae1','#c6dbef','#e6550d']);
+            expect(colorTest(chart, domain))
+                .toMatchColors([standardColors[0], standardColors[1],
+                    standardColors[2], standardColors[3], standardColors[4]]);
         });
 
         it('custom', function () {
@@ -48,7 +50,8 @@ describe('dc.colorMixin', function () {
         });
 
         it('default', function () {
-            expect(colorTest(chart, domain, test)).toMatchColors(['#9ecae1','#3182bd','#c6dbef','#6baed6','#e6550d','#3182bd']);
+            expect(colorTest(chart, domain, test)).toMatchColors([standardColors[2], standardColors[0],
+                standardColors[3], standardColors[1], standardColors[4], standardColors[0]]);
         });
 
         it('custom', function () {

--- a/spec/helpers/custom_matchers.js
+++ b/spec/helpers/custom_matchers.js
@@ -149,6 +149,11 @@ function compareIntList (actual, expected) {
     return {pass: true};
 }
 
+function normalizeColor (c) {
+    // will convert to rgb(0, 0, 0)
+    return d3.color(c).toString();
+}
+
 beforeEach(function () {
     jasmine.addMatchers({
         toBeWithinDelta: function (_) {
@@ -222,14 +227,19 @@ beforeEach(function () {
                 compare: compareIntList
             };
         },
+        toMatchColor: function () {
+            return {
+                compare: function (actual, expected) {
+                    // Colors can be rgb(0, 0, 0), #000000 or black
+                    expect(normalizeColor(actual)).toEqual(normalizeColor(expected));
+                    return {pass: true};
+                }
+            };
+        },
         toMatchColors: function () {
             return {
                 compare: function (actual, expected) {
                     // Colors can be rgb(0, 0, 0), #000000 or black
-                    var normalizeColor = function (c) {
-                        // will convert to rgb(0, 0, 0)
-                        return d3.color(c).toString();
-                    };
                     actual = actual.map(normalizeColor);
                     expected = expected.map(normalizeColor);
 

--- a/spec/helpers/standard-colors.js
+++ b/spec/helpers/standard-colors.js
@@ -1,8 +1,0 @@
-/* exported standardColors */
-
-/* Use these in tests to avoid breaking tests if default colors are changed */
-var standardColors = [
-    '#e41a1c', '#377eb8', '#4daf4a',
-    '#984ea3', '#ff7f00', '#ffff33',
-    '#a65628', '#f781bf', '#999999'
-];

--- a/spec/helpers/standard-colors.js
+++ b/spec/helpers/standard-colors.js
@@ -1,0 +1,8 @@
+/* exported standardColors */
+
+/* Use these in tests to avoid breaking tests if default colors are changed */
+var standardColors = [
+    '#e41a1c', '#377eb8', '#4daf4a',
+    '#984ea3', '#ff7f00', '#ffff33',
+    '#a65628', '#f781bf', '#999999'
+];

--- a/spec/pie-chart-spec.js
+++ b/spec/pie-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate */
+/* global appendChartID, loadDateFixture, makeDate, standardColors */
 describe('dc.pieChart', function () {
     var width = 200;
     var height = 200;
@@ -157,10 +157,10 @@ describe('dc.pieChart', function () {
             });
         });
         it('slice path fill should be set correctly', function () {
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[0]).attr('fill')).toMatch(/#3182bd/i);
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[1]).attr('fill')).toMatch(/#6baed6/i);
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[2]).attr('fill')).toMatch(/#9ecae1/i);
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[3]).attr('fill')).toMatch(/#c6dbef/i);
+            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[0]).attr('fill')).toMatchColor(standardColors[0]);
+            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[1]).attr('fill')).toMatchColor(standardColors[1]);
+            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[2]).attr('fill')).toMatchColor(standardColors[2]);
+            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[3]).attr('fill')).toMatchColor(standardColors[3]);
         });
         it('slice label should be created', function () {
             expect(chart.selectAll('svg text.pie-slice').data().length).toEqual(5);

--- a/spec/pie-chart-spec.js
+++ b/spec/pie-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate, standardColors */
+/* global appendChartID, loadDateFixture, makeDate */
 describe('dc.pieChart', function () {
     var width = 200;
     var height = 200;
@@ -157,10 +157,11 @@ describe('dc.pieChart', function () {
             });
         });
         it('slice path fill should be set correctly', function () {
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[0]).attr('fill')).toMatchColor(standardColors[0]);
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[1]).attr('fill')).toMatchColor(standardColors[1]);
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[2]).attr('fill')).toMatchColor(standardColors[2]);
-            expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[3]).attr('fill')).toMatchColor(standardColors[3]);
+            var numSlices = 5;
+            for (var i = 0; i < numSlices; i++) {
+                expect(d3.select(chart.selectAll('g.pie-slice path').nodes()[i]).attr('fill'))
+                    .toMatchColor(dc.config.defaultColors()[i]);
+            }
         });
         it('slice label should be created', function () {
             expect(chart.selectAll('svg text.pie-slice').data().length).toEqual(5);

--- a/spec/row-chart-spec.js
+++ b/spec/row-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate, standardColors */
+/* global appendChartID, loadDateFixture, makeDate */
 describe('dc.rowChart', function () {
     var id, chart;
     var data, dimension, nvdimension;
@@ -117,11 +117,10 @@ describe('dc.rowChart', function () {
                 });
 
                 it('should fill each row rect with pre-defined colors', function () {
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[0]).attr('fill')).toMatchColor(standardColors[0]);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[1]).attr('fill')).toMatchColor(standardColors[1]);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[2]).attr('fill')).toMatchColor(standardColors[2]);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[3]).attr('fill')).toMatchColor(standardColors[3]);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[4]).attr('fill')).toMatchColor(standardColors[4]);
+                    for (var i = 0; i < N; i++) {
+                        expect(d3.select(chart.selectAll('g.row rect').nodes()[i]).attr('fill'))
+                            .toMatchColor(dc.config.defaultColors()[i]);
+                    }
                 });
 
                 it('should create a row label from the data for each row', function () {

--- a/spec/row-chart-spec.js
+++ b/spec/row-chart-spec.js
@@ -1,4 +1,4 @@
-/* global appendChartID, loadDateFixture, makeDate */
+/* global appendChartID, loadDateFixture, makeDate, standardColors */
 describe('dc.rowChart', function () {
     var id, chart;
     var data, dimension, nvdimension;
@@ -117,11 +117,11 @@ describe('dc.rowChart', function () {
                 });
 
                 it('should fill each row rect with pre-defined colors', function () {
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[0]).attr('fill')).toMatch(/#3182bd/i);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[1]).attr('fill')).toMatch(/#6baed6/i);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[2]).attr('fill')).toMatch(/#9ecae1/i);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[3]).attr('fill')).toMatch(/#c6dbef/i);
-                    expect(d3.select(chart.selectAll('g.row rect').nodes()[4]).attr('fill')).toMatch(/#e6550d/i);
+                    expect(d3.select(chart.selectAll('g.row rect').nodes()[0]).attr('fill')).toMatchColor(standardColors[0]);
+                    expect(d3.select(chart.selectAll('g.row rect').nodes()[1]).attr('fill')).toMatchColor(standardColors[1]);
+                    expect(d3.select(chart.selectAll('g.row rect').nodes()[2]).attr('fill')).toMatchColor(standardColors[2]);
+                    expect(d3.select(chart.selectAll('g.row rect').nodes()[3]).attr('fill')).toMatchColor(standardColors[3]);
+                    expect(d3.select(chart.selectAll('g.row rect').nodes()[4]).attr('fill')).toMatchColor(standardColors[4]);
                 });
 
                 it('should create a row label from the data for each row', function () {

--- a/src/color-mixin.js
+++ b/src/color-mixin.js
@@ -8,7 +8,7 @@
  * @returns {dc.colorMixin}
  */
 dc.colorMixin = function (_chart) {
-    var _colors = d3.scaleOrdinal(d3.schemeCategory20c);
+    var _colors = d3.scaleOrdinal(dc.config.compatColors ? dc.config.compatColors : d3.schemeSet1);
     var _defaultAccessor = true;
 
     var _colorAccessor = function (d) { return _chart.keyAccessor()(d); };

--- a/src/color-mixin.js
+++ b/src/color-mixin.js
@@ -8,7 +8,7 @@
  * @returns {dc.colorMixin}
  */
 dc.colorMixin = function (_chart) {
-    var _colors = d3.scaleOrdinal(dc.config.compatColors ? dc.config.compatColors : d3.schemeSet1);
+    var _colors = d3.scaleOrdinal(dc.config.defaultColors());
     var _defaultAccessor = true;
 
     var _colorAccessor = function (d) { return _chart.keyAccessor()(d); };

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,44 @@
+/**
+ * General configuration
+ *
+ * @class config
+ * @memberof dc
+ * @returns {dc.config}
+ */
+dc.config = (function () {
+    var _config = {};
+
+    var _useV2CompatColorScheme = false;
+    _config.compatColors = null;
+    var _schemeCategory20c = [
+        '#3182bd', '#6baed6', '#9ecae1', '#c6dbef', '#e6550d',
+        '#fd8d3c', '#fdae6b', '#fdd0a2', '#31a354', '#74c476',
+        '#a1d99b', '#c7e9c0', '#756bb1', '#9e9ac8', '#bcbddc',
+        '#dadaeb', '#636363', '#969696', '#bdbdbd', '#d9d9d9'];
+
+    /**
+     * Set this flag to use DCv2's color scheme (d3.schemeCategory20c).
+     * Please note this color scheme has been deprecated by D3
+     * (https://github.com/d3/d3/blob/master/CHANGES.md#changes-in-d3-50) as well as DC.
+     * @method useV2CompatColorScheme
+     * @memberof dc.config
+     * @instance
+     * @param {Boolean} [flag=false]
+     * @returns {Boolean|dc.config}
+     */
+    _config.useV2CompatColorScheme = function (flag) {
+        if (!arguments.length) {
+            return _useV2CompatColorScheme;
+        }
+        _useV2CompatColorScheme = flag;
+        if (_useV2CompatColorScheme) {
+            dc.logger.warn('Forcing use of d3.schemeCategory20c. It has been deprecated and will be removed in dc 3.1');
+            _config.compatColors = _schemeCategory20c;
+        }
+        return _config;
+    };
+
+    // _config.useV2CompatColorScheme(true);
+
+    return _config;
+})();

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,14 @@ dc.config = (function () {
      */
     _config.defaultColors = function (colors) {
         if (!arguments.length) {
+            // Issue warning if it uses _schemeCategory20c
+            if (_defaultColors === _schemeCategory20c) {
+                dc.logger.warnOnce('You are using d3.schemeCategory20c; which has been removed in D3v5. ' +
+                    'See the explanation at https://github.com/d3/d3/blob/master/CHANGES.md#changes-in-d3-50. ' +
+                    'DC is using it for backward compatibility, however it will be changed in DCv3.1. ' +
+                    'You can change it by calling dc.config.defaultColors(newScheme). ' +
+                    'See https://github.com/d3/d3-scale-chromatic for some alternatives.');
+            }
             return _defaultColors;
         }
         _defaultColors = colors;

--- a/src/config.js
+++ b/src/config.js
@@ -8,37 +8,38 @@
 dc.config = (function () {
     var _config = {};
 
-    var _useV2CompatColorScheme = false;
-    _config.compatColors = null;
+    // D3v5 has removed schemeCategory20c, copied here for backward compatibility
     var _schemeCategory20c = [
         '#3182bd', '#6baed6', '#9ecae1', '#c6dbef', '#e6550d',
         '#fd8d3c', '#fdae6b', '#fdd0a2', '#31a354', '#74c476',
         '#a1d99b', '#c7e9c0', '#756bb1', '#9e9ac8', '#bcbddc',
         '#dadaeb', '#636363', '#969696', '#bdbdbd', '#d9d9d9'];
 
+    var _defaultColors = _schemeCategory20c;
+
     /**
-     * Set this flag to use DCv2's color scheme (d3.schemeCategory20c).
-     * Please note this color scheme has been deprecated by D3
-     * (https://github.com/d3/d3/blob/master/CHANGES.md#changes-in-d3-50) as well as DC.
-     * @method useV2CompatColorScheme
+     * Set the default color scheme for ordinal charts. Changing it will impact all ordinal charts.
+     *
+     * By default it is set to
+     * (d3.schemeCategory20c) for backward compatibility. This color scheme has been
+     * removed from D3v5 (https://github.com/d3/d3/blob/master/CHANGES.md#changes-in-d3-50).
+     * In DC 3.1 release it will change to a more appropriate default.
+     *
+     * @example
+     * dc.config.defaultColors(d3.schemeSet1)
+     * @method defaultColors
      * @memberof dc.config
      * @instance
-     * @param {Boolean} [flag=false]
-     * @returns {Boolean|dc.config}
+     * @param {Array} [colors]
+     * @returns {Array|dc.config}
      */
-    _config.useV2CompatColorScheme = function (flag) {
+    _config.defaultColors = function (colors) {
         if (!arguments.length) {
-            return _useV2CompatColorScheme;
+            return _defaultColors;
         }
-        _useV2CompatColorScheme = flag;
-        if (_useV2CompatColorScheme) {
-            dc.logger.warn('Forcing use of d3.schemeCategory20c. It has been deprecated and will be removed in dc 3.1');
-            _config.compatColors = _schemeCategory20c;
-        }
+        _defaultColors = colors;
         return _config;
     };
-
-    // _config.useV2CompatColorScheme(true);
 
     return _config;
 })();

--- a/src/d3v3-compat.js
+++ b/src/d3v3-compat.js
@@ -88,12 +88,3 @@ d3.stackD3v3 = function () {
         return stack;
     }
 }();
-
-// d3v4 Compat
-if (!d3.schemeCategory20c) {
-    d3.schemeCategory20c = [
-        '#3182bd', '#6baed6', '#9ecae1', '#c6dbef', '#e6550d',
-        '#fd8d3c', '#fdae6b', '#fdd0a2', '#31a354', '#74c476',
-        '#a1d99b', '#c7e9c0', '#756bb1', '#9e9ac8', '#bcbddc',
-        '#dadaeb', '#636363', '#969696', '#bdbdbd', '#d9d9d9'];
-}


### PR DESCRIPTION
This PR contains following:

- Concept of `dc.config`, which will be a single instance object. It currently holds one setting and one variable. Please see if you are ok with the concept.
- For backward compatibility, following needs to be added before creating charts:
```javascript
    dc.config.useV2CompatColorScheme(true);
```
- Concept of standard colors in specs. This will help us in minimizing breakage when making global changes in color palette.
- A special matcher for color which covers more cases than a reg ex.
- Enabled back `index.html` generation in `specs` folder, this allows to run test cases interactively by going to http://localhost:8888/spec/ - useful for interactive debugging.

Charts work but they do look different :)

