### PR TITLE
Remove polyfill code fragments

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -437,24 +437,3 @@ export const renderlet = function (_) {
 export const instanceOfChart = function (o) {
     return o instanceof Object && o.__dcFlag__ && true;
 };
-
-/* ES6: probably can be dropped */
-// polyfill for IE
-// from https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
-if (!Element.prototype.matches) {
-    Element.prototype.matches =
-        Element.prototype.matchesSelector ||
-        Element.prototype.mozMatchesSelector ||
-        Element.prototype.msMatchesSelector ||
-        Element.prototype.oMatchesSelector ||
-        Element.prototype.webkitMatchesSelector ||
-        function (s) {
-            var matches = (this.document || this.ownerDocument).querySelectorAll(s),
-                i = matches.length;
-            do {
-                --i;
-            }
-            while (i >= 0 && matches.item(i) !== this);
-            return i > -1;
-        };
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -447,34 +447,3 @@ utils.arraysIdentical = function (a, b) {
     }
     return true;
 };
-
-/* ES6: can be dropped, works on all except IE */
-if (typeof Object.assign !== 'function') {
-    // Must be writable: true, enumerable: false, configurable: true
-    Object.defineProperty(Object, 'assign', {
-        value: function assign (target, varArgs) { // .length of function is 2
-            'use strict';
-            if (target === null) { // TypeError if undefined or null
-                throw new TypeError('Cannot convert undefined or null to object');
-            }
-
-            var to = Object(target);
-
-            for (var index = 1; index < arguments.length; index++) {
-                var nextSource = arguments[index];
-
-                if (nextSource !== null) { // Skip over if undefined or null
-                    for (var nextKey in nextSource) {
-                        // Avoid bugs when hasOwnProperty is shadowed
-                        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-                            to[nextKey] = nextSource[nextKey];
-                        }
-                    }
-                }
-            }
-            return to;
-        },
-        writable: true,
-        configurable: true
-    });
-}


### PR DESCRIPTION
In ES6 modules it is not desirable to keep code that causes side effects during load. This implies that polyfill code should not be inside a module.

The current polyfills only target IE browsers, so, these can be removed. If someone does want to use this with IE, we can put documentation in how they can add required polyfills.