### PR TITLE
Mouse event sensors for bar charts

### DIFF
--- a/dc.css
+++ b/dc.css
@@ -11,6 +11,14 @@ div.dc-chart {
   .dc-chart rect.bar:hover {
     fill-opacity: .5; }
 
+.dc-chart .sensor rect.bar {
+  fill-opacity: 0;
+  stroke-opacity: 0;
+  stroke: none;
+  cursor: pointer; }
+  .dc-chart .sensor rect.bar:hover {
+    fill-opacity: .1; }
+
 .dc-chart rect.deselected {
   stroke: none;
   fill: #ccc; }


### PR DESCRIPTION
I'm really excited for the new version to be compatible with d3 v4/v5! Thanks for the update!

I'd like to propose the addition of mouse-sensor bars for the bar charts. These are 'hidden' bars that span the entire height of the chart, beyond the top of the visible bar. This is particularly helpful for bars with a small enough value that it is barely visible.

Note: this requires update to bar-chart.js as well as a css change that I made in dc.css - but may need to also be made elsewhere? And as you can see, I did not make any changes to dc.js, dc.min.js, or dc.min.css.