### PR TITLE
Cleanup .call/.apply

### DIFF
--- a/docs/dc-v4-upgrade-guide.md
+++ b/docs/dc-v4-upgrade-guide.md
@@ -38,7 +38,7 @@ for your case.
 - The previous was of instantiating a chart is still supported.
   However new way is recommended. For example:
   
-    - `dc.pieChart = (parent, chartGroup)` --> `new dc.PieChart(parent, chartGroup)`
+    - `dc.pieChart(parent, chartGroup)` --> `new dc.PieChart(parent, chartGroup)`
 
 - In dcv4, inside a `dc` chart functions set and expect `this` to be the chart
   instance. However `d3` sets it to the d3 element.

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -351,7 +351,7 @@ export class BaseMixin {
      */
     data (callback) {
         if (!arguments.length) {
-            return this._data.call(this, this._group);
+            return this._data(this._group);
         }
         this._data = typeof callback === 'function' ? callback : utils.constant(callback);
         this.expireCache();

--- a/src/charts/cbox-menu.js
+++ b/src/charts/cbox-menu.js
@@ -31,31 +31,6 @@ import {utils} from '../core/utils'
 const GROUP_CSS_CLASS = 'dc-cbox-group';
 const ITEM_CSS_CLASS = 'dc-cbox-item';
 
-function _onChange (d, i, chart) {
-    let values;
-    const target = d3.select(d3.event.target);
-    let options;
-
-    if (!target.datum()) {
-        values = chart._promptValue || null;
-    } else {
-        options = d3.select(this).selectAll('input')
-            .filter(function (o) {
-                if (o) {
-                    return this.checked;
-                }
-            });
-        values = options.nodes().map(function (option) {
-            return option.value;
-        });
-        // check if only prompt option is selected
-        if (!chart._multiple && values.length === 1) {
-            values = values[0];
-        }
-    }
-    chart.onChange(values);
-}
-
 export class CboxMenu extends BaseMixin {
     constructor (parent, chartGroup) {
         super();
@@ -147,7 +122,7 @@ export class CboxMenu extends BaseMixin {
                 .attr('type', 'reset')
                 .text(this._promptText)
                 .on('click', function (d, i) {
-                    return _onChange.call(this, d, i, chart);
+                    return chart._onChange(d, i, this);
                 });
         } else {
             const li = this._cbox.append('li');
@@ -167,9 +142,34 @@ export class CboxMenu extends BaseMixin {
             .sort(this._order);
 
         this._cbox.on('change',  function (d, i) {
-            return _onChange.call(this, d, i, chart);
+            return chart._onChange(d, i, this);
         });
         return options;
+    }
+
+    _onChange (d, i, element) {
+        let values;
+        const target = d3.select(d3.event.target);
+        let options;
+
+        if (!target.datum()) {
+            values = this._promptValue || null;
+        } else {
+            options = d3.select(element).selectAll('input')
+                .filter(function (o) {
+                    if (o) {
+                        return this.checked;
+                    }
+                });
+            values = options.nodes().map(function (option) {
+                return option.value;
+            });
+            // check if only prompt option is selected
+            if (!this._multiple && values.length === 1) {
+                values = values[0];
+            }
+        }
+        this.onChange(values);
     }
 
     onChange (val) {
@@ -291,7 +291,6 @@ export class CboxMenu extends BaseMixin {
 
         return this;
     }
-
 }
 
 export const cboxMenu = (parent, chartGroup) => new CboxMenu(parent, chartGroup);

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -6,20 +6,6 @@ import {transition} from '../core/core';
 
 const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
 
-function _tweenPie (b, chart) {
-    b.innerRadius = chart._innerRadius;
-    let current = this._current;
-    if (chart._isOffCanvas(current)) {
-        current = {startAngle: 0, endAngle: 0};
-    } else {
-        // only interpolate startAngle & endAngle, not the whole data object
-        current = {startAngle: current.startAngle, endAngle: current.endAngle};
-    }
-    const i = d3.interpolate(current, b);
-    this._current = i(0);
-    return t => chart._safeArc(i(t), 0, chart._buildArcs());
-}
-
 /**
  * The pie chart implementation is usually used to visualize a small categorical distribution.  The pie
  * chart uses keyAccessor to determine the slices, and valueAccessor to calculate the size of each
@@ -179,7 +165,7 @@ class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
         if (tranNodes.attrTween) {
             const chart = this;
             tranNodes.attrTween('d', function (d) {
-                return _tweenPie.call(this, d, chart);
+                return chart._tweenPie(d, this);
             });
         }
     }
@@ -297,7 +283,7 @@ class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
         if (tranNodes.attrTween) {
             const chart = this;
             tranNodes.attrTween('d', function (d) {
-                return _tweenPie.call(this, d, chart);
+                return chart._tweenPie(d, this);
             });
         }
         tranNodes.attr('fill', (d, i) => this._fill(d, i));
@@ -594,6 +580,22 @@ class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
             }
         });
     }
+
+    _tweenPie (b, element) {
+        b.innerRadius = this._innerRadius;
+        let current = element._current;
+        if (this._isOffCanvas(current)) {
+            current = {startAngle: 0, endAngle: 0};
+        } else {
+            // only interpolate startAngle & endAngle, not the whole data object
+            current = {startAngle: current.startAngle, endAngle: current.endAngle};
+        }
+        const i = d3.interpolate(current, b);
+        element._current = i(0);
+        return t => this._safeArc(i(t), 0, this._buildArcs());
+    }
+
+
 }
 
 export const pieChart = (parent, chartGroup) => new PieChart(parent, chartGroup);

--- a/src/charts/series-chart.js
+++ b/src/charts/series-chart.js
@@ -61,7 +61,7 @@ export class SeriesChart extends CompositeChart {
         const nesting = nester.entries(this.data());
         const children =
             nesting.map((sub, i) => {
-                const subChart = this._charts[sub.key] || this._chartFunction.call(this, this, this._chartGroup , sub.key, i);
+                const subChart = this._charts[sub.key] || this._chartFunction(this, this._chartGroup , sub.key, i);
                 if (!this._charts[sub.key]) {
                     childrenChanged = true;
                 }

--- a/src/charts/sunburst-chart.js
+++ b/src/charts/sunburst-chart.js
@@ -9,22 +9,6 @@ import {BaseMixin} from '../base/base-mixin';
 
 const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
 
-function _tweenSlice (d, chart) {
-    let current = this._current;
-    if (chart._isOffCanvas(current)) {
-        current = {x0: 0, x1: 0, y0: 0, y1: 0};
-    }
-    const tweenTarget = {
-        x0: d.x0,
-        x1: d.x1,
-        y0: d.y0,
-        y1: d.y1
-    };
-    const i = d3.interpolate(current, tweenTarget);
-    this._current = i(0);
-    return t => chart._safeArc(chart._buildArcs(), Object.assign({}, d, i(t)));
-}
-
 /**
  * The sunburst chart implementation is usually used to visualize a small tree distribution.  The sunburst
  * chart uses keyAccessor to determine the slices, and valueAccessor to calculate the size of each
@@ -188,7 +172,7 @@ class SunburstChart extends ColorMixin(BaseMixin) {
         if (tranNodes.attrTween) {
             const chart = this;
             tranNodes.attrTween('d', function (d) {
-                return _tweenSlice.call(this, d, chart);
+                return chart._tweenSlice(d, this);
             });
         }
     }
@@ -249,7 +233,7 @@ class SunburstChart extends ColorMixin(BaseMixin) {
         if (tranNodes.attrTween) {
             const chart = this;
             tranNodes.attrTween('d', function (d) {
-                return _tweenSlice.call(this, d, chart);
+                return chart._tweenSlice(d, this);
             });
         }
         tranNodes.attr('fill', (d, i) => this._fill(d, i));
@@ -570,5 +554,21 @@ class SunburstChart extends ColorMixin(BaseMixin) {
                 d3.select(this).classed('highlight', highlighted);
             }
         });
+    }
+
+    _tweenSlice (d, element) {
+        let current = element._current;
+        if (this._isOffCanvas(current)) {
+            current = {x0: 0, x1: 0, y0: 0, y1: 0};
+        }
+        const tweenTarget = {
+            x0: d.x0,
+            x1: d.x1,
+            y0: d.y0,
+            y1: d.y1
+        };
+        const i = d3.interpolate(current, tweenTarget);
+        element._current = i(0);
+        return t => this._safeArc(this._buildArcs(), Object.assign({}, d, i(t)));
     }
 }


### PR DESCRIPTION
I have been reviewing all usage of `.call` and `.apply`. Majority of such calls are to invoke some d3 method which expect specific value of `this`.

There are some cases within dc code as well. Majority of these set `this` to a d3 element. In general I am finding code difficult to understand and maintain with .call/.apply.

I have restructured a function in https://github.com/dc-js/dc.js/commit/fb3f9db1cd55a8ce522364bad6c817722f3403b0. In this now the d3-element is passed a parameter and `this` is set to the chart. This makes the function very similar to other functions.

I think the same restructuring will help in cleaning up getColor in color-mixin.

This is for your review and discussion, then I will convert similar cases in other charts.