### PR TITLE
Example - Table with other widget

### DIFF
--- a/web/examples/index.html
+++ b/web/examples/index.html
@@ -78,6 +78,7 @@ here</a>.</p>
     <td><a href="table-pagination.html">table pagination</a></td>
   </tr>
   <tr>
+    <td><a href="table-with-other-widgets.html">table with other widgets</a></td>
     <td><a href="text-filter-widget.html">text filter widget</a></td>
     <td><a href="time-intervals.html">time intervals</a></td>
   </tr>

--- a/web/examples/table-with-other-widgets.html
+++ b/web/examples/table-with-other-widgets.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>dc.js - Table of Aggregated Data</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="../css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="../css/dc.css"/>
+</head>
+<body>
+
+  <div class="container">
+    <script type="text/javascript" src="header.js"></script>
+      
+    <div class="row">
+      <div id="piechart"><h4>Expt:</h4>
+        <div class="reset" style="visibility: hidden;">selected: <span class="filter"></span>
+          <a href="javascript:piechart.filterAll();dc.redrawAll();">reset</a>
+        </div>
+      </div>      
+    </div>
+    <div class="row">
+      <div id="paging">
+        Showing <span id="begin"></span>-<span id="end"></span> of <span id="size"></span> <span id="totalsize"></span>
+        <input id="last" class="btn" type="Button" value="Last" onclick="javascript:last()" />
+        <input id="next" class="btn" type="button" value="Next" onclick="javascript:next()"/>
+      </div>
+      <table id="test" class="table table-striped"></table>
+    </div>
+  
+    <script type="text/javascript" src="../js/d3.js"></script>
+    <script type="text/javascript" src="../js/crossfilter.js"></script>
+    <script type="text/javascript" src="../js/dc.js"></script>
+    <script type="text/javascript">
+
+      var chart = dc.dataTable("#test");
+      var piechart = dc.pieChart("#piechart");
+
+      var ndx;
+      d3.csv("morley.csv").then(function(experiments) {
+        ndx = crossfilter(experiments);
+        var fmt = d3.format('02d');
+        var runDimension = ndx.dimension(function(d) {return [fmt(+d.Expt),fmt(+d.Run)];}),
+        experimentDimension = ndx.dimension(function(d) {return d.Expt;}),
+        grouping = function (d) {return d.Expt;},
+        experimentGroup = experimentDimension.group().reduceCount();
+
+        piechart.width(300).height(280)
+          .innerRadius(100).externalLabels(50).externalRadiusPadding(50).drawPaths(true)
+          .dimension(experimentDimension).group(experimentGroup)
+          .legend(dc.legend())
+          .controlsUseVisibility(true)
+          .on('filtered', function(chart, filter){update();});
+
+        chart
+          .width(300)
+          .height(480)
+          .dimension(runDimension)
+          .group(grouping)
+          .size(Infinity)
+          .showGroups(false)
+          .columns(['Expt', 'Run', 'Speed'])
+          .sortBy(function (d) { return [fmt(+d.Expt),fmt(+d.Run)]; })
+          .order(d3.ascending);
+
+        update();
+        dc.renderAll();
+      });
+
+      // use odd page size to show the effect better
+      var ofs = 0, pag = 17;
+      function display() {
+
+          var totFilteredRecs = ndx.groupAll().value();
+          var end = ofs + pag > totFilteredRecs ? totFilteredRecs : ofs + pag;
+          ofs = ofs >= totFilteredRecs ? Math.floor((totFilteredRecs - 1) / pag) * pag : ofs;
+          ofs = ofs < 0 ? 0 : ofs;
+
+          d3.select('#begin')
+              .text(end === 0? ofs : ofs + 1);
+          d3.select('#end')
+              .text(end);
+          d3.select('#last')
+              .attr('disabled', ofs-pag<0 ? 'true' : null);
+          d3.select('#next')
+              .attr('disabled', ofs+pag>=totFilteredRecs ? 'true' : null);
+          d3.select('#size').text(totFilteredRecs);
+          if(totFilteredRecs != ndx.size()){
+            d3.select('#totalsize').text("(filtered Total: " + ndx.size() + " )"); 
+          }else{
+            d3.select('#totalsize').text(''); 
+          }
+      }
+      function update() {
+          chart.beginSlice(ofs);
+          chart.endSlice(ofs+pag);
+          display();
+      }
+      function next() {
+          ofs += pag;
+          update();
+          chart.redraw();
+      }
+      function last() {
+          ofs -= pag;
+          update();
+          chart.redraw();
+      }
+
+    </script>
+
+  </div>
+</body>
+</html>

--- a/web/examples/table-with-other-widgets.html
+++ b/web/examples/table-with-other-widgets.html
@@ -49,7 +49,7 @@
           .dimension(experimentDimension).group(experimentGroup)
           .legend(dc.legend())
           .controlsUseVisibility(true)
-          .on('filtered', function(chart, filter){update();});
+          .on('filtered', function(chart, filter){update(true);});
 
         chart
           .width(300)
@@ -90,7 +90,10 @@
             d3.select('#totalsize').text(''); 
           }
       }
-      function update() {
+      function update(reset=false) {
+          if(reset){
+            ofs=0;
+          }
           chart.beginSlice(ofs);
           chart.endSlice(ofs+pag);
           display();


### PR DESCRIPTION
Expanded table pagination example with interaction with other widget and filtered|total item count

based on: https://www.intothevoid.io/data-visualization/sortable-table-dc-js/ 