### PR TITLE
Replace `rangesEqual` with `dc.utils.arraysEqual`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## 3.0.4
+* Code cleanup - replaced `.rangesEqual` with `dc.utils.arraysEqual`, by Deepak Kumar ([#1436](https://github.com/dc-js/dc.js/pull/1436))
+
 ## 3.0.3
 * Update versions and release new fiddles and blocks pegged to dc@3 and d3@5
 

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -136,6 +136,11 @@ describe('dc utils', function () {
             var a2 = null;
             expect(dc.utils.arraysEqual(a1, a2)).toBe(true);
         });
+        it('null and undefined should be equal', function () {
+            var a1 = null;
+            var a2; // undefined
+            expect(dc.utils.arraysEqual(a1, a2)).toBe(true);
+        });
         it('null should not be equal to any array', function () {
             var a1 = null;
             var a2 = [];

--- a/src/coordinate-grid-mixin.js
+++ b/src/coordinate-grid-mixin.js
@@ -1306,7 +1306,7 @@ dc.coordinateGridMixin = function (_chart) {
         _chart.redraw();
 
         if (!noRaiseEvents) {
-            if (_rangeChart && !rangesEqual(_chart.filter(), _rangeChart.filter())) {
+            if (_rangeChart && !dc.utils.arraysEqual(_chart.filter(), _rangeChart.filter())) {
                 dc.events.trigger(function () {
                     _rangeChart.replaceFilter(domFilter);
                     _rangeChart.redraw();
@@ -1405,7 +1405,7 @@ dc.coordinateGridMixin = function (_chart) {
     };
 
     _chart.refocused = function () {
-        return !rangesEqual(_chart.x().domain(), _xOriginalDomain);
+        return !dc.utils.arraysEqual(_chart.x().domain(), _xOriginalDomain);
     };
 
     _chart.focusChart = function (c) {
@@ -1418,7 +1418,7 @@ dc.coordinateGridMixin = function (_chart) {
                 dc.events.trigger(function () {
                     _focusChart.x().domain(_focusChart.xOriginalDomain(), true);
                 });
-            } else if (!rangesEqual(chart.filter(), _focusChart.filter())) {
+            } else if (!dc.utils.arraysEqual(chart.filter(), _focusChart.filter())) {
                 dc.events.trigger(function () {
                     _focusChart.focus(chart.filter(), true);
                 });
@@ -1426,20 +1426,6 @@ dc.coordinateGridMixin = function (_chart) {
         });
         return _chart;
     };
-
-    function rangesEqual (range1, range2) {
-        if (!range1 && !range2) {
-            return true;
-        } else if (!range1 || !range2) {
-            return false;
-        } else if (range1.length === 0 && range2.length === 0) {
-            return true;
-        } else if (range1[0].valueOf() === range2[0].valueOf() &&
-            range1[1].valueOf() === range2[1].valueOf()) {
-            return true;
-        }
-        return false;
-    }
 
     /**
      * Turn on/off the brush-based range filter. When brushing is on then user can drag the mouse

--- a/src/utils.js
+++ b/src/utils.js
@@ -349,15 +349,19 @@ dc.utils.safeNumber = function (n) { return dc.utils.isNumber(+n) ? +n : 0;};
  * @returns {Boolean}
  */
 dc.utils.arraysEqual = function (a1, a2) {
+    if (!a1 && !a2) {
+        return true;
+    }
+
     if (!a1 || !a2) {
-        return a1 === a2;
+        return false;
     }
 
     return a1.length === a2.length &&
         // If elements are not integers/strings, we hope that it will match because of toString
         // Test cases cover dates as well.
         a1.every(function (elem, i) {
-            return elem === a2[i] || elem.toString() === a2[i].toString();
+            return elem.valueOf() === a2[i].valueOf();
         });
 };
 


### PR DESCRIPTION
Fixes #1405

Improved `dc.utils.arraysEqual` in the process. Now it is more defensive, added a new test as well.