### PR TITLE
Cleanup color-mixin and color accessor

### DIFF
--- a/spec/color-spec.js
+++ b/spec/color-spec.js
@@ -2,7 +2,7 @@
 describe('dc.colorMixin', () => {
     function colorTest (chart, domain, test) {
         chart.colorDomain(domain);
-        return (test || domain).map(chart.getColor);
+        return (test || domain).map((d, i) => chart.getColor(d, i));
     }
 
     function identity (d) { return d; }

--- a/src/base/color-mixin.js
+++ b/src/base/color-mixin.js
@@ -20,27 +20,21 @@ export const ColorMixin = Base => class extends Base {
 
         this._colorAccessor = d => this.keyAccessor()(d);
         this._colorCalculator = undefined;
+    }
 
-        {
-            const chart = this;
-            // ES6: this method is called very differently from stack-mixin and derived charts
-            // Removing and placing it as a member method is tricky
-
-            /**
-                 * Get the color for the datum d and counter i. This is used internally by charts to retrieve a color.
-                 * @method getColor
-                 * @memberof ColorMixin
-                 * @instance
-                 * @param {*} d
-                 * @param {Number} [i]
-                 * @returns {String}
-                 */
-            chart.getColor = function (d, i) {
-                return chart._colorCalculator ?
-                    chart._colorCalculator.call(this, d, i) :
-                    chart._colors(chart._colorAccessor.call(this, d, i));
-            };
-        }
+    /**
+     * Get the color for the datum d and counter i. This is used internally by charts to retrieve a color.
+     * @method getColor
+     * @memberof ColorMixin
+     * @instance
+     * @param {*} d
+     * @param {Number} [i]
+     * @returns {String}
+     */
+    getColor (d, i) {
+        return this._colorCalculator ?
+            this._colorCalculator(d, i) :
+            this._colors(this._colorAccessor(d, i));
     }
 
     /**

--- a/src/base/stack-mixin.js
+++ b/src/base/stack-mixin.js
@@ -114,6 +114,8 @@ export class StackMixin extends CoordinateGridMixin {
         const layer = {group: group};
         if (typeof name === 'string') {
             layer.name = name;
+        } else {
+            layer.name = String(this._stack.length);
         }
         if (typeof accessor === 'function') {
             layer.accessor = accessor;

--- a/src/base/stack-mixin.js
+++ b/src/base/stack-mixin.js
@@ -19,10 +19,11 @@ export class StackMixin extends CoordinateGridMixin {
         this._titles = {};
 
         this._hidableStacks = false;
+        this._hiddenStacks = {};
         this._evadeDomainFilter = false;
 
         this.data(() => {
-            const layers = this._stack.filter(this._visibility);
+            const layers = this._stack.filter(l => this._visibility(l));
             if (!layers.length) {
                 return [];
             }
@@ -53,12 +54,13 @@ export class StackMixin extends CoordinateGridMixin {
     _prepareValues (layer, layerIdx) {
         const valAccessor = layer.accessor || this.valueAccessor();
         layer.name = String(layer.name || layerIdx);
+        const isLayerHidden = !this._visibility(layer);
         const allValues = layer.group.all().map((d, i) => ({
             x: this.keyAccessor()(d, i),
-            y: layer.hidden ? null : valAccessor(d, i),
+            y: isLayerHidden ? null : valAccessor(d, i),
             data: d,
             layer: layer.name,
-            hidden: layer.hidden
+            hidden: isLayerHidden
         }));
 
         layer.domainValues = allValues.filter(l => this._domainFilter()(l));
@@ -160,10 +162,7 @@ export class StackMixin extends CoordinateGridMixin {
      * @returns {StackMixin}
      */
     hideStack (stackName) {
-        const layer = this._findLayerByName(stackName);
-        if (layer) {
-            layer.hidden = true;
-        }
+        this._hiddenStacks[stackName] = true;
         return this;
     }
 
@@ -174,10 +173,7 @@ export class StackMixin extends CoordinateGridMixin {
      * @returns {StackMixin}
      */
     showStack (stackName) {
-        const layer = this._findLayerByName(stackName);
-        if (layer) {
-            layer.hidden = false;
-        }
+        this._hiddenStacks[stackName] = false;
         return this;
     }
 
@@ -287,7 +283,7 @@ export class StackMixin extends CoordinateGridMixin {
     }
 
     _visibility (l) {
-        return !l.hidden;
+        return !this._hiddenStacks[l.name];
     }
 
     _ordinalXDomain () {
@@ -300,14 +296,14 @@ export class StackMixin extends CoordinateGridMixin {
         return this._stack.map((layer, i) => ({
             chart: this,
             name: layer.name,
-            hidden: layer.hidden || false,
+            hidden: !this._visibility(layer),
             color: this.getColor.call(layer, layer.values, i)
         }));
     }
 
     isLegendableHidden (d) {
         const layer = this._findLayerByName(d.name);
-        return layer ? layer.hidden : false;
+        return layer ? !this._visibility(layer) : false;
     }
 
     legendToggle (d) {

--- a/src/base/stack-mixin.js
+++ b/src/base/stack-mixin.js
@@ -53,14 +53,11 @@ export class StackMixin extends CoordinateGridMixin {
 
     _prepareValues (layer, layerIdx) {
         const valAccessor = layer.accessor || this.valueAccessor();
-        layer.name = String(layer.name || layerIdx);
-        const isLayerHidden = !this._visibility(layer);
         const allValues = layer.group.all().map((d, i) => ({
             x: this.keyAccessor()(d, i),
-            y: isLayerHidden ? null : valAccessor(d, i),
+            y: valAccessor(d, i),
             data: d,
-            layer: layer.name,
-            hidden: isLayerHidden
+            layer: layer.name
         }));
 
         layer.domainValues = allValues.filter(l => this._domainFilter()(l));

--- a/src/base/stack-mixin.js
+++ b/src/base/stack-mixin.js
@@ -46,9 +46,7 @@ export class StackMixin extends CoordinateGridMixin {
             return layers;
         });
 
-        this.colorAccessor(function (d) {
-            return this.name || d.name;
-        });
+        this.colorAccessor(d => d.name);
     }
 
     _prepareValues (layer, layerIdx) {
@@ -296,7 +294,7 @@ export class StackMixin extends CoordinateGridMixin {
             chart: this,
             name: layer.name,
             hidden: !this._visibility(layer),
-            color: this.getColor.call(layer, layer.values, i)
+            color: this.getColor(layer, i)
         }));
     }
 

--- a/src/base/stack-mixin.js
+++ b/src/base/stack-mixin.js
@@ -47,7 +47,7 @@ export class StackMixin extends CoordinateGridMixin {
         });
 
         this.colorAccessor(function (d) {
-            return this.layer || this.name || d.name || d.layer;
+            return this.name || d.name;
         });
     }
 
@@ -57,7 +57,7 @@ export class StackMixin extends CoordinateGridMixin {
             x: this.keyAccessor()(d, i),
             y: valAccessor(d, i),
             data: d,
-            layer: layer.name
+            name: layer.name
         }));
 
         layer.domainValues = allValues.filter(l => this._domainFilter()(l));

