### PR TITLE
Allow stroke to be used for line-chart data points

### DIFF
--- a/spec/line-chart-spec.js
+++ b/spec/line-chart-spec.js
@@ -45,7 +45,7 @@ describe('dc.lineChart', function () {
                 chart.selectAll('circle.dot').each(function () {
                     var dot = d3.select(this);
                     expect(dot.style('fill-opacity')).toBeWithinDelta(0.8);
-                    expect(dot.style('stroke-opacity')).toBeWithinDelta(0.8);
+                    expect(dot.style('stroke-opacity')).toBeWithinDelta(0.0);
                     expect(dot.attr('r')).toBe('2');
                 });
             });

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -391,6 +391,7 @@ dc.lineChart = function (parent, chartGroup) {
                         .style('fill-opacity', _dataPointFillOpacity)
                         .style('stroke-opacity', _dataPointStrokeOpacity)
                         .attr('fill', _chart.getColor)
+                        .attr('stroke', _chart.getColor)
                         .on('mousemove', function () {
                             var dot = d3.select(this);
                             showDot(dot);
@@ -546,8 +547,8 @@ dc.lineChart = function (parent, chartGroup) {
      * @memberof dc.lineChart
      * @instance
      * @example
-     * chart.renderDataPoints({radius: 2, fillOpacity: 0.8, strokeOpacity: 0.8})
-     * @param  {{fillOpacity: Number, strokeOpacity: Number, radius: Number}} [options={fillOpacity: 0.8, strokeOpacity: 0.8, radius: 2}]
+     * chart.renderDataPoints({radius: 2, fillOpacity: 0.8, strokeOpacity: 0.0})
+     * @param  {{fillOpacity: Number, strokeOpacity: Number, radius: Number}} [options={fillOpacity: 0.8, strokeOpacity: 0.0, radius: 2}]
      * @returns {{fillOpacity: Number, strokeOpacity: Number, radius: Number}|dc.lineChart}
      */
     _chart.renderDataPoints = function (options) {
@@ -563,7 +564,7 @@ dc.lineChart = function (parent, chartGroup) {
             _dataPointRadius = null;
         } else {
             _dataPointFillOpacity = options.fillOpacity || 0.8;
-            _dataPointStrokeOpacity = options.strokeOpacity || 0.8;
+            _dataPointStrokeOpacity = options.strokeOpacity || 0.0;
             _dataPointRadius = options.radius || 2;
         }
         return _chart;

--- a/style/dc.scss
+++ b/style/dc.scss
@@ -250,9 +250,6 @@ div.dc-chart {
             cursor: default;
         }
     }
-    circle.dot {
-        stroke: none;
-    }
 }
 
 .dc-data-count {


### PR DESCRIPTION
remove stroke: none css rule for circle.dot, add stroke attribute to line-chart dataPoints and set default value for dataPoints.strokeOpacity to 0.0, update line-chart-spec test for default options

see [#1447](https://github.com/dc-js/dc.js/issues/1447)