### PR TITLE
Convert Logger and Chart Registry to ES6 classes

### DIFF
--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -78,32 +78,6 @@ describe('dc.logger', () => {
         });
     });
 
-    describe('deprecate', () => {
-        let dummy, wrappedFn;
-
-        beforeEach(() => {
-            dummy = {
-                origFn: function () {
-                }
-            };
-            spyOn(dummy, 'origFn');
-            spyOn(dc.logger, 'warn');
-
-            wrappedFn = dc.logger.deprecate(dummy.origFn, 'origFn is deprecated');
-        });
-        it('should call deprecated function and issue a warning', () => {
-            wrappedFn('a');
-            expect(dummy.origFn).toHaveBeenCalledWith('a');
-            expect(dc.logger.warn).toHaveBeenCalled();
-        });
-        it('should warn for one deprecated function only once', () => {
-            wrappedFn();
-            wrappedFn();
-            expect(dummy.origFn.calls.count()).toBe(2);
-            expect(dc.logger.warn.calls.count()).toBe(1);
-        });
-    });
-
     describe('warnOnce', () => {
         beforeEach(() => {
             spyOn(dc.logger, 'warn');

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -114,9 +114,10 @@ export class HeatMap extends ColorMixin(MarginMixin) {
     }
 
     filter (filter) {
-        const nonstandardFilter = logger.deprecate(
-            f => this._filter(filters.TwoDimensionalFilter(f)),
-            'heatmap.filter taking a coordinate is deprecated - please pass dc.filters.TwoDimensionalFilter instead');
+        const nonstandardFilter = f => {
+            logger.warnOnce('heatmap.filter taking a coordinate is deprecated - please pass dc.filters.TwoDimensionalFilter instead');
+            return this._filter(filters.TwoDimensionalFilter(f));
+        };
 
         if (!arguments.length) {
             return super.filter();

--- a/src/core/chart-registry.js
+++ b/src/core/chart-registry.js
@@ -1,6 +1,93 @@
 import {constants} from './constants';
 import {config} from './config';
 
+class ChartRegistry {
+    constructor () {
+        // chartGroup:string => charts:array
+        this._chartMap = {};
+    }
+
+    _initializeChartGroup (group) {
+        if (!group) {
+            group = constants.DEFAULT_CHART_GROUP;
+        }
+
+        if (!(this._chartMap)[group]) {
+            (this._chartMap)[group] = [];
+        }
+
+        return group;
+    }
+
+    /**
+     * Determine if a given chart instance resides in any group in the registry.
+     * @param {Object} chart dc.js chart instance
+     * @returns {Boolean}
+     */
+    has (chart) {
+        for (const e in this._chartMap) {
+            if ((this._chartMap)[e].indexOf(chart) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Add given chart instance to the given group, creating the group if necessary.
+     * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
+     * @param {Object} chart dc.js chart instance
+     * @param {String} [group] Group name
+     * @return {undefined}
+     */
+    register (chart, group) {
+        const _chartMap = this._chartMap;
+        group = this._initializeChartGroup(group);
+        _chartMap[group].push(chart);
+    }
+
+    /**
+     * Remove given chart instance from the given group, creating the group if necessary.
+     * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
+     * @param {Object} chart dc.js chart instance
+     * @param {String} [group] Group name
+     * @return {undefined}
+     */
+    deregister (chart, group) {
+        group = this._initializeChartGroup(group);
+        for (let i = 0; i < (this._chartMap)[group].length; i++) {
+            if ((this._chartMap)[group][i].anchorName() === chart.anchorName()) {
+                (this._chartMap)[group].splice(i, 1);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Clear given group if one is provided, otherwise clears all groups.
+     * @param {String} group Group name
+     * @return {undefined}
+     */
+    clear (group) {
+        if (group) {
+            delete (this._chartMap)[group];
+        } else {
+            this._chartMap = {};
+        }
+    }
+
+    /**
+     * Get an array of each chart instance in the given group.
+     * If no group is provided, the charts in the default group are returned.
+     * @param {String} [group] Group name
+     * @returns {Array<Object>}
+     */
+    list (group) {
+        group = this._initializeChartGroup(group);
+        return (this._chartMap)[group];
+    }
+}
+
 /**
  * The chartRegistry object maintains sets of all instantiated dc.js charts under named groups
  * and the default group.
@@ -11,105 +98,8 @@ import {config} from './config';
  * {@link renderAll renderAll}, {@link redrawAll redrawAll}, or chart functions
  * {@link baseMixin#renderGroup baseMixin.renderGroup},
  * {@link baseMixin#redrawGroup baseMixin.redrawGroup} are called.
- *
- * @namespace chartRegistry
- * @type {{has, register, deregister, clear, list}}
  */
-export const chartRegistry = (function () {
-    // chartGroup:string => charts:array
-    let _chartMap = {};
-
-    function initializeChartGroup (group) {
-        if (!group) {
-            group = constants.DEFAULT_CHART_GROUP;
-        }
-
-        if (!_chartMap[group]) {
-            _chartMap[group] = [];
-        }
-
-        return group;
-    }
-
-    return {
-        /**
-         * Determine if a given chart instance resides in any group in the registry.
-         * @method has
-         * @memberof chartRegistry
-         * @param {Object} chart dc.js chart instance
-         * @returns {Boolean}
-         */
-        has: function (chart) {
-            for (const e in _chartMap) {
-                if (_chartMap[e].indexOf(chart) >= 0) {
-                    return true;
-                }
-            }
-            return false;
-        },
-
-        /**
-         * Add given chart instance to the given group, creating the group if necessary.
-         * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
-         * @method register
-         * @memberof chartRegistry
-         * @param {Object} chart dc.js chart instance
-         * @param {String} [group] Group name
-         * @return {undefined}
-         */
-        register: function (chart, group) {
-            group = initializeChartGroup(group);
-            _chartMap[group].push(chart);
-        },
-
-        /**
-         * Remove given chart instance from the given group, creating the group if necessary.
-         * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
-         * @method deregister
-         * @memberof chartRegistry
-         * @param {Object} chart dc.js chart instance
-         * @param {String} [group] Group name
-         * @return {undefined}
-         */
-        deregister: function (chart, group) {
-            group = initializeChartGroup(group);
-            for (let i = 0; i < _chartMap[group].length; i++) {
-                if (_chartMap[group][i].anchorName() === chart.anchorName()) {
-                    _chartMap[group].splice(i, 1);
-                    break;
-                }
-            }
-        },
-
-        /**
-         * Clear given group if one is provided, otherwise clears all groups.
-         * @method clear
-         * @memberof chartRegistry
-         * @param {String} group Group name
-         * @return {undefined}
-         */
-        clear: function (group) {
-            if (group) {
-                delete _chartMap[group];
-            } else {
-                _chartMap = {};
-            }
-        },
-
-        /**
-         * Get an array of each chart instance in the given group.
-         * If no group is provided, the charts in the default group are returned.
-         * @method list
-         * @memberof chartRegistry
-         * @param {String} [group] Group name
-         * @returns {Array<Object>}
-         */
-        list: function (group) {
-            group = initializeChartGroup(group);
-            return _chartMap[group];
-        }
-    };
-})();
+export const chartRegistry = new ChartRegistry();
 
 /**
  * Add given chart instance to the given group, creating the group if necessary.

--- a/src/core/logger.js
+++ b/src/core/logger.js
@@ -1,31 +1,28 @@
 /**
  * Provides basis logging and deprecation utilities
- * @class logger
- * @returns {logger}
  */
-export const logger = (function () {
+export class Logger {
 
-    const _logger = {};
+    constructor () {
+        /**
+         * Enable debug level logging. Set to `false` by default.
+         * @name enableDebugLog
+         * @memberof Logger
+         * @instance
+         */
+        this.enableDebugLog = false;
 
-    /**
-     * Enable debug level logging. Set to `false` by default.
-     * @name enableDebugLog
-     * @memberof logger
-     * @instance
-     */
-    _logger.enableDebugLog = false;
+        this._alreadyWarned = {};
+    }
 
     /**
      * Put a warning message to console
-     * @method warn
-     * @memberof logger
-     * @instance
      * @example
      * logger.warn('Invalid use of .tension on CurveLinear');
      * @param {String} [msg]
-     * @returns {logger}
+     * @returns {Logger}
      */
-    _logger.warn = function (msg) {
+    warn (msg) {
         if (console) {
             if (console.warn) {
                 console.warn(msg);
@@ -34,43 +31,35 @@ export const logger = (function () {
             }
         }
 
-        return _logger;
-    };
-
-    const _alreadyWarned = {};
+        return this;
+    }
 
     /**
      * Put a warning message to console. It will warn only on unique messages.
-     * @method warnOnce
-     * @memberof logger
-     * @instance
      * @example
      * logger.warnOnce('Invalid use of .tension on CurveLinear');
      * @param {String} [msg]
-     * @returns {logger}
+     * @returns {Logger}
      */
-    _logger.warnOnce = function (msg) {
-        if (!_alreadyWarned[msg]) {
-            _alreadyWarned[msg] = true;
+    warnOnce (msg) {
+        if (!this._alreadyWarned[msg]) {
+            this._alreadyWarned[msg] = true;
 
             logger.warn(msg);
         }
 
-        return _logger;
-    };
+        return this;
+    }
 
     /**
      * Put a debug message to console. It is controlled by `logger.enableDebugLog`
-     * @method debug
-     * @memberof logger
-     * @instance
      * @example
      * logger.debug('Total number of slices: ' + numSlices);
      * @param {String} [msg]
-     * @returns {logger}
+     * @returns {Logger}
      */
-    _logger.debug = function (msg) {
-        if (_logger.enableDebugLog && console) {
+    debug (msg) {
+        if (this.enableDebugLog && console) {
             if (console.debug) {
                 console.debug(msg);
             } else if (console.log) {
@@ -78,77 +67,8 @@ export const logger = (function () {
             }
         }
 
-        return _logger;
-    };
+        return this;
+    }
+}
 
-    /**
-     * Used to deprecate a function. It will return a wrapped version of the function, which will
-     * will issue a warning when invoked. The warning will be issued only once.
-     *
-     * @method deprecate
-     * @memberof logger
-     * @instance
-     * @example
-     * _chart.interpolate = logger.deprecate(function (interpolate) {
-     *    if (!arguments.length) {
-     *        return _interpolate;
-     *    }
-     *    _interpolate = interpolate;
-     *    return _chart;
-     * }, 'lineChart.interpolate has been deprecated since version 3.0 use lineChart.curve instead');
-     * @param {Function} [fn]
-     * @param {String} [msg]
-     * @returns {Function}
-     */
-    _logger.deprecate = function (fn, msg) {
-        // Allow logging of deprecation
-        let warned = false;
-
-        function deprecated () {
-            if (!warned) {
-                _logger.warn(msg);
-                warned = true;
-            }
-            return fn.apply(this, arguments);
-        }
-        return deprecated;
-    };
-
-    /**
-     * Used to provide an informational message for a function. It will return a wrapped version of
-     * the function, which will will issue a messsage with stack when invoked. The message will be
-     * issued only once.
-     *
-     * @method annotate
-     * @memberof logger
-     * @instance
-     * @example
-     * _chart.interpolate = logger.annotate(function (interpolate) {
-     *    if (!arguments.length) {
-     *        return _interpolate;
-     *    }
-     *    _interpolate = interpolate;
-     *    return _chart;
-     * }, 'lineChart.interpolate has been annotated since version 3.0 use lineChart.curve instead');
-     * @param {Function} [fn]
-     * @param {String} [msg]
-     * @returns {Function}
-     */
-    _logger.annotate = function (fn, msg) {
-        // Allow logging of deprecation
-        let warned = false;
-
-        function annotated () {
-            if (!warned) {
-                console.groupCollapsed(msg);
-                console.trace();
-                console.groupEnd();
-                warned = true;
-            }
-            return fn.apply(this, arguments);
-        }
-        return annotated;
-    };
-
-    return _logger;
-})();
+export const logger = new Logger();


### PR DESCRIPTION
I have also cleaned up methods `logger.deprecate` and `logger.annotate`. Ref #1630 