### PR TITLE
Watch `web-src` and `docs` as well during `watch:test` grunt task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
                 tasks: ['sass', 'cssmin:main', 'copy:dc-to-gh']
             },
             tests: {
-                files: ['<%= conf.src %>/**/*.js', '<%= conf.spec %>/**/*.js'],
+                files: ['<%= conf.src %>/**/*.js', '<%= conf.spec %>/**/*.js', 'web-src/**/*', 'docs/**/*'],
                 tasks: ['test']
             },
             reload: {


### PR DESCRIPTION
Fixes #1635 