### PR TITLE
A strange interaction with crossfilter - subtle issue in Bubble Overlay

### DIFF
--- a/spec/bubble-overlay-spec.js
+++ b/spec/bubble-overlay-spec.js
@@ -103,17 +103,17 @@ describe('dc.bubbleOverlay', () => {
         });
     });
 
-    function removeEmptyBins (grp) {
+    function cloneAndRemoveEmptyBins (grp) {
         return {
             all: function () {
-                return grp.all().filter(d => d.value !== 0);
+                return grp.all().map(d => Object.assign({}, d)).filter(d => d.value !== 0);
             }
         };
     }
     describe('filtering another dimension', () => {
         let regionDim;
         beforeEach(() => {
-            chart.group(removeEmptyBins(group)).render();
+            chart.group(cloneAndRemoveEmptyBins(group)).render();
             regionDim = data.dimension(d => d.region);
         });
         function expectRadii (expected) {

--- a/src/charts/bubble-overlay.js
+++ b/src/charts/bubble-overlay.js
@@ -145,7 +145,7 @@ export class BubbleOverlay extends BubbleMixin(BaseMixin) {
                 .attr('transform', `translate(${point.x},${point.y})`);
         }
 
-        nodeG.datum(data[point.name]);
+        nodeG.datum(data[point.name] || {});
 
         return nodeG;
     }


### PR DESCRIPTION
**Edit: now test case has been updated, so easier to review and merge.**

Most charts uses `d3.data`, however, Bubble Overlay uses `d3.datum`.

There are two tests to check if filtering another dimension sets few circles to zero radii:

- https://github.com/dc-js/dc.js/blob/develop/spec/bubble-overlay-spec.js#L129
- https://github.com/dc-js/dc.js/blob/develop/spec/bubble-overlay-spec.js#L142

The test cases pass - but due to a strange coincidence. To demonstrate the issue I have made a change in the test cases which should not have made any difference (https://github.com/dc-js/dc.js/pull/1687/commits/ae21b7a7804a9d7aa10574c93df3099f0c9d8d06). However, with this change the test cases fail.

Underlying issue appears to be the following:

- When we bind using `.datum`, children inherit it.
- When we update `.datum` of the parent node, it reflects in the children.
- However, if we set `.datum` to `undefined` in the parent node, the children retain the older value.
- The fix is simple - instead of setting `.datum` to `undefined` we should set it to `{}` (commit https://github.com/dc-js/dc.js/pull/1687/commits/1759e22c5bc1f2939f7a76cb0c9de37e78599151).

The unmodified code ties the crossfilter objects directly. When the filter is applied the tied objects get updated. This combined with the d3 behavior with `undefined`, makes the test cases succeed.

Not sure since which release the underlying issue appeared - it might be a d3 behavior change in d3v4.

I realize it is lot of explaining for a single line change.