### PR TITLE
Module sample

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,11 @@
 !LICENSE
 !dist/**/*
 
+# ES6 modules
+!src/**/*
+
+# Exclude index-with-version from ES6 modules
+src/index-with-version.js
+
 # ignore the source map files, these have no use without source files
 dist/**/*.map

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,11 +79,11 @@ module.exports = function (grunt) {
                 tasks: ['test']
             },
             reload: {
-                files: ['<%= conf.dist %>/es6/<%= conf.pkg.name %>.js',
+                files: ['<%= conf.dist %>/<%= conf.pkg.name %>.js',
                         '<%= conf.dist %>/style/<%= conf.pkg.name %>.css',
                         '<%= conf.web %>/js/<%= conf.pkg.name %>.js',
                         '<%= conf.web %>/css/<%= conf.pkg.name %>.css',
-                        '<%= conf.dist %>/es6/<%= conf.pkg.name %>.min.js'],
+                        '<%= conf.dist %>/<%= conf.pkg.name %>.min.js'],
                 options: {
                     livereload: true
                 }
@@ -117,7 +117,7 @@ module.exports = function (grunt) {
                 src: [
                     '<%= conf.web %>/js/d3.js',
                     '<%= conf.web %>/js/crossfilter.js',
-                    '<%= conf.dist %>/es6/<%= conf.pkg.name %>.js'
+                    '<%= conf.dist %>/<%= conf.pkg.name %>.js'
                 ]
             }
         },
@@ -133,7 +133,7 @@ module.exports = function (grunt) {
                     // source files, that you wanna generate coverage for
                     // do not include tests or libraries
                     // (these files will be instrumented by Istanbul)
-                    '<%= conf.dist %>/es6/<%= conf.pkg.name %>.js': ['coverage']
+                    '<%= conf.dist %>/<%= conf.pkg.name %>.js': ['coverage']
                 },
 
                 // optionally, configure the reporter
@@ -199,7 +199,7 @@ module.exports = function (grunt) {
         },
         jsdoc2md: {
             dist: {
-                src: '<%= conf.dist %>/es6/<%= conf.pkg.name %>.js',
+                src: '<%= conf.dist %>/<%= conf.pkg.name %>.js',
                 dest: 'web/docs/api-latest.md'
             }
         },
@@ -232,10 +232,10 @@ module.exports = function (grunt) {
                         flatten: true,
                         nonull: true,
                         src: [
-                            '<%= conf.dist %>/es6/<%= conf.pkg.name %>.js',
-                            '<%= conf.dist %>/es6/<%= conf.pkg.name %>.js.map',
-                            '<%= conf.dist %>/es6/<%= conf.pkg.name %>.min.js',
-                            '<%= conf.dist %>/es6/<%= conf.pkg.name %>.min.js.map',
+                            '<%= conf.dist %>/<%= conf.pkg.name %>.js',
+                            '<%= conf.dist %>/<%= conf.pkg.name %>.js.map',
+                            '<%= conf.dist %>/<%= conf.pkg.name %>.min.js',
+                            '<%= conf.dist %>/<%= conf.pkg.name %>.min.js.map',
                             'node_modules/d3/' + d3pkgSubDir + '/d3.js',
                             'node_modules/crossfilter2/crossfilter.js',
                             'node_modules/file-saver/FileSaver.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
             'web/js/d3.js',
             'web/js/crossfilter.js',
             // Code to be tested
-            'dist/es6/dc.js',
+            'dist/dc.js',
             // Jasmine spec files
             'spec/*spec.js'
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3676,15 +3676,15 @@
       }
     },
     "glob": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.2",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -3797,6 +3797,20 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "grunt-cli": {
           "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -80,12 +80,12 @@
       "files": [
         "dist/style/dc.css",
         "dist/style/dc.min.css",
-        "dist/es6/dc.min.js",
-        "dist/es6/dc.js"
+        "dist/dc.min.js",
+        "dist/dc.js"
       ]
     }
   ],
-  "browser": "dist/es6/dc.js",
-  "main": "dist/es6/dc.js",
+  "browser": "dist/dc.js",
+  "main": "dist/dc.js",
   "module": "dist/esm/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "compare-versions": "^3.5.1",
     "crossfilter2": "^1.4.7",
     "file-saver": "^1.3.8",
+    "glob": "^7.1.5",
     "grunt": "^1.0.4",
     "grunt-browserify": "^5.2.0",
     "grunt-cli": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -87,5 +87,5 @@
   ],
   "browser": "dist/es6/dc.js",
   "main": "dist/es6/dc.js",
-  "module": "dist/es6/dc.esm.js"
+  "module": "dist/esm/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -87,5 +87,5 @@
   ],
   "browser": "dist/dc.js",
   "main": "dist/dc.js",
-  "module": "dist/esm/index.js"
+  "module": "src/index.js"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import {terser} from 'rollup-plugin-terser';
 import json from 'rollup-plugin-json';
+import glob from 'glob';
 import license from 'rollup-plugin-license';
 
 const jsonPlugin = json({include: 'package.json', preferConst: true});