--- a/src/charts/bar-chart.js
+++ b/src/charts/bar-chart.js
@@ -176,7 +176,7 @@ export class BarChart extends StackMixin {
         const enter = bars.enter()
             .append('rect')
             .attr('class', 'bar')
-            .attr('fill', pluck('data', this.getColor))
+            .attr('fill', (d, i) => this.getColor(d, i))
             .attr('x', d => this._barXPos(d))
             .attr('y', this.yAxisHeight())
             .attr('height', 0);
@@ -204,7 +204,7 @@ export class BarChart extends StackMixin {
             })
             .attr('width', this._barWidth)
             .attr('height', d => this._barHeight(d))
-            .attr('fill', pluck('data', this.getColor))
+            .attr('fill', (d, i) => this.getColor(d, i))
             .select('title').text(pluck('data', this.title(data.name)));
 
         transition(bars.exit(), this.transitionDuration(), this.transitionDelay())

--- a/src/charts/bubble-chart.js
+++ b/src/charts/bubble-chart.js
@@ -74,7 +74,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
             .attr('transform', d => this._bubbleLocator(d))
             .append('circle').attr('class', (d, i) => `${this.BUBBLE_CLASS} _${i}`)
             .on('click', d => this.onClick(d))
-            .attr('fill', this.getColor)
+            .attr('fill', (d, i) => this.getColor(d, i))
             .attr('r', 0);
 
         bubbleG = bubbleGEnter.merge(bubbleG);
@@ -95,7 +95,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
         transition(bubbleG, this.transitionDuration(), this.transitionDelay())
             .attr('transform', d => this._bubbleLocator(d))
             .select(`circle.${this.BUBBLE_CLASS}`)
-            .attr('fill', this.getColor)
+            .attr('fill', (d, i) => this.getColor(d, i))
             .attr('r', d => this.bubbleR(d))
             .attr('opacity', d => (this.bubbleR(d) > 0) ? 1 : 0);
 

--- a/src/charts/bubble-overlay.js
+++ b/src/charts/bubble-overlay.js
@@ -113,7 +113,7 @@ export class BubbleOverlay extends BubbleMixin(BaseMixin) {
                 circle = nodeG.append('circle')
                     .attr('class', BUBBLE_CLASS)
                     .attr('r', 0)
-                    .attr('fill', this.getColor)
+                    .attr('fill', (d, i) => this.getColor(d, i))
                     .on('click', d => this.onClick(d));
             }
 
