### PR TITLE
tslint - space-before-function-paren to always

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -21,6 +21,7 @@
       true,
       "single"
     ],
+    "space-before-function-paren": [true, "always"],
     "trailing-comma": false,
     "variable-name": [
       true,


### PR DESCRIPTION
The actual fixing will be done as part of the typings.