### PR TITLE
dc.logger enhacements

### DIFF
--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -77,4 +77,56 @@ describe('dc.logger', function () {
             });
         });
     });
+
+    describe('deprecate', function () {
+        var dummy, wrappedFn;
+
+        beforeEach(function () {
+            dummy = {
+                origFn: function () {
+                }
+            };
+            spyOn(dummy, 'origFn');
+            spyOn(dc.logger, 'warn');
+
+            wrappedFn = dc.logger.deprecate(dummy.origFn, 'origFn is deprecated');
+        });
+        it('should call deprecated function and issue a warning', function () {
+            wrappedFn('a');
+            expect(dummy.origFn).toHaveBeenCalledWith('a');
+            expect(dc.logger.warn).toHaveBeenCalled();
+        });
+        it('should warn for one deprecated function only once', function () {
+            wrappedFn();
+            wrappedFn();
+            expect(dummy.origFn.calls.count()).toBe(2);
+            expect(dc.logger.warn.calls.count()).toBe(1);
+        });
+    });
+
+    describe('warnOnce', function () {
+        beforeEach(function () {
+            spyOn(dc.logger, 'warn');
+        });
+
+        it('should warn only once for the same message', function () {
+            dc.logger.warnOnce('Message 01');
+            dc.logger.warnOnce('Message 01');
+
+            expect(dc.logger.warn.calls.count()).toBe(1);
+        });
+
+        // Please remember that during run of the entire test suite warnOnce remembers messages.
+        // So, ensure to use distinct messages in different test cases.
+        it('should warn only once each for different messages', function () {
+            dc.logger.warnOnce('Message 02');
+            dc.logger.warnOnce('Message 03');
+            dc.logger.warnOnce('Message 02');
+            dc.logger.warnOnce('Message 03');
+
+            expect(dc.logger.warn.calls.count()).toBe(2);
+            expect(dc.logger.warn.calls.argsFor(0)).toEqual(['Message 02']);
+            expect(dc.logger.warn.calls.argsFor(1)).toEqual(['Message 03']);
+        });
+    });
 });

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,40 +1,118 @@
-dc.logger = {};
+/**
+ * Provides basis logging and deprecation utilities
+ * @class logger
+ * @memberof dc
+ * @returns {dc.logger}
+ */
+dc.logger = (function () {
 
-dc.logger.enableDebugLog = false;
+    var _logger = {};
 
-dc.logger.warn = function (msg) {
-    if (console) {
-        if (console.warn) {
-            console.warn(msg);
-        } else if (console.log) {
-            console.log(msg);
+    /**
+     * Enable debug level logging. Set to `false` by default.
+     * @name enableDebugLog
+     * @memberof dc.logger
+     * @instance
+     */
+    _logger.enableDebugLog = false;
+
+    /**
+     * Put a warning message to console
+     * @method warn
+     * @memberof dc.logger
+     * @instance
+     * @example
+     * dc.logger.warn('Invalid use of .tension on CurveLinear');
+     * @param {String} [msg]
+     * @returns {dc.logger}
+     */
+    _logger.warn = function (msg) {
+        if (console) {
+            if (console.warn) {
+                console.warn(msg);
+            } else if (console.log) {
+                console.log(msg);
+            }
         }
-    }
 
-    return dc.logger;
-};
+        return _logger;
+    };
 
-dc.logger.debug = function (msg) {
-    if (dc.logger.enableDebugLog && console) {
-        if (console.debug) {
-            console.debug(msg);
-        } else if (console.log) {
-            console.log(msg);
-        }
-    }
+    var _alreadyWarned = {};
 
-    return dc.logger;
-};
+    /**
+     * Put a warning message to console. It will warn only on unique messages.
+     * @method warnOnce
+     * @memberof dc.logger
+     * @instance
+     * @example
+     * dc.logger.warnOnce('Invalid use of .tension on CurveLinear');
+     * @param {String} [msg]
+     * @returns {dc.logger}
+     */
+    _logger.warnOnce = function (msg) {
+        if (!_alreadyWarned[msg]) {
+            _alreadyWarned[msg] = true;
 
-dc.logger.deprecate = function (fn, msg) {
-    // Allow logging of deprecation
-    var warned = false;
-    function deprecated () {
-        if (!warned) {
             dc.logger.warn(msg);
-            warned = true;
         }
-        return fn.apply(this, arguments);
-    }
-    return deprecated;
-};
+
+        return _logger;
+    };
+
+    /**
+     * Put a debug message to console. It is controlled by `dc.logger.enableDebugLog`
+     * @method debug
+     * @memberof dc.logger
+     * @instance
+     * @example
+     * dc.logger.debug('Total number of slices: ' + numSlices);
+     * @param {String} [msg]
+     * @returns {dc.logger}
+     */
+    _logger.debug = function (msg) {
+        if (_logger.enableDebugLog && console) {
+            if (console.debug) {
+                console.debug(msg);
+            } else if (console.log) {
+                console.log(msg);
+            }
+        }
+
+        return _logger;
+    };
+
+    /**
+     * Use it to deprecate a function. It will return a wrapped version of the function, which will
+     * will issue a warning when invoked. For each function, warning will be issued only once.
+     *
+     * @method deprecate
+     * @memberof dc.logger
+     * @instance
+     * @example
+     * _chart.interpolate = dc.logger.deprecate(function (interpolate) {
+     *    if (!arguments.length) {
+     *        return _interpolate;
+     *    }
+     *    _interpolate = interpolate;
+     *    return _chart;
+     * }, 'dc.lineChart.interpolate has been deprecated since version 3.0 use dc.lineChart.curve instead');
+     * @param {Function} [fn]
+     * @param {String} [msg]
+     * @returns {Function}
+     */
+    _logger.deprecate = function (fn, msg) {
+        // Allow logging of deprecation
+        var warned = false;
+        function deprecated () {
+            if (!warned) {
+                _logger.warn(msg);
+                warned = true;
+            }
+            return fn.apply(this, arguments);
+        }
+        return deprecated;
+    };
+
+    return _logger;
+})();


### PR DESCRIPTION
- new function `dc.logger.warnOnce`
- update code structure to somewhat similar to rest of dc
- add missing test cases for `dc.logger.deprecate`
- add documentation for `dc.logger`

I am planning to use `dc.logger.warnOnce` for #1409 