### PR TITLE
docs: Fix simple typo, exeeding -> exceeding

### DIFF
--- a/docs/api-latest.md
+++ b/docs/api-latest.md
@@ -2710,7 +2710,7 @@ var chart2 = new PieChart('#chart-container2', 'chartGroupA');
 
 ### pieChart.slicesCap([cap]) ⇒ <code>Number</code> \| [<code>PieChart</code>](#PieChart)
 Get or set the maximum number of slices the pie chart will generate. The top slices are determined by
-value from high to low. Other slices exeeding the cap will be rolled up into one single *Others* slice.
+value from high to low. Other slices exceeding the cap will be rolled up into one single *Others* slice.
 
 **Kind**: instance method of [<code>PieChart</code>](#PieChart)  
 

--- a/docs/old-api-docs/api-1.5.0.md
+++ b/docs/old-api-docs/api-1.5.0.md
@@ -488,7 +488,7 @@ Default min angle is 0.5.
 
 #### .slicesCap([cap])
 Get or set the maximum number of slices the pie chart will generate. Slices are ordered by its value from high to low.
- Other slices exeeding the cap will be rolled up into one single *Others* slice.
+ Other slices exceeding the cap will be rolled up into one single *Others* slice.
 
 #### .othersGrouper([grouperFunction])
 Get or set the grouper funciton that will perform the insersion of data for the *Others* slice if the slices cap is

--- a/docs/old-api-docs/api-1.6.0.md
+++ b/docs/old-api-docs/api-1.6.0.md
@@ -594,7 +594,7 @@ var chart2 = dc.pieChart("#chart-container2", "chartGroupA");
 
 #### .slicesCap([cap])
 Get or set the maximum number of slices the pie chart will generate. Slices are ordered by its value from high to low.
- Other slices exeeding the cap will be rolled up into one single *Others* slice.
+ Other slices exceeding the cap will be rolled up into one single *Others* slice.
 
 #### .innerRadius([innerRadius])
 Get or set the inner radius on a particular pie chart instance. If inner radius is greater than 0px then the pie chart

--- a/docs/old-api-docs/api-1.7.0.md
+++ b/docs/old-api-docs/api-1.7.0.md
@@ -597,7 +597,7 @@ var chart2 = dc.pieChart("#chart-container2", "chartGroupA");
 
 #### .slicesCap([cap])
 Get or set the maximum number of slices the pie chart will generate. Slices are ordered by its value from high to low.
- Other slices exeeding the cap will be rolled up into one single *Others* slice.
+ Other slices exceeding the cap will be rolled up into one single *Others* slice.
 
 #### .innerRadius([innerRadius])
 Get or set the inner radius on a particular pie chart instance. If inner radius is greater than 0px then the pie chart

--- a/docs/old-api-docs/api-2.0.0.md
+++ b/docs/old-api-docs/api-2.0.0.md
@@ -371,7 +371,7 @@ var chart2 = dc.pieChart('#chart-container2', 'chartGroupA');
 
 #### pieChart.slicesCap([cap]) ⇒ <code>Number</code> &#124; <code>[pieChart](#dc.pieChart)</code>
 Get or set the maximum number of slices the pie chart will generate. The top slices are determined by
-value from high to low. Other slices exeeding the cap will be rolled up into one single *Others* slice.
+value from high to low. Other slices exceeding the cap will be rolled up into one single *Others* slice.
 
 **Kind**: instance method of <code>[pieChart](#dc.pieChart)</code>  
 

--- a/docs/old-api-docs/api-2.1.0.md
+++ b/docs/old-api-docs/api-2.1.0.md
@@ -383,7 +383,7 @@ var chart2 = dc.pieChart('#chart-container2', 'chartGroupA');
 
 #### pieChart.slicesCap([cap]) ⇒ <code>Number</code> \| [<code>pieChart</code>](#dc.pieChart)
 Get or set the maximum number of slices the pie chart will generate. The top slices are determined by
-value from high to low. Other slices exeeding the cap will be rolled up into one single *Others* slice.
+value from high to low. Other slices exceeding the cap will be rolled up into one single *Others* slice.
 
 **Kind**: instance method of [<code>pieChart</code>](#dc.pieChart)  
 

--- a/docs/old-api-docs/api-3.1.9.md
+++ b/docs/old-api-docs/api-3.1.9.md
@@ -598,7 +598,7 @@ var chart2 = dc.pieChart('#chart-container2', 'chartGroupA');
 
 #### pieChart.slicesCap([cap]) ⇒ <code>Number</code> \| [<code>pieChart</code>](#dc.pieChart)
 Get or set the maximum number of slices the pie chart will generate. The top slices are determined by
-value from high to low. Other slices exeeding the cap will be rolled up into one single *Others* slice.
+value from high to low. Other slices exceeding the cap will be rolled up into one single *Others* slice.
 
 **Kind**: instance method of [<code>pieChart</code>](#dc.pieChart)  
 

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -75,7 +75,7 @@ export class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
 
     /**
      * Get or set the maximum number of slices the pie chart will generate. The top slices are determined by
-     * value from high to low. Other slices exeeding the cap will be rolled up into one single *Others* slice.
+     * value from high to low. Other slices exceeding the cap will be rolled up into one single *Others* slice.
      * @param {Number} [cap]
      * @returns {Number|PieChart}
      */


### PR DESCRIPTION
There is a small typo in docs/api-latest.md, docs/old-api-docs/api-1.5.0.md, docs/old-api-docs/api-1.6.0.md, docs/old-api-docs/api-1.7.0.md, docs/old-api-docs/api-2.0.0.md, docs/old-api-docs/api-2.1.0.md, docs/old-api-docs/api-3.1.9.md, src/charts/pie-chart.js.

Should read `exceeding` rather than `exeeding`.

