### PR TITLE
Rdoc fixes for ES6 version

### DIFF
--- a/src/base/bubble-mixin.js
+++ b/src/base/bubble-mixin.js
@@ -66,6 +66,8 @@ export const BubbleMixin = Base => class extends ColorMixin(Base) {
     /**
          * Turn on or off the elastic bubble radius feature, or return the value of the flag. If this
          * feature is turned on, then bubble radii will be automatically rescaled to fit the chart better.
+         * @memberof BubbleMixin
+         * @instance
          * @param {Boolean} [elasticRadius=false]
          * @returns {Boolean|BubbleChart}
          */

--- a/src/core/chart-registry.js
+++ b/src/core/chart-registry.js
@@ -108,6 +108,7 @@ export const chartRegistry = new ChartRegistry();
 /**
  * Add given chart instance to the given group, creating the group if necessary.
  * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
+ * @function registerChart
  * @param {Object} chart dc.js chart instance
  * @param {String} [group] Group name
  * @return {undefined}
@@ -119,6 +120,7 @@ export const registerChart = function (chart, group) {
 /**
  * Remove given chart instance from the given group, creating the group if necessary.
  * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
+ * @function deregisterChart
  * @param {Object} chart dc.js chart instance
  * @param {String} [group] Group name
  * @return {undefined}
@@ -129,6 +131,7 @@ export const deregisterChart = function (chart, group) {
 
 /**
  * Determine if a given chart instance resides in any group in the registry.
+ * @function hasChart
  * @param {Object} chart dc.js chart instance
  * @returns {Boolean}
  */
@@ -138,6 +141,7 @@ export const hasChart = function (chart) {
 
 /**
  * Clear given group if one is provided, otherwise clears all groups.
+ * @function deregisterAllCharts
  * @param {String} group Group name
  * @return {undefined}
  */
@@ -148,6 +152,7 @@ export const deregisterAllCharts = function (group) {
 /**
  * Clear all filters on all charts within the given chart group. If the chart group is not given then
  * only charts that belong to the default chart group will be reset.
+ * @function filterAll
  * @param {String} [group]
  * @return {undefined}
  */
@@ -161,6 +166,7 @@ export const filterAll = function (group) {
 /**
  * Reset zoom level / focus on all charts that belong to the given chart group. If the chart group is
  * not given then only charts that belong to the default chart group will be reset.
+ * @function refocusAll
  * @param {String} [group]
  * @return {undefined}
  */
@@ -176,6 +182,7 @@ export const refocusAll = function (group) {
 /**
  * Re-render all charts belong to the given chart group. If the chart group is not given then only
  * charts that belong to the default chart group will be re-rendered.
+ * @function renderAll
  * @param {String} [group]
  * @return {undefined}
  */
@@ -195,6 +202,7 @@ export const renderAll = function (group) {
  * that belong to the default chart group will be re-drawn. Redraw is different from re-render since
  * when redrawing dc tries to update the graphic incrementally, using transitions, instead of starting
  * from scratch.
+ * @function redrawAll
  * @param {String} [group]
  * @return {undefined}
  */

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -5,6 +5,7 @@ import {config} from './config';
  * ({@link disableTransitions} is false) and the duration is greater than zero; otherwise return
  * the selection. Since most operations are the same on a d3 selection and a d3 transition, this
  * allows a common code path for both cases.
+ * @function transition
  * @param {d3.selection} selection - the selection to be transitioned
  * @param {Number|Function} [duration=250] - the duration of the transition in milliseconds, a
  * function returning the duration, or 0 for no transition

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -21,6 +21,7 @@ import {config} from './config';
  *     return this.radius + x;
  * });
  * selectAll('.circle').data(...).x(xPosition);
+ * @function pluck
  * @param {String} n
  * @param {Function} [f]
  * @returns {Function}


### PR DESCRIPTION
Should fix #1674 

* Fixing documentation of global members with explicit annotation.
* Ensure `elasticRadius` is documented as part of `BubbleMixin`.