### PR TITLE
Number display transition

### DIFF
--- a/src/number-display.js
+++ b/src/number-display.js
@@ -110,7 +110,7 @@ dc.numberDisplay = function (parent, chartGroup) {
         span.transition()
             .duration(_chart.transitionDuration())
             .delay(_chart.transitionDelay())
-            .ease(d3.easeQuadIn)
+            .ease(d3.easeQuad)
             .tween('text', function () {
                 // [XA] don't try and interpolate from Infinity, else this breaks.
                 var interpStart = isFinite(_lastValue) ? _lastValue : 0;


### PR DESCRIPTION
Your suggestion makes sense. 'quad-out-in' was not proper and may be the reason that D3v4 removed it. Changed it to `d3.easeQuad`.