### PR TITLE
move .exit before .enter to fix removal of bubbles on redraw

### DIFF
--- a/src/bubble-chart.js
+++ b/src/bubble-chart.js
@@ -48,11 +48,11 @@ dc.bubbleChart = function (parent, chartGroup) {
             bubbleG.order();
         }
 
+	removeNodes(bubbleG);
+
         bubbleG = renderNodes(bubbleG);
 
         updateNodes(bubbleG);
-
-        removeNodes(bubbleG);
 
         _chart.fadeDeselectedArea(_chart.filter());
     };


### PR DESCRIPTION
I am having the same issue with the bubble chart as was fixed with the scatter chart in this pr: https://github.com/dc-js/dc.js/pull/1463/files. Basically when I would call `redraw()` on a bubble chart and pass in a new group it would update the existing bubbles, but if any were removed from the group... they would not be removed. 

This pr moves the removeNodes before the update and it resolves the issue. 

I did notice it doesn't seem to be an issue here: https://dc-js.github.io/dc.js/, but I tried 1000 different ways in my code base and each time the bubbles would not be removed until I reordered the .exit and .enter. My only guess is that I'm calling .redraw() on a chart and in the demo that's somehow happening internally? Not really sure. 

Related issue (scatter plots) https://github.com/dc-js/dc.js/issues/1460