### PR TITLE
Inline `pluck` and move it to compat layer

### DIFF
--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -2,7 +2,7 @@ import {BaseType, select, Selection} from 'd3-selection';
 import {dispatch, Dispatch} from 'd3-dispatch';
 import {ascending} from 'd3-array';
 
-import {pluck, utils} from '../core/utils';
+import {utils} from '../core/utils';
 import {instanceOfChart} from '../core/core';
 import {deregisterChart, redrawAll, registerChart, renderAll} from '../core/chart-registry';
 import {constants} from '../core/constants';
@@ -151,11 +151,11 @@ export class BaseMixin {
         this._height = undefined;
         this._useViewBoxResizing = false;
 
-        this._keyAccessor = pluck('key');
-        this._valueAccessor = pluck('value');
-        this._label = pluck('key');
+        this._keyAccessor = d => d.key;
+        this._valueAccessor = d => d.value;
+        this._label = d => d.key;
 
-        this._ordering = pluck('key');
+        this._ordering = d => d.key;
 
         this._renderLabel = false;
 

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -1,7 +1,7 @@
 import {Stack, stack} from 'd3-shape';
 import {max, min} from 'd3-array';
 
-import {pluck, utils} from '../core/utils';
+import {utils} from '../core/utils';
 import {CoordinateGridMixin} from './coordinate-grid-mixin';
 import {BaseAccessor, LegendSpecs, MinimalCFGroup, TitleAccessor} from '../core/types';
 
@@ -160,7 +160,7 @@ export class StackMixin extends CoordinateGridMixin {
     }
 
     public _findLayerByName (n) {
-        const i = this._stack.map(pluck('name')).indexOf(n);
+        const i = this._stack.map(d => d.name).indexOf(n);
         return this._stack[i];
     }
 
@@ -208,12 +208,12 @@ export class StackMixin extends CoordinateGridMixin {
     }
 
     public xAxisMin () {
-        const m = min(this._flattenStack(), pluck('x'));
+        const m = min(this._flattenStack(), d => d.x);
         return utils.subtract(m, this.xAxisPadding(), this.xAxisPaddingUnit());
     }
 
     public xAxisMax () {
-        const m = max(this._flattenStack(), pluck('x'));
+        const m = max(this._flattenStack(), d => d.x);
         return utils.add(m, this.xAxisPadding(), this.xAxisPaddingUnit());
     }
 
@@ -303,7 +303,7 @@ export class StackMixin extends CoordinateGridMixin {
     }
 
     public _ordinalXDomain () {
-        const flat = this._flattenStack().map(pluck('data'));
+        const flat = this._flattenStack().map(d => d.data);
         const ordered = this._computeOrderedGroups(flat);
         return ordered.map(this.keyAccessor());
     }

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -4,7 +4,7 @@ import {StackMixin} from '../base/stack-mixin';
 import {transition} from '../core/core';
 import {constants} from '../core/constants';
 import {logger} from '../core/logger';
-import {pluck, utils} from '../core/utils';
+import {utils} from '../core/utils';
 import {ChartParentType, DCBrushSelection, SVGGElementSelection} from '../core/types';
 
 const MIN_BAR_WIDTH = 1;
@@ -140,7 +140,7 @@ export class BarChart extends StackMixin {
 
     public _renderLabels (layer: SVGGElementSelection, layerIndex: number, data): void {
         const labels: Selection<SVGTextElement, unknown, SVGGElement, any> = layer.selectAll<SVGTextElement, any>('text.barLabel')
-            .data(data.values, pluck('x'));
+            .data(data.values, d => d.x);
 
         const labelsEnterUpdate: Selection<SVGTextElement, unknown, SVGGElement, any> = labels
             .enter()
@@ -178,10 +178,10 @@ export class BarChart extends StackMixin {
     }
 
     public _renderBars (layer: SVGGElementSelection, layerIndex: number, data): void {
-        const bars: Selection<SVGRectElement, unknown, SVGGElement, any> = layer.selectAll<SVGRectElement, any>('rect.bar')
-            .data(data.values, pluck('x'));
+        const bars: Selection<SVGRectElement, any, SVGGElement, any> = layer.selectAll<SVGRectElement, any>('rect.bar')
+            .data<any>(data.values, d => d.x);
 
-        const enter: Selection<SVGRectElement, unknown, SVGGElement, any> = bars.enter()
+        const enter: Selection<SVGRectElement, any, SVGGElement, any> = bars.enter()
             .append('rect')
             .attr('class', 'bar')
             .attr('fill', (d, i) => this.getColor(d, i))
@@ -192,7 +192,7 @@ export class BarChart extends StackMixin {
         const barsEnterUpdate: Selection<SVGRectElement, unknown, SVGGElement, any> = enter.merge(bars);
 
         if (this.renderTitle()) {
-            enter.append('title').text(pluck('data', this.title(data.name)));
+            enter.append('title').text((d, i) => this.title(d.name)(d.data, i));
         }
 
         if (this.isOrdinal()) {
@@ -213,7 +213,7 @@ export class BarChart extends StackMixin {
             .attr('width', this._barWidth)
             .attr('height', d => this._barHeight(d))
             .attr('fill', (d, i) => this.getColor(d, i))
-            .select('title').text(pluck('data', this.title(data.name)));
+            .select('title').text((d, i) => this.title(d.name)(d.data, i));
 
         transition(bars.exit(), this.transitionDuration(), this.transitionDelay())
             .attr('x', d => this.x()(d.x))

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -4,7 +4,7 @@ import {StackMixin} from '../base/stack-mixin';
 import {transition} from '../core/core';
 import {constants} from '../core/constants';
 import {logger} from '../core/logger';
-import {utils} from '../core/utils';
+import {pluck2, utils} from '../core/utils';
 import {ChartParentType, DCBrushSelection, SVGGElementSelection} from '../core/types';
 
 const MIN_BAR_WIDTH = 1;
@@ -192,7 +192,7 @@ export class BarChart extends StackMixin {
         const barsEnterUpdate: Selection<SVGRectElement, unknown, SVGGElement, any> = enter.merge(bars);
 
         if (this.renderTitle()) {
-            enter.append('title').text((d, i) => this.title(d.name)(d.data, i));
+            enter.append('title').text(pluck2('data', this.title(data.name)));
         }
 
         if (this.isOrdinal()) {
@@ -213,7 +213,7 @@ export class BarChart extends StackMixin {
             .attr('width', this._barWidth)
             .attr('height', d => this._barHeight(d))
             .attr('fill', (d, i) => this.getColor(d, i))
-            .select('title').text((d, i) => this.title(d.name)(d.data, i));
+            .select('title').text(pluck2('data', this.title(data.name)));
 
         transition(bars.exit(), this.transitionDuration(), this.transitionDelay())
             .attr('x', d => this.x()(d.x))

--- a/src/charts/html-legend.ts
+++ b/src/charts/html-legend.ts
@@ -1,6 +1,6 @@
 import {select, Selection} from 'd3-selection';
 
-import {pluck, utils} from '../core/utils';
+import {utils} from '../core/utils';
 import {constants} from '../core/constants';
 import {LegendSpecs, LegendTextAccessor, ParentOfLegend} from '../core/types';
 
@@ -78,7 +78,7 @@ export class HtmlLegend {
 
         itemEnter.append('span')
             .attr('class', 'dc-legend-item-color')
-            .style('background-color', pluck('color'));
+            .style('background-color', d => d.color);
 
         itemEnter.append('span')
             .attr('class', 'dc-legend-item-label')

--- a/src/charts/legend.ts
+++ b/src/charts/legend.ts
@@ -1,4 +1,4 @@
-import {pluck, utils} from '../core/utils';
+import {utils} from '../core/utils';
 import {constants} from '../core/constants';
 import {LegendSpecs, LegendTextAccessor, ParentOfLegend} from '../core/types';
 import {Selection} from 'd3-selection';
@@ -278,7 +278,7 @@ export class Legend {
         this._g.selectAll<SVGGElement, any>('g.dc-legend-item')
             .classed('fadeout', d => d.chart.isLegendableHidden(d));
 
-        if (legendables.some(pluck('dashstyle'))) {
+        if (legendables.some(d => d.dashstyle)) {
             itemEnter
                 .append('line')
                 .attr('x1', 0)
@@ -286,8 +286,8 @@ export class Legend {
                 .attr('x2', this._itemHeight)
                 .attr('y2', this._itemHeight / 2)
                 .attr('stroke-width', 2)
-                .attr('stroke-dasharray', pluck('dashstyle'))
-                .attr('stroke', pluck('color'));
+                .attr('stroke-dasharray', d => d.dashstyle)
+                .attr('stroke', d => d.color);
         } else {
             itemEnter
                 .append('rect')

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -20,7 +20,7 @@ import {
 import {select, Selection} from 'd3-selection';
 
 import {logger} from '../core/logger';
-import {pluck, utils} from '../core/utils';
+import {utils} from '../core/utils';
 import {StackMixin} from '../base/stack-mixin';
 import {transition} from '../core/core';
 import {BaseAccessor, ChartParentType, LegendSpecs, SVGGElementSelection} from '../core/types';
@@ -401,7 +401,7 @@ export class LineChart extends StackMixin {
 
                 const dots: Selection<SVGCircleElement, any, SVGGElement, any> =
                     g.selectAll<SVGCircleElement, any>(`circle.${DOT_CIRCLE_CLASS}`)
-                     .data<any>(points, pluck('x'));
+                     .data<any>(points, d => d.x);
 
                 const chart = this;
                 const dotsEnterModify = dots
@@ -443,8 +443,8 @@ export class LineChart extends StackMixin {
         const chart = this;
         layers.each(function (data, layerIndex) {
             const layer = select(this);
-            const labels = layer.selectAll<SVGTextElement, unknown>('text.lineLabel')
-                .data(data.values, pluck('x'));
+            const labels = layer.selectAll<SVGTextElement, any>('text.lineLabel')
+                .data(data.values, d => d.x);
 
             const labelsEnterModify = labels
                 .enter()
@@ -520,7 +520,7 @@ export class LineChart extends StackMixin {
     private _doRenderTitle (dot: Selection<SVGCircleElement, any, SVGGElement, any>, d): void {
         if (this.renderTitle()) {
             dot.select('title').remove();
-            dot.append('title').text(pluck('data', this.title(d.name)));
+            dot.append('title').text( (d, i) => this.title(d.name)(d.data, i));
         }
     }
 

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -20,7 +20,7 @@ import {
 import {select, Selection} from 'd3-selection';
 
 import {logger} from '../core/logger';
-import {utils} from '../core/utils';
+import {pluck2, utils} from '../core/utils';
 import {StackMixin} from '../base/stack-mixin';
 import {transition} from '../core/core';
 import {BaseAccessor, ChartParentType, LegendSpecs, SVGGElementSelection} from '../core/types';
@@ -520,7 +520,7 @@ export class LineChart extends StackMixin {
     private _doRenderTitle (dot: Selection<SVGCircleElement, any, SVGGElement, any>, d): void {
         if (this.renderTitle()) {
             dot.select('title').remove();
-            dot.append('title').text( (d, i) => this.title(d.name)(d.data, i));
+            dot.append('title').text(pluck2('data', this.title(d.name)));
         }
     }
 

--- a/src/charts/sunburst-chart.ts
+++ b/src/charts/sunburst-chart.ts
@@ -6,7 +6,7 @@ import {interpolate} from 'd3-interpolate';
 
 import {transition} from '../core/core';
 import {filters} from '../core/filters';
-import {pluck, utils} from '../core/utils';
+import {utils} from '../core/utils';
 import {events} from '../core/events';
 import {ColorMixin} from '../base/color-mixin';
 import {BaseMixin} from '../base/base-mixin';
@@ -92,7 +92,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
         this.colorAccessor(d => this.keyAccessor()(d));
 
         // override cap mixin
-        this.ordering(pluck('key'));
+        this.ordering(d => d.key);
 
         this.title(d => `${this.keyAccessor()(d)}: ${this._extendedValueAccessor(d)}`);
 

--- a/src/compat/core/utils.ts
+++ b/src/compat/core/utils.ts
@@ -1,1 +1,30 @@
 export * from '../../core/utils';
+
+/**
+ * Returns a function that given a string property name, can be used to pluck the property off an object.  A function
+ * can be passed as the second argument to also alter the data being returned.
+ *
+ * This can be a useful shorthand method to create accessor functions.
+ * @example
+ * var xPluck = pluck('x');
+ * var objA = {x: 1};
+ * xPluck(objA) // 1
+ * @example
+ * var xPosition = pluck('x', function (x, i) {
+ *     // `this` is the original datum,
+ *     // `x` is the x property of the datum,
+ *     // `i` is the position in the array
+ *     return this.radius + x;
+ * });
+ * selectAll('.circle').data(...).x(xPosition);
+ * @function pluck
+ * @param {String} n
+ * @param {Function} [f]
+ * @returns {Function}
+ */
+export const pluck = function (n, f?) {
+    if (!f) {
+        return function (d) { return d[n]; };
+    }
+    return function (d, i) { return f.call(d, d[n], i); };
+};

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -28,6 +28,10 @@ interface IUtils {
     arraysIdentical: (a, b) => (boolean);
 }
 
+export const pluck2 = function (n, f) {
+    return function (d, i) { return f.call(d, d[n], i); };
+};
+
 /**
  * @namespace utils
  * @type {{}}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -29,35 +29,6 @@ interface IUtils {
 }
 
 /**
- * Returns a function that given a string property name, can be used to pluck the property off an object.  A function
- * can be passed as the second argument to also alter the data being returned.
- *
- * This can be a useful shorthand method to create accessor functions.
- * @example
- * var xPluck = pluck('x');
- * var objA = {x: 1};
- * xPluck(objA) // 1
- * @example
- * var xPosition = pluck('x', function (x, i) {
- *     // `this` is the original datum,
- *     // `x` is the x property of the datum,
- *     // `i` is the position in the array
- *     return this.radius + x;
- * });
- * selectAll('.circle').data(...).x(xPosition);
- * @function pluck
- * @param {String} n
- * @param {Function} [f]
- * @returns {Function}
- */
-export const pluck = function (n, f?) {
-    if (!f) {
-        return function (d) { return d[n]; };
-    }
-    return function (d, i) { return f.call(d, d[n], i); };
-};
-
-/**
  * @namespace utils
  * @type {{}}
  */


### PR DESCRIPTION
We had discussed this when doing ES6 conversion. Finally did it :smile:. Changes span multiple files, however, the pattern is similar. 

In three places 2 argument version was used, it was first fetching the title accessor for the stack and then using it to get the actual title (Line and Bar charts).

The original function has been moved to the compat layer.