### PR TITLE
Use terser, enhance rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -17,7 +16,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -203,7 +201,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1066,8 +1063,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -1282,7 +1278,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1473,7 +1468,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1481,8 +1475,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-support": {
       "version": "1.1.3",
@@ -2774,8 +2767,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
@@ -2996,11 +2988,15 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -4196,114 +4192,6 @@
         }
       }
     },
-    "grunt-contrib-uglify-es": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify-es/-/grunt-contrib-uglify-es-3.3.0.tgz",
-      "integrity": "sha1-wV97Ef1BMgPU4MkTf10/r1Wo34A=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.0.0",
-        "maxmin": "^1.1.0",
-        "uglify-es": "~3.3.0",
-        "uri-path": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "browserify-zlib": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-          "dev": true,
-          "requires": {
-            "pako": "~0.2.0"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
-        },
-        "gzip-size": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
-          "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
-          "dev": true,
-          "requires": {
-            "browserify-zlib": "^0.1.4",
-            "concat-stream": "^1.4.1"
-          }
-        },
-        "maxmin": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
-          "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.0.0",
-            "figures": "^1.0.1",
-            "gzip-size": "^1.0.0",
-            "pretty-bytes": "^1.0.0"
-          }
-        },
-        "pako": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
-          "dev": true
-        },
-        "pretty-bytes": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-          "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "uglify-es": {
-          "version": "3.3.9",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-          "dev": true,
-          "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
-          }
-        }
-      }
-    },
     "grunt-contrib-watch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz",
@@ -4667,8 +4555,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -5484,6 +5371,25 @@
       "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
+    "jest-worker": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+      "requires": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
@@ -5493,8 +5399,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -6629,6 +6534,11 @@
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
       }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -8934,6 +8844,26 @@
         }
       }
     },
+    "rollup-plugin-terser": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz",
+      "integrity": "sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.6.0",
+        "rollup-pluginutils": "^2.8.1",
+        "serialize-javascript": "^1.7.0",
+        "terser": "^4.1.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -9132,6 +9062,11 @@
           "dev": true
         }
       }
+    },
+    "serialize-javascript": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -9546,6 +9481,22 @@
         "urix": "^0.1.0"
       }
     },
+    "source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -9893,7 +9844,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -10044,6 +9994,28 @@
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
       "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
       "dev": true
+    },
+    "terser": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
+      "integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "test-value": {
       "version": "3.0.0",
@@ -10560,12 +10532,6 @@
           "dev": true
         }
       }
-    },
-    "uri-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
-      "integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
-      "dev": true
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "grunt-contrib-copy": "~1.0",
     "grunt-contrib-cssmin": "3.x",
     "grunt-contrib-jasmine": "~2.1",
-    "grunt-contrib-uglify-es": "^3.3.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-docco2": "^0.2.1",
     "grunt-eslint": "^21.1.0",
@@ -65,6 +64,7 @@
     "node-sass": "^4.12.0",
     "promise-polyfill": "^8.1.3",
     "reductio": "0.6.x",
+    "rollup-plugin-terser": "^5.1.2",
     "time-grunt": "~1.4",
     "uglify-js": "^3.6.0",
     "whatwg-fetch": "^3.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,78 @@
+import {terser} from 'rollup-plugin-terser';
+
+const umdConf = {
+    file: 'dist/es6/dc.js',
+    external: ['d3'],
+    format: 'umd',
+    name: 'dc',
+    sourcemap: true,
+    globals: {
+        d3: 'd3'
+    }
+};
+
+const umdMinConf = Object.assign({}, umdConf, {file: 'dist/es6/dc.min.js'});
+
+const esmFlat = {
+    format: 'esm',
+    sourcemap: true,
+    file: 'dist/esf/dc.esm.js'
+};
+
+const esmFlatMin = Object.assign({}, esmFlat, {file: 'dist/esf/dc.esm.min.js'});
+
+const modulesMap = {
+    'index': 'src/index.js',
+    'legend': 'src/base/legend.js',
+    'html-legend': 'src/base/html-legend.js',
+    'bar-chart': 'src/charts/bar-chart.js',
+    'box-plot': 'src/charts/box-plot.js',
+    'bubble-chart': 'src/charts/bubble-chart.js',
+    'bubble-overlay': 'src/charts/bubble-overlay.js',
+    'cbox-menu': 'src/charts/cbox-menu.js',
+    'composite-chart': 'src/charts/composite-chart.js',
+    'data-count': 'src/charts/data-count.js',
+    'data-grid': 'src/charts/data-grid.js',
+    'data-table': 'src/charts/data-table.js',
+    'geo-choropleth-chart': 'src/charts/geo-choropleth-chart.js',
+    'heatmap': 'src/charts/heatmap.js',
+    'line-chart': 'src/charts/line-chart.js',
+    'number-display': 'src/charts/number-display.js',
+    'pie-chart': 'src/charts/pie-chart.js',
+    'row-chart': 'src/charts/row-chart.js',
+    'scatter-plot': 'src/charts/scatter-plot.js',
+    'select-menu': 'src/charts/select-menu.js',
+    'series-chart': 'src/charts/series-chart.js',
+    'sunburst-chart': 'src/charts/sunburst-chart.js',
+    'text-filter-widget': 'src/charts/text-filter-widget.js'
+};
+
+export default [
+    {
+        input: 'src/index.js',
+        plugins: [terser({
+            include: [/^.+\.min\.js$/]
+        })],
+        output: [
+            umdConf,
+            umdMinConf,
+            esmFlat,
+            esmFlatMin
+        ]
+    },
+    {
+        input: modulesMap,
+        output: {
+            dir: 'dist/esm',
+            format: 'esm'
+        }
+    },
+    {
+        plugins: [terser()],
+        input: modulesMap,
+        output: {
+            dir: 'dist/esm-min',
+            format: 'esm'
+        }
+    }
+];

