### PR TITLE
Convert deprecation and direct method assigment to ES6 style.

### DIFF
--- a/spec/composite-chart-spec.js
+++ b/spec/composite-chart-spec.js
@@ -110,6 +110,14 @@ describe('dc.compositeChart', function () {
         expect(chart.valueAccessor()).not.toBeNull();
     });
 
+    it('should not allow calling yAxisMin', function () {
+        expect(chart.yAxisMin).toThrowError();
+    });
+
+    it('should not allow calling yAxisMax', function () {
+        expect(chart.yAxisMax).toThrowError();
+    });
+
     describe('rendering the chart', function () {
         beforeEach(function () {
             chart.render();

--- a/spec/data-count-spec.js
+++ b/spec/data-count-spec.js
@@ -30,6 +30,18 @@ describe('dc.dataCount', function () {
         it('should generate something', function () {
             expect(chart).not.toBeNull();
         });
+        it('treats dimension as synonym of crossfilter', function () {
+            expect(chart.dimension()).toEqual(chart.crossfilter());
+            const newVal = () => {}; // Just any value will do
+            chart.dimension(newVal);
+            expect(chart.crossfilter()).toBe(newVal);
+        });
+        it('treats group as synonym of groupAll', function () {
+            expect(chart.group()).toEqual(chart.groupAll());
+            const newVal = () => {}; // Just any value will do
+            chart.group(newVal);
+            expect(chart.groupAll()).toBe(newVal);
+        });
         it('should be registered', function () {
             expect(dc.hasChart(chart)).toBeTruthy();
         });

--- a/spec/data-grid-spec.js
+++ b/spec/data-grid-spec.js
@@ -51,6 +51,18 @@ describe('dc.dataGrid', function () {
         it('sets the group label', function () {
             expect(chart.selectAll('.dc-grid-group h1.dc-grid-label').nodes()[0].innerHTML).toEqual('Data Grid');
         });
+        it('treats group as synonym of section', function () {
+            expect(chart.group()).toEqual(chart.section());
+            const newSection = () => {};
+            chart.group(newSection);
+            expect(chart.section()).toBe(newSection);
+        });
+        it('treats htmlGroup as synonym of htmlSection', function () {
+            expect(chart.htmlGroup()).toEqual(chart.htmlSection());
+            const newHtmlSection = () => {};
+            chart.htmlGroup(newHtmlSection);
+            expect(chart.htmlSection()).toBe(newHtmlSection);
+        });
         it('creates id div', function () {
             expect(chart.selectAll('.dc-grid-item div#id_9').nodes().length).toEqual(1);
             expect(chart.selectAll('.dc-grid-item div#id_8').nodes().length).toEqual(1);

--- a/spec/data-table-spec.js
+++ b/spec/data-table-spec.js
@@ -61,6 +61,18 @@ describe('dc.dataTable', function () {
             it('group should be set', function () {
                 expect(chart.group()).toEqual(valueGroup);
             });
+            it('treats group as synonym of section', function () {
+                expect(chart.group()).toEqual(chart.section());
+                const newSection = () => {};
+                chart.group(newSection);
+                expect(chart.section()).toBe(newSection);
+            });
+            it('treats showGroups as synonym of showSections', function () {
+                expect(chart.showGroups()).toEqual(chart.showSections());
+                const newVal = !(chart.showGroups());
+                chart.showGroups(newVal);
+                expect(chart.showSections()).toBe(newVal);
+            });
             it('group tr should not be undefined', function () {
                 expect(typeof(chart.selectAll('tr.dc-table-group').nodes()[0])).not.toBe('undefined');
             });

--- a/spec/scatter-plot-spec.js
+++ b/spec/scatter-plot-spec.js
@@ -40,7 +40,7 @@ describe('dc.scatterPlot', function () {
             expect(chart.group().all().length).toBe(chart.selectAll('path.symbol').size());
         });
 
-        it('treats hiddenSize as synonym for emptySize', function () {
+        it('treats hiddenSize as synonym of emptySize', function () {
             expect(chart.hiddenSize()).toEqual(chart.emptySize());
             const newVal = 5;
             chart.hiddenSize(newVal);

--- a/spec/scatter-plot-spec.js
+++ b/spec/scatter-plot-spec.js
@@ -40,6 +40,13 @@ describe('dc.scatterPlot', function () {
             expect(chart.group().all().length).toBe(chart.selectAll('path.symbol').size());
         });
 
+        it('treats hiddenSize as synonym for emptySize', function () {
+            expect(chart.hiddenSize()).toEqual(chart.emptySize());
+            const newVal = 5;
+            chart.hiddenSize(newVal);
+            expect(chart.emptySize()).toEqual(newVal);
+        });
+
         it('should correctly place the symbols', function () {
             expect(nthSymbol(4).attr('transform')).toMatchTranslate(264, 131);
             expect(nthSymbol(5).attr('transform')).toMatchTranslate(264, 75);

--- a/spec/select-menu-spec.js
+++ b/spec/select-menu-spec.js
@@ -48,9 +48,15 @@ describe('dc.selectMenu', function () {
         it('select tag does not have size by default', function () {
             expect(chart.selectAll('select').attr('size')).toBeNull();
         });
-        it('can have size set', function () {
+        it('can have numberVisible set', function () {
             chart.numberVisible(10).redraw();
             expect(chart.selectAll('select').attr('size')).toEqual('10');
+        });
+        it('treats size as synonym of numberVisible', function () {
+            chart.numberVisible(10);
+            expect(chart.size()).toEqual(chart.numberVisible());
+            chart.size(20);
+            expect(chart.numberVisible()).toEqual(20);
         });
         it('creates prompt option with empty value', function () {
             var option = chart.selectAll('option').nodes()[0];

--- a/spec/series-chart-spec.js
+++ b/spec/series-chart-spec.js
@@ -42,6 +42,10 @@ describe('dc.seriesChart', function () {
             expect(chart.svg()).not.toBeNull();
         });
 
+        it('should not allow calling compose', function () {
+            expect(chart.compose).toThrowError();
+        });
+
         it('should position generated lineCharts using the data', function () {
             var lines = chart.selectAll('path.line');
 

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -98,7 +98,6 @@ export class BaseMixin {
 
         this._renderLabel = false;
 
-        // ES6: the following can't be promoted to a member function, as it needs to be => function
         this._title = d => this.keyAccessor()(d) + ': ' + this.valueAccessor()(d);
         this._renderTitle = true;
         this._controlsUseVisibility = false;

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -135,37 +135,6 @@ export class BaseMixin {
         this._removeFilterHandler = _defaultRemoveFilterHandler;
         this._addFilterHandler = _defaultAddFilterHandler;
         this._resetFilterHandler = _defaultResetFilterHandler;
-
-        // ES6: need to figure out proper way to deprecate
-
-        /**
-         * A renderlet is similar to an event listener on rendering event. Multiple renderlets can be added
-         * to an individual chart.  Each time a chart is rerendered or redrawn the renderlets are invoked
-         * right after the chart finishes its transitions, giving you a way to modify the SVGElements.
-         * Renderlet functions take the chart instance as the only input parameter and you can
-         * use the dc API or use raw d3 to achieve pretty much any effect.
-         *
-         * Use {@link dc.baseMixin#on on} with a 'renderlet' prefix.
-         * Generates a random key for the renderlet, which makes it hard to remove.
-         * @method renderlet
-         * @memberof dc.baseMixin
-         * @instance
-         * @deprecated
-         * @example
-         * // do this instead of .renderlet(function(chart) { ... })
-         * chart.on("renderlet", function(chart){
-         *     // mix of dc API and d3 manipulation
-         *     chart.select('g.y').style('display', 'none');
-         *     // its a closure so you can also access other chart variable available in the closure scope
-         *     moveChart.filter(chart.filter());
-         * });
-         * @param {Function} renderletFunction
-         * @returns {dc.baseMixin}
-         */
-        this.renderlet = logger.deprecate(renderletFunction => {
-            this.on('renderlet.' + utils.uniqueId(), renderletFunction);
-            return this;
-        }, 'chart.renderlet has been deprecated.  Please use chart.on("renderlet.<renderletKey>", renderletFunction)');
     }
 
     /**
@@ -1570,6 +1539,36 @@ export class BaseMixin {
      */
     on (event, listener) {
         this._listeners.on(event, listener);
+        return this;
+    }
+
+    /**
+     * A renderlet is similar to an event listener on rendering event. Multiple renderlets can be added
+     * to an individual chart.  Each time a chart is rerendered or redrawn the renderlets are invoked
+     * right after the chart finishes its transitions, giving you a way to modify the SVGElements.
+     * Renderlet functions take the chart instance as the only input parameter and you can
+     * use the dc API or use raw d3 to achieve pretty much any effect.
+     *
+     * Use {@link dc.baseMixin#on on} with a 'renderlet' prefix.
+     * Generates a random key for the renderlet, which makes it hard to remove.
+     * @method renderlet
+     * @memberof dc.baseMixin
+     * @instance
+     * @deprecated chart.renderlet has been deprecated. Please use chart.on("renderlet.<renderletKey>", renderletFunction)
+     * @example
+     * // do this instead of .renderlet(function(chart) { ... })
+     * chart.on("renderlet", function(chart){
+     *     // mix of dc API and d3 manipulation
+     *     chart.select('g.y').style('display', 'none');
+     *     // its a closure so you can also access other chart variable available in the closure scope
+     *     moveChart.filter(chart.filter());
+     * });
+     * @param {Function} renderletFunction
+     * @returns {dc.baseMixin}
+     */
+    renderlet (renderletFunction) {
+        logger.warnOnce('chart.renderlet has been deprecated. Please use chart.on("renderlet.<renderletKey>", renderletFunction)');
+        this.on('renderlet.' + utils.uniqueId(), renderletFunction);
         return this;
     }
 

--- a/src/charts/bar-chart.js
+++ b/src/charts/bar-chart.js
@@ -49,18 +49,23 @@ class BarChart extends StackMixin(CoordinateGridMixin) {
 
         this.label(d => utils.printSingleValue(d.y0 + d.y), false);
 
-        /**
-         * Get or set the outer padding on an ordinal bar chart. This setting has no effect on non-ordinal charts.
-         * Will pad the width by `padding * barWidth` on each side of the chart.
-         * @method outerPadding
-         * @memberof dc.barChart
-         * @instance
-         * @param {Number} [padding=0.5]
-         * @returns {Number|dc.barChart}
-         */
-        this.outerPadding = this._outerRangeBandPadding;
-
         this.anchor(parent, chartGroup);
+    }
+
+    /**
+     * Get or set the outer padding on an ordinal bar chart. This setting has no effect on non-ordinal charts.
+     * Will pad the width by `padding * barWidth` on each side of the chart.
+     * @method outerPadding
+     * @memberof dc.barChart
+     * @instance
+     * @param {Number} [padding=0.5]
+     * @returns {Number|dc.barChart}
+     */
+    outerPadding (padding) {
+        if (!arguments.length) {
+            return this._outerRangeBandPadding();
+        }
+        return this._outerRangeBandPadding(padding);
     }
 
     rescale () {

--- a/src/charts/box-plot.js
+++ b/src/charts/box-plot.js
@@ -94,18 +94,6 @@ class BoxPlot extends CoordinateGridMixin {
             return values.length !== 0;
         }));
 
-        /**
-         * Get or set the spacing between boxes as a fraction of box size. Valid values are within 0-1.
-         * See the {@link https://github.com/d3/d3-scale/blob/master/README.md#scaleBand d3 docs}
-         * for a visual description of how the padding is applied.
-         * @method boxPadding
-         * @memberof dc.boxPlot
-         * @instance
-         * @see {@link https://github.com/d3/d3-scale/blob/master/README.md#scaleBand d3.scaleBand}
-         * @param {Number} [padding=0.8]
-         * @returns {Number|dc.boxPlot}
-         */
-        this.boxPadding = this._rangeBandPadding;
         this.boxPadding(0.8);
 
         /**
@@ -122,6 +110,21 @@ class BoxPlot extends CoordinateGridMixin {
         this.outerPadding(0.5);
 
         this.anchor(parent, chartGroup);
+    }
+
+    /**
+     * Get or set the spacing between boxes as a fraction of box size. Valid values are within 0-1.
+     * See the {@link https://github.com/d3/d3-scale/blob/master/README.md#scaleBand d3 docs}
+     * for a visual description of how the padding is applied.
+     * @method boxPadding
+     * @memberof dc.boxPlot
+     * @instance
+     * @see {@link https://github.com/d3/d3-scale/blob/master/README.md#scaleBand d3.scaleBand}
+     * @param {Number} [padding=0.8]
+     * @returns {Number|dc.boxPlot}
+     */
+    boxPadding (padding) {
+        return this._rangeBandPadding(padding);
     }
 
     /**

--- a/src/charts/box-plot.js
+++ b/src/charts/box-plot.js
@@ -95,18 +95,6 @@ class BoxPlot extends CoordinateGridMixin {
         }));
 
         this.boxPadding(0.8);
-
-        /**
-         * Get or set the outer padding on an ordinal box chart. This setting has no effect on non-ordinal charts
-         * or on charts with a custom {@link dc.boxPlot#boxWidth .boxWidth}. Will pad the width by
-         * `padding * barWidth` on each side of the chart.
-         * @method outerPadding
-         * @memberof dc.boxPlot
-         * @instance
-         * @param {Number} [padding=0.5]
-         * @returns {Number|dc.boxPlot}
-         */
-        this.outerPadding = this._outerRangeBandPadding;
         this.outerPadding(0.5);
 
         this.anchor(parent, chartGroup);
@@ -124,7 +112,27 @@ class BoxPlot extends CoordinateGridMixin {
      * @returns {Number|dc.boxPlot}
      */
     boxPadding (padding) {
+        if (!arguments.length) {
+            return this._rangeBandPadding();
+        }
         return this._rangeBandPadding(padding);
+    }
+
+    /**
+     * Get or set the outer padding on an ordinal box chart. This setting has no effect on non-ordinal charts
+     * or on charts with a custom {@link dc.boxPlot#boxWidth .boxWidth}. Will pad the width by
+     * `padding * barWidth` on each side of the chart.
+     * @method outerPadding
+     * @memberof dc.boxPlot
+     * @instance
+     * @param {Number} [padding=0.5]
+     * @returns {Number|dc.boxPlot}
+     */
+    outerPadding (padding) {
+        if (!arguments.length) {
+            return this._outerRangeBandPadding();
+        }
+        return this._outerRangeBandPadding(padding);
     }
 
     /**

--- a/src/charts/composite-chart.js
+++ b/src/charts/composite-chart.js
@@ -56,12 +56,6 @@ export class CompositeChart extends CoordinateGridMixin {
             }
         });
 
-        // ES6: avoid deleting
-        delete this.yAxisMin;
-
-        // ES6: avoid deleting
-        delete this.yAxisMax;
-
         this.anchor(parent, chartGroup);
     }
 
@@ -553,6 +547,14 @@ export class CompositeChart extends CoordinateGridMixin {
         }
         this._rightYAxis = rightYAxis;
         return this;
+    }
+
+    yAxisMin () {
+        throw new Error('Not supported for this chart type');
+    }
+
+    yAxisMax () {
+        throw new Error('Not supported for this chart type');
     }
 }
 

--- a/src/charts/data-count.js
+++ b/src/charts/data-count.js
@@ -45,12 +45,6 @@ export class DataCount extends BaseMixin {
 
         this._mandatoryAttributes(['crossfilter', 'groupAll']);
 
-        this.dimension = logger.annotate(this.crossfilter,
-                                         'consider using dataCount.crossfilter instead of dataCount.dimension for clarity');
-
-        this.group = logger.annotate(this.groupAll,
-                                     'consider using dataCount.groupAll instead of dataCount.group for clarity');
-
         this.anchor(parent, chartGroup);
     }
 
@@ -132,12 +126,28 @@ export class DataCount extends BaseMixin {
         return this;
     }
 
+    dimension (cf) {
+        logger.warnOnce('consider using dataCount.crossfilter instead of dataCount.dimension for clarity');
+        if (!arguments.length) {
+            return this.crossfilter();
+        }
+        return this.crossfilter(cf);
+    }
+
     groupAll (groupAll) {
         if (!arguments.length) {
             return this._groupAll;
         }
         this._groupAll = groupAll;
         return this;
+    }
+
+    group (groupAll) {
+        logger.warnOnce('consider using dataCount.groupAll instead of dataCount.group for clarity');
+        if (!arguments.length) {
+            return this.groupAll();
+        }
+        return this.groupAll(groupAll);
     }
 }
 

--- a/src/charts/data-grid.js
+++ b/src/charts/data-grid.js
@@ -52,29 +52,6 @@ export class DataGrid extends BaseMixin {
 
         this._mandatoryAttributes(['dimension', 'section']);
 
-        /**
-         * Backward-compatible synonym for {@link dc.dataGrid#section section}.
-         *
-         * @method group
-         * @memberof dc.dataGrid
-         * @instance
-         * @param {Function} groupFunction Function taking a row of data and returning the nest key.
-         * @returns {Function|dc.dataGrid}
-         */
-        this.group = logger.annotate(this.section,
-                                     'consider using dataGrid.section instead of dataGrid.group for clarity');
-
-        /**
-         * Backward-compatible synonym for {@link dc.dataGrid#htmlSection htmlSection}.
-         * @method htmlGroup
-         * @memberof dc.dataGrid
-         * @instance
-         * @param {Function} [htmlGroup]
-         * @returns {Function|dc.dataGrid}
-         */
-        this.htmlGroup = logger.annotate(this.htmlSection,
-                                         'consider using dataGrid.htmlSection instead of dataGrid.htmlGroup for clarity');
-
         this.anchor(parent, chartGroup);
     }
 
@@ -165,6 +142,23 @@ export class DataGrid extends BaseMixin {
     }
 
     /**
+     * Backward-compatible synonym for {@link dc.dataGrid#section section}.
+     *
+     * @method group
+     * @memberof dc.dataGrid
+     * @instance
+     * @param {Function} section Function taking a row of data and returning the nest key.
+     * @returns {Function|dc.dataGrid}
+     */
+    group (section) {
+        logger.warnOnce('consider using dataGrid.section instead of dataGrid.group for clarity');
+        if (!arguments.length) {
+            return this.section();
+        }
+        return this.section(section);
+    }
+
+    /**
      * Get or set the index of the beginning slice which determines which entries get displayed by the widget.
      * Useful when implementing pagination.
      * @method beginSlice
@@ -250,6 +244,22 @@ export class DataGrid extends BaseMixin {
         }
         this._htmlSection = htmlSection;
         return this;
+    }
+
+    /**
+     * Backward-compatible synonym for {@link dc.dataGrid#htmlSection htmlSection}.
+     * @method htmlGroup
+     * @memberof dc.dataGrid
+     * @instance
+     * @param {Function} [htmlSection]
+     * @returns {Function|dc.dataGrid}
+     */
+    htmlGroup (htmlSection) {
+        logger.warnOnce('consider using dataGrid.htmlSection instead of dataGrid.htmlGroup for clarity');
+        if (!arguments.length) {
+            return this.htmlSection();
+        }
+        return this.htmlSection(htmlSection);
     }
 
     /**

--- a/src/charts/data-table.js
+++ b/src/charts/data-table.js
@@ -56,29 +56,6 @@ export class DataTable extends BaseMixin {
 
         this._mandatoryAttributes(['dimension']);
 
-        /**
-         * Backward-compatible synonym for {@link dc.dataTable#section section}.
-         *
-         * @method group
-         * @memberof dc.dataTable
-         * @instance
-         * @param {Function} groupFunction Function taking a row of data and returning the nest key.
-         * @returns {Function|dc.dataTable}
-         */
-        this.group = logger.annotate(this.section,
-                                     'consider using dataTable.section instead of dataTable.group for clarity');
-
-        /**
-         * Backward-compatible synonym for {@link dc.dataTable#showSections showSections}.
-         * @method showGroups
-         * @memberof dc.dataTable
-         * @instance
-         * @param {Boolean} [showGroups=true]
-         * @returns {Boolean|dc.dataTable}
-         */
-        this.showGroups = logger.annotate(this.showSections,
-                                          'consider using dataTable.showSections instead of dataTable.showGroups for clarity');
-
         this.anchor(parent, chartGroup);
     }
 
@@ -248,6 +225,23 @@ export class DataTable extends BaseMixin {
         }
         this._section = section;
         return this;
+    }
+
+    /**
+     * Backward-compatible synonym for {@link dc.dataTable#section section}.
+     *
+     * @method group
+     * @memberof dc.dataTable
+     * @instance
+     * @param {Function} section Function taking a row of data and returning the nest key.
+     * @returns {Function|dc.dataTable}
+     */
+    group (section) {
+        logger.warnOnce('consider using dataTable.section instead of dataTable.group for clarity');
+        if (!arguments.length) {
+            return this.section();
+        }
+        return this.section(section);
     }
 
     /**
@@ -452,6 +446,22 @@ export class DataTable extends BaseMixin {
         }
         this._showSections = showSections;
         return this;
+    }
+
+    /**
+     * Backward-compatible synonym for {@link dc.dataTable#showSections showSections}.
+     * @method showGroups
+     * @memberof dc.dataTable
+     * @instance
+     * @param {Boolean} [showSections=true]
+     * @returns {Boolean|dc.dataTable}
+     */
+    showGroups (showSections) {
+        logger.warnOnce('consider using dataTable.showSections instead of dataTable.showGroups for clarity');
+        if (!arguments.length) {
+            return this.showSections();
+        }
+        return this.showSections(showSections);
     }
 }
 

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -51,7 +51,6 @@ export class HeatMap extends ColorMixin(MarginMixin(BaseMixin)) {
         this._colsLabel = d => d;
         this._rowsLabel = d => d;
 
-        // ES6: revisit after converting mixins
         this._xAxisOnClick = d => {
             this._filterAxis(0, d);
         };

--- a/src/charts/line-chart.js
+++ b/src/charts/line-chart.js
@@ -62,59 +62,6 @@ class LineChart extends StackMixin(CoordinateGridMixin) {
 
         this.label(d => utils.printSingleValue(d.y0 + d.y), false);
 
-        /**
-         * Gets or sets the interpolator to use for lines drawn, by string name, allowing e.g. step
-         * functions, splines, and cubic interpolation.
-         *
-         * Possible values are: 'linear', 'linear-closed', 'step', 'step-before', 'step-after', 'basis',
-         * 'basis-open', 'basis-closed', 'bundle', 'cardinal', 'cardinal-open', 'cardinal-closed', and
-         * 'monotone'.
-         *
-         * This function exists for backward compatibility. Use {@link dc.lineChart#curve}
-         * which is generic and provides more options.
-         * Value set through `.curve` takes precedence over `.interpolate` and `.tension`.
-         * @method interpolate
-         * @memberof dc.lineChart
-         * @instance
-         * @deprecated since version 3.0 use {@link dc.lineChart#curve} instead
-         * @see {@link dc.lineChart#curve}
-         * @param  {d3.curve} [interpolate=d3.curveLinear]
-         * @returns {d3.curve|dc.lineChart}
-         */
-        this.interpolate = logger.deprecate(function (interpolate) {
-            if (!arguments.length) {
-                return this._interpolate;
-            }
-            this._interpolate = interpolate;
-            return this;
-        }, 'dc.lineChart.interpolate has been deprecated since version 3.0 use dc.lineChart.curve instead');
-
-        /**
-         * Gets or sets the tension to use for lines drawn, in the range 0 to 1.
-         *
-         * Passed to the {@link https://github.com/d3/d3-shape/blob/master/README.md#curves d3 curve function}
-         * if it provides a `.tension` function. Example:
-         * {@link https://github.com/d3/d3-shape/blob/master/README.md#curveCardinal_tension curveCardinal.tension}.
-         *
-         * This function exists for backward compatibility. Use {@link dc.lineChart#curve}
-         * which is generic and provides more options.
-         * Value set through `.curve` takes precedence over `.interpolate` and `.tension`.
-         * @method tension
-         * @memberof dc.lineChart
-         * @instance
-         * @deprecated since version 3.0 use {@link dc.lineChart#curve} instead
-         * @see {@link dc.lineChart#curve}
-         * @param  {Number} [tension=0]
-         * @returns {Number|dc.lineChart}
-         */
-        this.tension = logger.deprecate(function (tension) {
-            if (!arguments.length) {
-                return this._tension;
-            }
-            this._tension = tension;
-            return this;
-        }, 'dc.lineChart.tension has been deprecated since version 3.0 use dc.lineChart.curve instead');
-
         this.anchor(parent, chartGroup);
     }
 
@@ -181,6 +128,61 @@ class LineChart extends StackMixin(CoordinateGridMixin) {
             return this._curve;
         }
         this._curve = curve;
+        return this;
+    }
+
+    /**
+     * Gets or sets the interpolator to use for lines drawn, by string name, allowing e.g. step
+     * functions, splines, and cubic interpolation.
+     *
+     * Possible values are: 'linear', 'linear-closed', 'step', 'step-before', 'step-after', 'basis',
+     * 'basis-open', 'basis-closed', 'bundle', 'cardinal', 'cardinal-open', 'cardinal-closed', and
+     * 'monotone'.
+     *
+     * This function exists for backward compatibility. Use {@link dc.lineChart#curve}
+     * which is generic and provides more options.
+     * Value set through `.curve` takes precedence over `.interpolate` and `.tension`.
+     * @method interpolate
+     * @memberof dc.lineChart
+     * @instance
+     * @deprecated since version 3.0 use {@link dc.lineChart#curve} instead
+     * @see {@link dc.lineChart#curve}
+     * @param  {d3.curve} [interpolate=d3.curveLinear]
+     * @returns {d3.curve|dc.lineChart}
+     */
+    interpolate (interpolate) {
+        logger.warnOnce('dc.lineChart.interpolate has been deprecated since version 3.0 use dc.lineChart.curve instead');
+        if (!arguments.length) {
+            return this._interpolate;
+        }
+        this._interpolate = interpolate;
+        return this;
+    }
+
+    /**
+     * Gets or sets the tension to use for lines drawn, in the range 0 to 1.
+     *
+     * Passed to the {@link https://github.com/d3/d3-shape/blob/master/README.md#curves d3 curve function}
+     * if it provides a `.tension` function. Example:
+     * {@link https://github.com/d3/d3-shape/blob/master/README.md#curveCardinal_tension curveCardinal.tension}.
+     *
+     * This function exists for backward compatibility. Use {@link dc.lineChart#curve}
+     * which is generic and provides more options.
+     * Value set through `.curve` takes precedence over `.interpolate` and `.tension`.
+     * @method tension
+     * @memberof dc.lineChart
+     * @instance
+     * @deprecated since version 3.0 use {@link dc.lineChart#curve} instead
+     * @see {@link dc.lineChart#curve}
+     * @param  {Number} [tension=0]
+     * @returns {Number|dc.lineChart}
+     */
+    tension (tension) {
+        logger.warnOnce('dc.lineChart.tension has been deprecated since version 3.0 use dc.lineChart.curve instead');
+        if (!arguments.length) {
+            return this._tension;
+        }
+        this._tension = tension;
         return this;
     }
 

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -69,9 +69,6 @@ export class ScatterPlot extends CoordinateGridMixin {
 
         this._symbol.size((d, i) => this._elementSize(d, i));
 
-        // ES6: do we need this
-        this.hiddenSize = this.emptySize;
-
         this.anchor(parent, chartGroup);
     }
 
@@ -509,6 +506,13 @@ export class ScatterPlot extends CoordinateGridMixin {
         }
         this._emptySize = emptySize;
         return this;
+    }
+
+    hiddenSize (emptySize) {
+        if (!arguments.length) {
+            return this.emptySize();
+        }
+        return this.emptySize(emptySize);
     }
 
     /**

--- a/src/charts/select-menu.js
+++ b/src/charts/select-menu.js
@@ -1,8 +1,7 @@
 import * as d3 from 'd3';
-
-import {logger} from '../core/logger';
 import {events} from '../core/events';
 import {BaseMixin} from '../base/base-mixin';
+import {logger} from '../core/logger';
 
 const SELECT_CSS_CLASS = 'dc-select-menu';
 const OPTION_CSS_CLASS = 'dc-select-option';
@@ -53,9 +52,6 @@ export class SelectMenu extends BaseMixin {
             }
             return 0;
         };
-
-        // ES6: drop it
-        this.size = logger.deprecate(this.numberVisible, 'selectMenu.size is ambiguous - use numberVisible instead');
 
         this.anchor(parent, chartGroup);
     }
@@ -272,6 +268,14 @@ export class SelectMenu extends BaseMixin {
         this._numberVisible = numberVisible;
 
         return this;
+    }
+
+    size (numberVisible) {
+        logger.warnOnce('selectMenu.size is ambiguous - use selectMenu.numberVisible instead');
+        if (!arguments.length) {
+            return this.numberVisible();
+        }
+        return this.numberVisible(numberVisible);
     }
 }
 

--- a/src/charts/series-chart.js
+++ b/src/charts/series-chart.js
@@ -41,11 +41,14 @@ export class SeriesChart extends CompositeChart {
 
         this._mandatoryAttributes().push('seriesAccessor', 'chart');
         this.shareColors(true);
+    }
 
-        // ES6: consider creating a method _compose that calls super.compose and make overridden compose to throw exception
-        // make compose private
-        this._compose = this.compose;
-        delete this.compose;
+    _compose (subChartArray) {
+        super.compose(subChartArray);
+    }
+
+    compose (subChartArray) {
+        throw new Error('Not supported for this chart type');
     }
 
     _preprocessData () {


### PR DESCRIPTION
I have carried out sample conversion of a deprecated method and a case of direct method assignment. Please see if this approach seems acceptable.

For logger.annotate we can take same approach.