### PR TITLE
Add chartGroup in redrawAll()

### DIFF
--- a/src/charts/text-filter-widget.js
+++ b/src/charts/text-filter-widget.js
@@ -65,7 +65,7 @@ export class TextFilterWidget extends BaseMixin {
         this._input.on('input', function () {
             chart.dimension().filterFunction(chart._filterFunctionFactory(this.value));
             events.trigger(() => {
-                redrawAll();
+                redrawAll(chartGroup);
             }, constants.EVENT_DELAY);
         });
 


### PR DESCRIPTION
It took me some time to figure out why the text filter wasn't working anymore and then I remembered that I recently added groups to the charts. After some google magic I found https://github.com/dc-js/dc.js/issues/1498 en by changing redrawAll(); to redrawAll(chartGroup); it works again.