### PR TITLE
Urgent: Using publicly released version of `grunt-jsdoc-to-markdown`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2383,9 +2383,9 @@
       }
     },
     "dmd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.3.tgz",
-      "integrity": "sha512-qU9jcZQCxfLlTbZU1e5jROXVkTsn9q3s1FmnOPFWo9tfDol3cSt0AZREiXCsgmSaS5L/AXXQqcZiR7YjFNAL1g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.4.tgz",
+      "integrity": "sha512-ZbHUPKUp5Tl8nVVMZw8rc/MQmFVKusvfR10X/lPAXjBUc/LRW7AaXnYrK2LnVIPfTGEw7T6OmsxkvNRX7GnjIQ==",
       "dev": true,
       "requires": {
         "array-back": "^4.0.0",
@@ -2403,9 +2403,9 @@
       },
       "dependencies": {
         "handlebars": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-          "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+          "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
           "dev": true,
           "requires": {
             "neo-async": "^2.6.0",
@@ -3896,7 +3896,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3961,7 +3961,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4452,11 +4452,12 @@
       }
     },
     "grunt-jsdoc-to-markdown": {
-      "version": "github:dc-js/grunt-jsdoc-to-markdown#9d32b5052e73a27fe8ee27ff1cb66e636a61e18c",
-      "from": "github:dc-js/grunt-jsdoc-to-markdown",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-jsdoc-to-markdown/-/grunt-jsdoc-to-markdown-5.0.0.tgz",
+      "integrity": "sha512-3mCIeYZF7h1mug5N7+mqn+D0Cqc4PQ6b8fHqzME0pLXgFoQZMAZP67ELwrwy7CEKXCo5fWzezyiBYs3Tt0QM4A==",
       "dev": true,
       "requires": {
-        "jsdoc-to-markdown": "^5.0"
+        "jsdoc-to-markdown": "^5.0.2"
       }
     },
     "grunt-karma": {
@@ -4544,7 +4545,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5582,13 +5583,13 @@
       }
     },
     "jsdoc-api": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.3.tgz",
-      "integrity": "sha512-7F/FR1DCRmRFlyuccpeRwW/4H5GtUD9detREDO/gxLjyEaVfRdD1JDzwZ4tMg32f0jP97PCDTy9CdSr8mW0txQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.4.tgz",
+      "integrity": "sha512-1KMwLnfo0FyhF06TQKzqIm8BiY1yoMIGICxRdJHUjzskaHMzHMmpLlmNFgzoa4pAC8t1CDPK5jWuQTvv1pBsEQ==",
       "dev": true,
       "requires": {
         "array-back": "^4.0.0",
-        "cache-point": "^0.4.1",
+        "cache-point": "^1.0.0",
         "collect-all": "^1.0.3",
         "file-set": "^2.0.1",
         "fs-then-native": "^2.0.0",
@@ -5596,6 +5597,19 @@
         "object-to-spawn-args": "^1.1.1",
         "temp-path": "^1.0.0",
         "walk-back": "^3.0.1"
+      },
+      "dependencies": {
+        "cache-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-1.0.0.tgz",
+          "integrity": "sha512-ZqrZp9Hi5Uq7vfSGmNP2bUT/9DzZC2Y/GXjHB8rUJN1a+KLmbV05+vxHipNsg8+CSVgjcVVzLV8VZms6w8ZeRw==",
+          "dev": true,
+          "requires": {
+            "array-back": "^4.0.0",
+            "fs-then-native": "^2.0.0",
+            "mkdirp2": "^1.0.4"
+          }
+        }
       }
     },
     "jsdoc-parse": {
@@ -5613,15 +5627,15 @@
       }
     },
     "jsdoc-to-markdown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.1.tgz",
-      "integrity": "sha512-l+2sPeNM0V4iYHMS5IGhwKDtCTAW0sF4PAXX1AX9f7r6xfszTB8bqlqNR8ymvU85L9U2kEQ/Qemd5NrtX5DR0w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.2.tgz",
+      "integrity": "sha512-Rcs9/3+NO1odClVhLDk0lDNFe11RiYUHh/PnROT5QU2Fpad2zBESmJD+DcmeK7lg1jalFfGG1MKOGuJHs27jsA==",
       "dev": true,
       "requires": {
         "array-back": "^4.0.0",
         "command-line-tool": "^0.8.0",
         "config-master": "^3.1.0",
-        "dmd": "^4.0.2",
+        "dmd": "^4.0.4",
         "jsdoc-api": "^5.0.3",
         "jsdoc-parse": "^4.0.1",
         "walk-back": "^3.0.1"
@@ -6570,7 +6584,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -6998,7 +7012,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -7119,7 +7133,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8220,7 +8234,7 @@
         },
         "qs": {
           "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
           "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g=",
           "dev": true
         }
@@ -8954,7 +8968,7 @@
     },
     "rw": {
       "version": "1.3.3",
-      "resolved": "https://repos.kreatio.com/repository/npm-all/rw/-/rw-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rxjs": {
@@ -10111,7 +10125,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt-fileindex": "~0.1",
     "grunt-gh-pages": "^3.1.0",
     "grunt-jsdoc": "^2.4.0",
-    "grunt-jsdoc-to-markdown": "github:dc-js/grunt-jsdoc-to-markdown",
+    "grunt-jsdoc-to-markdown": "^5.0.0",
     "grunt-karma": "^3.0.2",
     "grunt-rollup": "^10.0.0",
     "grunt-sass": "^3.1.0",


### PR DESCRIPTION
It seems you may have fixed it already in some commit, please merge the same, If not, please merge this.

It has started to mess up the development workflow.
