### PR TITLE
Cleanup redundant code in Sunburst chart

### DIFF
--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -24,8 +24,10 @@ const _defaultFilterHandler = (dimension, filters) => {
         dimension.filterFunction(d => {
             for (let i = 0; i < filters.length; i++) {
                 const filter = filters[i];
-                if (filter.isFiltered && filter.isFiltered(d)) {
-                    return true;
+                if (filter.isFiltered) {
+                    if(filter.isFiltered(d)) {
+                        return true;
+                    }
                 } else if (filter <= d && filter >= d) {
                     return true;
                 }

--- a/src/charts/sunburst-chart.js
+++ b/src/charts/sunburst-chart.js
@@ -73,23 +73,6 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
 
         this.transitionDuration(350);
 
-        this.filterHandler((dimension, _filters) => {
-            if (_filters.length === 0) {
-                dimension.filter(null);
-            } else {
-                dimension.filterFunction(d => {
-                    for (let i = 0; i < _filters.length; i++) {
-                        const filter = _filters[i];
-                        if (filter.isFiltered && filter.isFiltered(d)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                });
-            }
-            return _filters;
-        });
-
         this.anchor(parent, chartGroup);
     }
 


### PR DESCRIPTION
While working on some other refactors, I came across this.

Removing this code does not seem to have any impact. Test cases still pass, the charts work. In addition, reading the code makes the believe that the BaseMixin's implementation covers the needs of this chart.