@@ -32,31 +33,21 @@ const esmFlat = {
 
 const esmFlatMin = Object.assign({}, esmFlat, {file: 'dist/esf/dc.esm.min.js'});
 
-const modulesMap = {
-    'index': 'src/index.js',
-    'legend': 'src/base/legend.js',
+/*
+It will have entries like
+{
     'html-legend': 'src/base/html-legend.js',
-    'bar-chart': 'src/charts/bar-chart.js',
-    'box-plot': 'src/charts/box-plot.js',
-    'bubble-chart': 'src/charts/bubble-chart.js',
-    'bubble-overlay': 'src/charts/bubble-overlay.js',
-    'cbox-menu': 'src/charts/cbox-menu.js',
-    'composite-chart': 'src/charts/composite-chart.js',
-    'data-count': 'src/charts/data-count.js',
-    'data-grid': 'src/charts/data-grid.js',
-    'data-table': 'src/charts/data-table.js',
-    'geo-choropleth-chart': 'src/charts/geo-choropleth-chart.js',
-    'heatmap': 'src/charts/heatmap.js',
-    'line-chart': 'src/charts/line-chart.js',
-    'number-display': 'src/charts/number-display.js',
-    'pie-chart': 'src/charts/pie-chart.js',
-    'row-chart': 'src/charts/row-chart.js',
-    'scatter-plot': 'src/charts/scatter-plot.js',
-    'select-menu': 'src/charts/select-menu.js',
-    'series-chart': 'src/charts/series-chart.js',
-    'sunburst-chart': 'src/charts/sunburst-chart.js',
-    'text-filter-widget': 'src/charts/text-filter-widget.js'
-};
+    'bar-chart': 'src/charts/bar-chart.js'
+}
+
+This list is populated base on files in the src folder.
+If needed, some entries can be removed.
+*/
+const modulesMap = {};
+glob.sync('src/**/*.js', {}).forEach(function (f) {
+    const res = f.match(/\/([^\/]*).js$/);
+    modulesMap[res[1]] = f;
+});
 
 export default [
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import {terser} from 'rollup-plugin-terser';
 import json from 'rollup-plugin-json';
-import glob from 'glob';
 import license from 'rollup-plugin-license';
 
 const jsonPlugin = json({include: 'package.json', preferConst: true});
@@ -25,22 +24,6 @@ const umdConf = {
 
 const umdMinConf = Object.assign({}, umdConf, {file: 'dist/dc.min.js'});
 
-/*
-It will have entries like
-{
-    'html-legend': 'src/base/html-legend.js',
-    'bar-chart': 'src/charts/bar-chart.js'
-}
-
-This list is populated base on files in the src folder.
-If needed, some entries can be removed.
-*/
-const modulesMap = {};
-glob.sync('src/**/*.js', {}).forEach(function (f) {
-    const res = f.match(/\/([^\/]*).js$/);
-    modulesMap[res[1]] = f;
-});
-
 export default [
     {
         input: 'src/index-with-version.js',
@@ -54,17 +37,5 @@ export default [
             umdConf,
             umdMinConf
         ]
-    },
-    {
-        input: modulesMap,
-        external: ['d3'],
-        plugins: [
-            jsonPlugin,
-            licensePlugin
-        ],
-        output: {
-            dir: 'dist/esm',
-            format: 'esm'
-        }
     }
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ const licensePlugin = license({
 });
 
 const umdConf = {
-    file: 'dist/es6/dc.js',
+    file: 'dist/dc.js',
     format: 'umd',
     name: 'dc',
     sourcemap: true,
@@ -23,7 +23,7 @@ const umdConf = {
     }
 };
 
-const umdMinConf = Object.assign({}, umdConf, {file: 'dist/es6/dc.min.js'});
+const umdMinConf = Object.assign({}, umdConf, {file: 'dist/dc.min.js'});
 
 /*
 It will have entries like

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,7 +43,7 @@ glob.sync('src/**/*.js', {}).forEach(function (f) {
 
 export default [
     {
-        input: 'src/index.js',
+        input: 'src/index-with-version.js',
         external: ['d3'],
         plugins: [
             terser({include: [/^.+\.min\.js$/]}),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,14 +25,6 @@ const umdConf = {
 
 const umdMinConf = Object.assign({}, umdConf, {file: 'dist/es6/dc.min.js'});
 
-const esmFlat = {
-    format: 'esm',
-    sourcemap: true,
-    file: 'dist/esf/dc.esm.js'
-};
-
-const esmFlatMin = Object.assign({}, esmFlat, {file: 'dist/esf/dc.esm.min.js'});
-
 /*
 It will have entries like
 {
@@ -60,9 +52,7 @@ export default [
         ],
         output: [
             umdConf,
-            umdMinConf,
-            esmFlat,
-            esmFlatMin
+            umdMinConf
         ]
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -66,18 +66,5 @@ export default [
             dir: 'dist/esm',
             format: 'esm'
         }
-    },
-    {
-        input: modulesMap,
-        external: ['d3'],
-        plugins: [
-            terser(),
-            jsonPlugin,
-            licensePlugin
-        ],
-        output: {
-            dir: 'dist/esm-min',
-            format: 'esm'
-        }
     }
 ];

--- a/src/index-with-version.js
+++ b/src/index-with-version.js
@@ -1,0 +1,4 @@
+// Need rollup-plugin-json for the following magic
+export {version} from '../package.json';
+
+export * from './index';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-// Need rollup-plugin-json from the following magic
-export {version} from '../package.json';
-
 export * from './core/chart-registry';
 export * from './core/constants';
 export * from './core/core';


### PR DESCRIPTION
While creating the samples the ideal structure for modules have started emerging. At present I have made each source file to be a module in the output as well. This seems to be ok for now. In future we may rearrange code based on usage patterns.

The commit https://github.com/dc-js/dc.js/commit/8ceec9e428426102ae500cb8525321be37856c45 has the new module structure. I have also set the `esm` to be the default module as per package.json. We will figure out if this works better during development of samples.