### PR TITLE
Configure `grunt test` to use Firefox headless

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -195,7 +195,7 @@ module.exports = function (grunt) {
                 colors: true,
                 logLevel: 'INFO',
                 autoWatch: false,
-                browsers: ['Firefox'],
+                browsers: ['FirefoxHeadless'],
                 browserConsoleLogOptions: {level: 'error'},
                 singleRun: true,
                 concurrency: Infinity


### PR DESCRIPTION
Makes dev cycles faster.