### PR TITLE
Independent Karma

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,61 +162,7 @@ module.exports = function (grunt) {
         },
         karma: {
             options: {
-                basePath: '',
-                frameworks: ['jasmine'],
-                files: [
-                    // CSS files
-                    '<%= conf.web %>/css/dc.css',
-                    // Helpers
-                    '<%= conf.web %>/js/jasmine-jsreporter.js',
-                    '<%= conf.web %>/js/compare-versions.js',
-                    '<%= conf.spec %>/helpers/*.js',
-                    // JS code dependencies
-                    '<%= conf.web %>/js/d3.js',
-                    '<%= conf.web %>/js/crossfilter.js',
-                    // Code to be tested
-                    '<%= conf.pkg.name %>.js',
-                    // Jasmine spec files
-                    '<%= conf.spec %>/*spec.js'
-                ],
-                exclude: [],
-                preprocessors: {},
-                // possible values: 'dots', 'progress'
-                reporters: ['progress', 'summary'],
-                summaryReporter: {
-                    // 'failed', 'skipped' or 'all'
-                    show: 'failed',
-                    // Limit the spec label to this length
-                    specLength: 100,
-                    // Show an 'all' column as a summary
-                    overviewColumn: true
-                },
-                customLaunchers: {
-                    // See https://github.com/karma-runner/karma/issues/2603
-                    ChromeNoSandboxHeadless: {
-                        base: 'Chrome',
-                        flags: [
-                            '--no-sandbox',
-                            // See https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
-                            '--headless',
-                            '--disable-gpu',
-                            // Without a remote debugging port, Google Chrome exits immediately.
-                            ' --remote-debugging-port=9222'
-                        ]
-                    },
-                    FirefoxHeadless: {
-                        base: 'Firefox',
-                        flags: ['-headless']
-                    }
-                },
-                port: 9876,
-                colors: true,
-                logLevel: 'INFO',
-                autoWatch: false,
-                browsers: ['FirefoxHeadless'],
-                browserConsoleLogOptions: {level: 'error'},
-                singleRun: true,
-                concurrency: Infinity
+                configFile: 'karma.conf.js'
             },
             unit: {},
             coverage: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -191,6 +191,24 @@ module.exports = function (grunt) {
                     // Show an 'all' column as a summary
                     overviewColumn: true
                 },
+                customLaunchers: {
+                    // See https://github.com/karma-runner/karma/issues/2603
+                    ChromeNoSandboxHeadless: {
+                        base: 'Chrome',
+                        flags: [
+                            '--no-sandbox',
+                            // See https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
+                            '--headless',
+                            '--disable-gpu',
+                            // Without a remote debugging port, Google Chrome exits immediately.
+                            ' --remote-debugging-port=9222'
+                        ]
+                    },
+                    FirefoxHeadless: {
+                        base: 'Firefox',
+                        flags: ['-headless']
+                    }
+                },
                 port: 9876,
                 colors: true,
                 logLevel: 'INFO',
@@ -219,24 +237,6 @@ module.exports = function (grunt) {
             },
             ci: {
                 browsers: ['ChromeNoSandboxHeadless', 'FirefoxHeadless'],
-                customLaunchers: {
-                    // See https://github.com/karma-runner/karma/issues/2603
-                    ChromeNoSandboxHeadless: {
-                        base: 'Chrome',
-                        flags: [
-                            '--no-sandbox',
-                            // See https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
-                            '--headless',
-                            '--disable-gpu',
-                            // Without a remote debugging port, Google Chrome exits immediately.
-                            ' --remote-debugging-port=9222'
-                        ]
-                    },
-                    FirefoxHeadless: {
-                        base: 'Firefox',
-                        flags: ['-headless']
-                    }
-                },
                 concurrency: 1,
                 reporters: ['dots', 'summary']
             },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,63 @@
+// Karma configuration
+// Generated on Thu Jul 05 2018 16:43:26 GMT+0530 (IST)
+
+module.exports = function(config) {
+    config.set({
+        basePath: '',
+        frameworks: ['jasmine'],
+        files: [
+            // CSS files
+            'web/css/dc.css',
+            // Helpers
+            'web/js/jasmine-jsreporter.js',
+            'web/js/compare-versions.js',
+            'spec/helpers/*.js',
+            // JS code dependencies
+            'web/js/d3.js',
+            'web/js/crossfilter.js',
+            // Code to be tested
+            'dc.js',
+            // Jasmine spec files
+            'spec/*spec.js'
+        ],
+        exclude: [],
+        preprocessors: {},
+        // possible values: 'dots', 'progress'
+        reporters: ['progress', 'summary'],
+        summaryReporter: {
+            // 'failed', 'skipped' or 'all'
+            show: 'failed',
+            // Limit the spec label to this length
+            specLength: 100,
+            // Show an 'all' column as a summary
+            overviewColumn: true
+        },
+        customLaunchers: {
+            // See https://github.com/karma-runner/karma/issues/2603
+            // This is used by grunt:ci task, so, do not remove
+            ChromeNoSandboxHeadless: {
+                base: 'Chrome',
+                flags: [
+                    '--no-sandbox',
+                    // See https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
+                    '--headless',
+                    '--disable-gpu',
+                    // Without a remote debugging port, Google Chrome exits immediately.
+                    ' --remote-debugging-port=9222'
+                ]
+            },
+            FirefoxHeadless: {
+                base: 'Firefox',
+                flags: ['-headless']
+            }
+        },
+        port: 9876,
+        colors: true,
+        logLevel: 'INFO',
+        autoWatch: false,
+        browsers: ['FirefoxHeadless'],
+        browserConsoleLogOptions: {level: 'error'},
+        singleRun: true,
+        concurrency: Infinity
+    })
+};


### PR DESCRIPTION
I use IntelliJ RubyMine with node, nom, and karma add-ons. Keeping a karma config in a file of its own allows run and debug any test case from the IDE, without interacting with the browser. A big speedup during development.