@@ -169,7 +169,7 @@ export class BubbleOverlay extends BubbleMixin(BaseMixin) {
 
             transition(circle, this.transitionDuration(), this.transitionDelay())
                 .attr('r', d => this.bubbleR(d))
-                .attr('fill', this.getColor);
+                .attr('fill', (d, i) => this.getColor(d, i));
 
             this.doUpdateLabels(nodeG);
 

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -245,7 +245,7 @@ export class HeatMap extends ColorMixin(MarginMixin) {
             .attr('y', (d, i) => rows(this.valueAccessor()(d, i)))
             .attr('rx', this._xBorderRadius)
             .attr('ry', this._yBorderRadius)
-            .attr('fill', this.getColor)
+            .attr('fill', (d, i) => this.getColor(d, i))
             .attr('width', boxWidth)
             .attr('height', boxHeight);
 

--- a/src/charts/line-chart.js
+++ b/src/charts/line-chart.js
@@ -248,7 +248,7 @@ export class LineChart extends StackMixin {
     }
 
     _getColor (d, i) {
-        return this.getColor.call(d, d.values, i);
+        return this.getColor(d, i);
     }
 
     // To keep it backward compatible, this covers multiple cases
@@ -384,8 +384,8 @@ export class LineChart extends StackMixin {
                     .attr('r', this._getDotRadius())
                     .style('fill-opacity', this._dataPointFillOpacity)
                     .style('stroke-opacity', this._dataPointStrokeOpacity)
-                    .attr('fill', this.getColor)
-                    .attr('stroke', this.getColor)
+                    .attr('fill', (d, i) => this.getColor(d, i))
+                    .attr('stroke', (d, i) => this.getColor(d, i))
                     .on('mousemove', function () {
                         const dot = select(this);
                         chart._showDot(dot);
@@ -403,7 +403,7 @@ export class LineChart extends StackMixin {
                 transition(dotsEnterModify, this.transitionDuration())
                     .attr('cx', d => utils.safeNumber(this.x()(d.x)))
                     .attr('cy', d => utils.safeNumber(this.y()(d.y + d.y0)))
-                    .attr('fill', this.getColor);
+                    .attr('fill', (d, i) => this.getColor(d, i));
 
                 dots.exit().remove();
             });

--- a/src/charts/line-chart.js
+++ b/src/charts/line-chart.js
@@ -247,10 +247,6 @@ export class LineChart extends StackMixin {
         return this;
     }
 
-    _getColor (d, i) {
-        return this.getColor(d, i);
-    }
-
     // To keep it backward compatible, this covers multiple cases
     // See https://github.com/dc-js/dc.js/issues/1376
     // It will be removed when interpolate and tension are removed.
@@ -311,14 +307,14 @@ export class LineChart extends StackMixin {
 
         const path = layersEnter.append('path')
             .attr('class', 'line')
-            .attr('stroke', (d, i) => this._getColor(d, i));
+            .attr('stroke', (d, i) => this.getColor(d, i));
         if (this._dashStyle) {
             path.attr('stroke-dasharray', this._dashStyle);
         }
 
         transition(layers.select('path.line'), this.transitionDuration(), this.transitionDelay())
         //.ease('linear')
-            .attr('stroke', (d, i) => this._getColor(d, i))
+            .attr('stroke', (d, i) => this.getColor(d, i))
             .attr('d', d => this._safeD(_line(d.values)));
     }
 
@@ -335,12 +331,12 @@ export class LineChart extends StackMixin {
 
             layersEnter.append('path')
                 .attr('class', 'area')
-                .attr('fill', (d, i) => this._getColor(d, i))
+                .attr('fill', (d, i) => this.getColor(d, i))
                 .attr('d', d => this._safeD(_area(d.values)));
 
             transition(layers.select('path.area'), this.transitionDuration(), this.transitionDelay())
             //.ease('linear')
-                .attr('fill', (d, i) => this._getColor(d, i))
+                .attr('fill', (d, i) => this.getColor(d, i))
                 .attr('d', d => this._safeD(_area(d.values)));
         }
     }

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -189,7 +189,7 @@ export class RowChart extends CapMixin(ColorMixin(MarginMixin)) {
 
         const rect = rows.attr('transform', (d, i) => `translate(0,${(i + 1) * this._gap + i * height})`).select('rect')
             .attr('height', height)
-            .attr('fill', this.getColor)
+            .attr('fill', (d, i) => this.getColor(d, i))
             .on('click', d => this._onClick(d))
             .classed('deselected', d => (this.hasFilter()) ? !this._isSelectedRow(d) : false)
             .classed('selected', d => (this.hasFilter()) ? this._isSelectedRow(d) : false);

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -289,7 +289,7 @@ export class ScatterPlot extends CoordinateGridMixin {
             .append('path')
             .attr('class', 'symbol')
             .attr('opacity', 0)
-            .attr('fill', this.getColor)
+            .attr('fill', (d, i) => this.getColor(d, i))
             .attr('transform', d => this._locator(d))
             .merge(symbols);
 


### PR DESCRIPTION
Fixes #1575

The color accessor code in StackMixin was bit peculiar. By tracing the code it became clear that ultimately in all cases the name of the layer is getting used as the color accessor. So cleaning up the code to ensure that in every case we pass the entity that has `.name` (as the name of the layer).

Also made few small internal changes:

- Layer name is quite important, so as soon a new unnamed layer is added, a name is generated.
- The layer visibility information is maintained in a separate variable. This makes it more consistent.

With all the above changes, `getColor` has been moved as an instance method.

I do not think it breaks compatibility.