### PR TITLE
Filter printer does not correctly print out multi-element filters

### DIFF
--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -46,6 +46,9 @@ describe('dc utils', function () {
         it('print zero', function () {
             expect(printer(0)).toEqual(0);
         });
+        it('print a multi-element array', function () {
+            expect(printer(['this', 'that', 'and', 'the', 'other'])).toEqual('[this -> that -> and -> the -> other]');
+        });
     });
 
     describe('dc.utils.nameToId', function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,9 @@ dc.printers.filter = function (filter) {
     if (typeof filter !== 'undefined' && filter !== null) {
         if (filter instanceof Array) {
             if (filter.length >= 2) {
-                s = '[' + dc.utils.printSingleValue(filter[0]) + ' -> ' + dc.utils.printSingleValue(filter[1]) + ']';
+                s = '[' + filter.map(function (e) {
+                    return dc.utils.printSingleValue(e);
+                }).join(' -> ') + ']';
             } else if (filter.length >= 1) {
                 s = dc.utils.printSingleValue(filter[0]);
             }

--- a/web/stock.js
+++ b/web/stock.js
@@ -32,9 +32,10 @@ var nasdaqTable = dc.dataTable('.dc-data-table');
 // set on the chart (e.g. slice selection for pie chart and brush
 // selection for bar chart). Enable this with `chart.turnOnControls(true)`
 
-// dc.js >=2.1 uses `visibility: hidden` to hide/show controls without
-// disrupting the layout. To return the old `display: none` behavior,
-// set `chart.controlsUseVisibility(false)` and use that style instead.
+// By default, dc.js >=2.1 uses `display: none` to control whether or not chart
+// controls are shown. To use `visibility: hidden` to hide/show controls
+// without disrupting the layout, set `chart.controlsUseVisibility(true)`.
+
     <div id='chart'>
        <a class='reset'
           href='javascript:myChart.filterAll();dc.redrawAll();'


### PR DESCRIPTION
When using a hierarchical chart (the sunburst chart) where the filtered dimension is an array, the filter printer only prints out the first two members of the array. This alters the printer so every element of the array is printed out.

Apologies for the odd commit history; I accidentally reused an old branch.

Added a fix for [#1474](https://github.com/dc-js/dc.js/issues/1474), altering the documentation in `stock.js` for `chart.controlsUseVisibility`.