--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -442,7 +442,7 @@ describe('dc.coordinateGridChart', function () {
                     expect(chart.selectAll('.axis.y').size()).toBe(1);
                 });
 
-                // No longer valid in D3v4
+                // can't determine axis orientation in D3v4+, see d3/d3-axis#16
                 /*it('should orient the y-axis text to the left by default', function () {
                     expect(chart.yAxis().orient()).toBe('left');
                 });*/
@@ -490,7 +490,7 @@ describe('dc.coordinateGridChart', function () {
                     expect(chart.selectAll('.axis.y').size()).toBe(1);
                 });
 
-                // Not applicable in D3v4
+                // can't determine axis orientation in D3v4+, see d3/d3-axis#16
                 /*it('should orient the y-axis text to the right', function () {
                     expect(chart.yAxis().orient()).toBe('right');
                 });*/

--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -734,9 +734,6 @@ describe('dc.coordinateGridChart', function () {
             chart.render();
             rangeChart.render();
 
-            /* ES6 - will not allow spy on a method directly on dc, as it can not be reassigned. Re-look later.
-            spyOn(dc, 'redrawAll');
-            */
             spyOn(chart, 'redraw');
             spyOn(rangeChart, 'redraw');
         });
@@ -795,12 +792,6 @@ describe('dc.coordinateGridChart', function () {
                     expect(zoomCallback).toHaveBeenCalled();
                 });
 
-                /* ES6 - will not allow spy on a method directly on dc, as it can not be reassigned. Re-look later.
-                it('should trigger redraw on other charts in group after a brief pause', function () {
-                    jasmine.clock().tick(100);
-                    expect(dc.redrawAll).toHaveBeenCalledWith(chart.chartGroup());
-                });
-                */
             });
         }
     });

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -60,9 +60,18 @@ utils.printSingleValue = function (filter) {
 };
 utils.printSingleValue.fformat = d3.format('.2f');
 
-// convert 'day' to 'timeDay' and similar
-utils.toTimeFunc = function (t) {
-    return 'time' + t.charAt(0).toUpperCase() + t.slice(1);
+// convert 'day' to d3.timeDay and similar
+utils._toTimeFunc = function (t) {
+    const mappings = {
+        'second': d3.timeSecond,
+        'minute': d3.timeMinute,
+        'hour': d3.timeHour,
+        'day': d3.timeDay,
+        'week': d3.timeWeek,
+        'month': d3.timeMonth,
+        'year': d3.timeYear
+    };
+    return mappings[t];
 };
 
 /**
@@ -100,7 +109,7 @@ utils.add = function (l, r, t) {
         }
         t = t || d3.timeDay;
         if (typeof t !== 'function') {
-            t = d3[utils.toTimeFunc(t)];
+            t = utils._toTimeFunc(t);
         }
         return t.offset(l, r);
     } else if (typeof r === 'string') {
@@ -146,7 +155,7 @@ utils.subtract = function (l, r, t) {
         }
         t = t || d3.timeDay;
         if (typeof t !== 'function') {
-            t = d3[utils.toTimeFunc(t)];
+            t = utils._toTimeFunc(t);
         }
         return t.offset(l, -r);
     } else if (typeof r === 'string') {


### PR DESCRIPTION
Ref #1595 

This has package.json change. So, please run `npm i`. Also, I was not sure if I should checkin the package lock file, so, committed that as a separate commit.

This PR starts using terser, but does some more.

I have created a rollup config which does the following:

- UMD and corresponding minified file in `dist/es6`
- Flattened ESM and corresponding minified file in `dist/esf` (useful for importing as modules)
- Split ESM in `dist/esm`
- Minified ESM split modules in `dist/esm-min`

Currently it is not integrated with grunt. To test it, run the following:

```bash
$ rm -rf dist/*; npx rollup --config
```

I have included https://github.com/dc-js/dc.js/commit/b0b66a7e652c9ff2ae31f1a69a0c556db2726f18 which is part of #1601. I wanted to verify that with this change, the ESM version does not have `import * from 'd3'`.

Please see the output. For me also it was first such attempt.

It is clear from the output what rollup module splitting gives. We need to decide which of these six different output formats we need to include in our distribution.

The ESM output also shows that while our code imports everything from d3, the rollup output uses named imports.