### PR TITLE
pie-chart code cleanup

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -115,10 +115,7 @@ dc.pieChart = function (parent, chartGroup) {
 
             removeElements(slices, labels);
 
-            // Uglify does not like array assignments
-            var t = createElements(slices, labels, arc, pieData);
-            slices = t[0];
-            labels = t[1];
+            createElements(slices, labels, arc, pieData);
 
             updateElements(pieData, arc);
 
@@ -130,19 +127,13 @@ dc.pieChart = function (parent, chartGroup) {
     }
 
     function createElements (slices, labels, arc, pieData) {
-
-        // Uglify does not like array assignments
-        var t = createSliceNodes(slices);
-        var slicesEnter = t[0];
-        slices = t[1];
+        var slicesEnter = createSliceNodes(slices);
 
         createSlicePath(slicesEnter, arc);
 
         createTitles(slicesEnter);
 
-        labels = createLabels(labels, pieData, arc);
-
-        return [slices, labels];
+        createLabels(labels, pieData, arc);
     }
 
     function createSliceNodes (slices) {
@@ -152,9 +143,7 @@ dc.pieChart = function (parent, chartGroup) {
             .attr('class', function (d, i) {
                 return _sliceCssClass + ' _' + i;
             });
-
-        slices = slicesEnter.merge(slices);
-        return [slicesEnter, slices];
+        return slicesEnter;
     }
 
     function createSlicePath (slicesEnter, arc) {
@@ -227,16 +216,12 @@ dc.pieChart = function (parent, chartGroup) {
             if (_externalLabelRadius && _drawPaths) {
                 updateLabelPaths(pieData, arc);
             }
-
-            labels = labelsEnter.merge(labels);
         }
-
-        return labels;
     }
 
     function updateLabelPaths (pieData, arc) {
         var polyline = _g.selectAll('polyline.' + _sliceCssClass)
-            .data(pieData);
+                .data(pieData);
 
         polyline.exit().remove();
 


### PR DESCRIPTION
Fixes part of #1398. See https://github.com/dc-js/dc.js/issues/1398#issuecomment-379861299

Cleaned up pie-chart code, removed unnecessary return values. Code now much closer to DCv2.1 version.

Ready for review.