### PR TITLE
Concept of ChartGroup

### DIFF
--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -12,7 +12,7 @@ import {printers} from '../core/printers';
 import {InvalidStateException} from '../core/invalid-state-exception';
 import {BadArgumentException} from '../core/bad-argument-exception';
 import {
-    BaseAccessor,
+    BaseAccessor, ChartGroupType,
     ChartParentType,
     KeyAccessor,
     LabelAccessor, LegendItem,
@@ -491,7 +491,7 @@ export class BaseMixin {
      * @returns {String|node|d3.selection|BaseMixin}
      */
     public anchor (): string|Element;
-    public anchor (parent: ChartParentType, chartGroup: string|IChartGroup): this;
+    public anchor (parent: ChartParentType, chartGroup: ChartGroupType): this;
     public anchor (parent?, chartGroup?) {
         if (!arguments.length) {
             return this._anchor;
@@ -520,8 +520,8 @@ export class BaseMixin {
         return this;
     }
 
-    private _getChartGroup(chartGroup) {
-        return (!chartGroup || typeof chartGroup === 'string') ? chartRegistry.chartGroup(chartGroup) : chartGroup;
+    private _getChartGroup(chartGroup: ChartGroupType): IChartGroup {
+        return (!chartGroup || typeof chartGroup === 'string') ? chartRegistry.chartGroup(chartGroup as string) : chartGroup;
     }
 
     /**
@@ -1401,7 +1401,7 @@ export class BaseMixin {
      * @returns {String|BaseMixin}
      */
     public chartGroup (): IChartGroup;
-    public chartGroup (chartGroup: string|IChartGroup): this;
+    public chartGroup (chartGroup: ChartGroupType): this;
     public chartGroup (chartGroup?) {
         if (!arguments.length) {
             return this._chartGroup;

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -109,7 +109,7 @@ export class BaseMixin {
     private _transitionDelay: number;
     private _filterPrinter: (filters) => string;
     private _mandatoryAttributesList: string[];
-    protected _chartGroup: string;
+    private _chartGroup: string;
     private _listeners: Dispatch<BaseMixin>;
     private _legend; // TODO: figure out actual type
     private _commitHandler; // TODO: support async functions as well

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -12,10 +12,12 @@ import {printers} from '../core/printers';
 import {InvalidStateException} from '../core/invalid-state-exception';
 import {BadArgumentException} from '../core/bad-argument-exception';
 import {
-    BaseAccessor, ChartGroupType,
+    BaseAccessor,
+    ChartGroupType,
     ChartParentType,
     KeyAccessor,
-    LabelAccessor, LegendItem,
+    LabelAccessor,
+    LegendItem,
     MinimalCFDimension,
     MinimalCFGroup,
     TitleAccessor,
@@ -520,7 +522,7 @@ export class BaseMixin {
         return this;
     }
 
-    private _getChartGroup(chartGroup: ChartGroupType): IChartGroup {
+    private _getChartGroup (chartGroup: ChartGroupType): IChartGroup {
         return (!chartGroup || typeof chartGroup === 'string') ? chartRegistry.chartGroup(chartGroup as string) : chartGroup;
     }
 

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -5,7 +5,7 @@ import {transition} from '../core/core';
 import {constants} from '../core/constants';
 import {logger} from '../core/logger';
 import {pluck, utils} from '../core/utils';
-import {ChartParentType, DCBrushSelection, SVGGElementSelection} from '../core/types';
+import {ChartGroupType, ChartParentType, DCBrushSelection, SVGGElementSelection} from '../core/types';
 
 const MIN_BAR_WIDTH = 1;
 const DEFAULT_GAP_BETWEEN_BARS = 2;
@@ -42,7 +42,7 @@ export class BarChart extends StackMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._gap = DEFAULT_GAP_BETWEEN_BARS;

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -7,7 +7,14 @@ import {CoordinateGridMixin} from '../base/coordinate-grid-mixin';
 import {transition} from '../core/core';
 import {units} from '../core/units';
 import {utils} from '../core/utils';
-import {BoxWidthFn, ChartParentType, DCBrushSelection, NumberFormatFn, SVGGElementSelection} from '../core/types';
+import {
+    BoxWidthFn,
+    ChartGroupType,
+    ChartParentType,
+    DCBrushSelection,
+    NumberFormatFn,
+    SVGGElementSelection
+} from '../core/types';
 
 // Returns a function to compute the interquartile range.
 function defaultWhiskersIQR (k: number): (d) => [number, number] {
@@ -69,7 +76,7 @@ export class BoxPlot extends CoordinateGridMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._whiskerIqrFactor = 1.5;

--- a/src/charts/bubble-chart.ts
+++ b/src/charts/bubble-chart.ts
@@ -1,7 +1,7 @@
 import {BubbleMixin} from '../base/bubble-mixin';
 import {CoordinateGridMixin} from '../base/coordinate-grid-mixin';
 import {transition} from '../core/core';
-import {ChartParentType, DCBrushSelection, SVGGElementSelection} from '../core/types';
+import {ChartGroupType, ChartParentType, DCBrushSelection, SVGGElementSelection} from '../core/types';
 
 /**
  * A concrete implementation of a general purpose bubble chart that allows data visualization using the
@@ -34,7 +34,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this.transitionDuration(750);

--- a/src/charts/bubble-overlay.ts
+++ b/src/charts/bubble-overlay.ts
@@ -6,7 +6,7 @@ import {transition} from '../core/core';
 import {constants} from '../core/constants';
 import {utils} from '../core/utils';
 import {ColorMixin} from '../base/color-mixin';
-import {ChartParentType, SVGGElementSelection} from '../core/types';
+import {ChartGroupType, ChartParentType, SVGGElementSelection} from '../core/types';
 
 const BUBBLE_OVERLAY_CLASS = 'bubble-overlay';
 const BUBBLE_NODE_CLASS = 'node';
@@ -41,7 +41,7 @@ export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         /**

--- a/src/charts/cbox-menu.ts
+++ b/src/charts/cbox-menu.ts
@@ -3,7 +3,7 @@ import {event, select, Selection} from 'd3-selection';
 import {events} from '../core/events';
 import {BaseMixin} from '../base/base-mixin';
 import {utils} from '../core/utils'
-import {ChartParentType, CompareFn} from '../core/types';
+import {ChartGroupType, ChartParentType, CompareFn} from '../core/types';
 
 const GROUP_CSS_CLASS = 'dc-cbox-group';
 const ITEM_CSS_CLASS = 'dc-cbox-item';
@@ -43,7 +43,7 @@ export class CboxMenu extends BaseMixin {
      * @param {String} [chartGroup] - The name of the chart group this widget should be placed in.
      * Interaction with the widget will only trigger events and redraws within its group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._cbox = undefined;

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -4,7 +4,7 @@ import {Axis, axisRight} from 'd3-axis';
 
 import {utils} from '../core/utils';
 import {CoordinateGridMixin} from '../base/coordinate-grid-mixin';
-import {ChartParentType, Margins, MinimalXYScale, SVGGElementSelection} from '../core/types';
+import {ChartGroupType, ChartParentType, Margins, MinimalXYScale, SVGGElementSelection} from '../core/types';
 
 const SUB_CHART_CLASS = 'sub';
 const DEFAULT_RIGHT_Y_AXIS_LABEL_PADDING = 12;
@@ -40,7 +40,7 @@ export class CompositeChart extends CoordinateGridMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._children = [];

--- a/src/charts/data-count.ts
+++ b/src/charts/data-count.ts
@@ -1,7 +1,7 @@
 import {format} from 'd3-format';
 
 import {BaseMixin} from '../base/base-mixin';
-import {ChartParentType, NumberFormatFn} from '../core/types';
+import {ChartGroupType, ChartParentType, NumberFormatFn} from '../core/types';
 
 // Keeping these here for now, check if any other charts need same entities
 interface CF {
@@ -54,7 +54,7 @@ export class DataCount extends BaseMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._formatNumber = format(',d');

--- a/src/charts/data-grid.ts
+++ b/src/charts/data-grid.ts
@@ -3,7 +3,7 @@ import {nest} from 'd3-collection';
 
 import {logger} from '../core/logger';
 import {BaseMixin} from '../base/base-mixin';
-import {BaseAccessor, ChartParentType, CompareFn, GroupingFn} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, CompareFn, GroupingFn} from '../core/types';
 import {Selection} from 'd3-selection';
 
 const LABEL_CSS_CLASS = 'dc-grid-label';
@@ -41,7 +41,7 @@ export class DataGrid extends BaseMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._section = null;

--- a/src/charts/data-table.ts
+++ b/src/charts/data-table.ts
@@ -3,7 +3,7 @@ import {nest} from 'd3-collection';
 
 import {logger} from '../core/logger';
 import {BaseMixin} from '../base/base-mixin';
-import {BaseAccessor, ChartParentType, CompareFn} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, CompareFn} from '../core/types';
 import {Selection} from 'd3-selection';
 
 const LABEL_CSS_CLASS = 'dc-table-label';
@@ -57,7 +57,7 @@ export class DataTable extends BaseMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._size = 25;

--- a/src/charts/geo-choropleth-chart.ts
+++ b/src/charts/geo-choropleth-chart.ts
@@ -7,7 +7,7 @@ import {transition} from '../core/core';
 import {logger} from '../core/logger';
 import {events} from '../core/events';
 import {utils} from '../core/utils';
-import {BaseAccessor, ChartParentType} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType} from '../core/types';
 
 interface GeoJson {
     data;
@@ -44,7 +44,7 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this.colorAccessor(d => d || 0);

--- a/src/charts/heat-map.ts
+++ b/src/charts/heat-map.ts
@@ -7,7 +7,7 @@ import {filters} from '../core/filters';
 import {events} from '../core/events';
 import {ColorMixin} from '../base/color-mixin';
 import {MarginMixin} from '../base/margin-mixin';
-import {BaseAccessor, ChartParentType, CompareFn, MinimalXYScale} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, CompareFn, MinimalXYScale} from '../core/types';
 import {Selection} from 'd3-selection';
 
 const DEFAULT_BORDER_RADIUS = 6.75;
@@ -49,7 +49,7 @@ export class HeatMap extends ColorMixin(MarginMixin) {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._chartBody = undefined;

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -23,7 +23,7 @@ import {logger} from '../core/logger';
 import {pluck, utils} from '../core/utils';
 import {StackMixin} from '../base/stack-mixin';
 import {transition} from '../core/core';
-import {BaseAccessor, ChartParentType, LegendItem, SVGGElementSelection} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, LegendItem, SVGGElementSelection} from '../core/types';
 
 const DEFAULT_DOT_RADIUS = 5;
 const TOOLTIP_G_CLASS = 'dc-tooltip';
@@ -72,7 +72,7 @@ export class LineChart extends StackMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._renderArea = false;

--- a/src/charts/number-display.ts
+++ b/src/charts/number-display.ts
@@ -3,7 +3,7 @@ import {easeQuad} from 'd3-ease';
 import {interpolateNumber} from 'd3-interpolate';
 
 import {BaseMixin} from '../base/base-mixin';
-import {ChartParentType, NumberFormatFn} from '../core/types';
+import {ChartGroupType, ChartParentType, NumberFormatFn} from '../core/types';
 
 const SPAN_CLASS = 'number-display';
 
@@ -41,7 +41,7 @@ export class NumberDisplay extends BaseMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._formatNumber = format('.2s');

--- a/src/charts/pie-chart.ts
+++ b/src/charts/pie-chart.ts
@@ -7,7 +7,7 @@ import {CapMixin} from '../base/cap-mixin';
 import {ColorMixin} from '../base/color-mixin';
 import {BaseMixin} from '../base/base-mixin';
 import {transition} from '../core/core';
-import {ChartParentType, LegendItem, SVGGElementSelection} from '../core/types';
+import {ChartGroupType, ChartParentType, LegendItem, SVGGElementSelection} from '../core/types';
 
 const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
 
@@ -55,7 +55,7 @@ export class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._sliceCssClass = 'pie-slice';

--- a/src/charts/row-chart.ts
+++ b/src/charts/row-chart.ts
@@ -7,7 +7,7 @@ import {MarginMixin} from '../base/margin-mixin';
 import {ColorMixin} from '../base/color-mixin';
 import {transition} from '../core/core';
 import {Selection} from 'd3-selection';
-import {ChartParentType, MinimalXYScale, SVGGElementSelection} from '../core/types';
+import {ChartGroupType, ChartParentType, MinimalXYScale, SVGGElementSelection} from '../core/types';
 
 /**
  * Concrete row chart implementation.
@@ -50,7 +50,7 @@ export class RowChart extends CapMixin(ColorMixin(MarginMixin)) {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._g = undefined;

--- a/src/charts/scatter-plot.ts
+++ b/src/charts/scatter-plot.ts
@@ -7,7 +7,7 @@ import {optionalTransition, transition} from '../core/core';
 import {filters} from '../core/filters';
 import {constants} from '../core/constants';
 import {events} from '../core/events';
-import {BaseAccessor, ChartParentType, LegendItem} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, LegendItem} from '../core/types';
 
 export type SymbolTypeGenerator = (d: any, ...args: any[]) => SymbolType;
 
@@ -51,7 +51,7 @@ export class ScatterPlot extends CoordinateGridMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._symbol = symbol();

--- a/src/charts/select-menu.ts
+++ b/src/charts/select-menu.ts
@@ -3,7 +3,7 @@ import {event, Selection} from 'd3-selection';
 import {events} from '../core/events';
 import {BaseMixin} from '../base/base-mixin';
 import {logger} from '../core/logger';
-import {BaseAccessor, ChartParentType, CompareFn} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, CompareFn} from '../core/types';
 
 const SELECT_CSS_CLASS = 'dc-select-menu';
 const OPTION_CSS_CLASS = 'dc-select-option';
@@ -40,7 +40,7 @@ export class SelectMenu extends BaseMixin {
      * @param {String} [chartGroup] - The name of the chart group this widget should be placed in.
      * Interaction with the widget will only trigger events and redraws within its group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._select = undefined;

--- a/src/charts/series-chart.ts
+++ b/src/charts/series-chart.ts
@@ -4,7 +4,7 @@ import {nest} from 'd3-collection';
 import {CompositeChart} from './composite-chart';
 import {LineChart} from './line-chart';
 import {utils} from '../core/utils';
-import {BaseAccessor, ChartParentType, CompareFn} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, CompareFn} from '../core/types';
 
 export type LineChartFunction = (parent, chartGroup) => LineChart;
 
@@ -38,7 +38,7 @@ export class SeriesChart extends CompositeChart {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super(parent, chartGroup);
 
         this._keySort = (a, b) => ascending(this.keyAccessor()(a), this.keyAccessor()(b));

--- a/src/charts/series-chart.ts
+++ b/src/charts/series-chart.ts
@@ -45,7 +45,6 @@ export class SeriesChart extends CompositeChart {
 
         this._charts = {};
         this._chartFunction = (p, cg) => new LineChart(p, cg);
-        this._chartGroup = chartGroup;
         this._seriesAccessor = undefined;
         this._seriesSort = ascending;
         this._valueSort = this._keySort;
@@ -77,7 +76,7 @@ export class SeriesChart extends CompositeChart {
         const nesting = nester.entries(this.data());
         const children =
             nesting.map((sub, i) => {
-                const subChart = this._charts[sub.key] || this._chartFunction(this, this._chartGroup);
+                const subChart = this._charts[sub.key] || this._chartFunction(this, this.chartGroup());
                 if (!this._charts[sub.key]) {
                     childrenChanged = true;
                 }

--- a/src/charts/sunburst-chart.ts
+++ b/src/charts/sunburst-chart.ts
@@ -12,7 +12,7 @@ import {ColorMixin} from '../base/color-mixin';
 import {BaseMixin} from '../base/base-mixin';
 import {constants} from '../core/constants';
 import {BadArgumentException} from '../core/bad-argument-exception';
-import {BaseAccessor, ChartParentType, LegendItem, SVGGElementSelection} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType, LegendItem, SVGGElementSelection} from '../core/types';
 
 const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
 
@@ -71,7 +71,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._sliceCssClass = 'pie-slice';

--- a/src/charts/text-filter-widget.ts
+++ b/src/charts/text-filter-widget.ts
@@ -1,7 +1,7 @@
 import {BaseMixin} from '../base/base-mixin';
 import {constants} from '../core/constants';
 import {events} from '../core/events';
-import {BaseAccessor, ChartParentType} from '../core/types';
+import {BaseAccessor, ChartGroupType, ChartParentType} from '../core/types';
 import {Selection} from 'd3-selection';
 
 const INPUT_CSS_CLASS = 'dc-text-filter-input';
@@ -42,7 +42,7 @@ export class TextFilterWidget extends BaseMixin {
      * @param {String} [chartGroup] - The name of the chart group this chart instance should be placed in.
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
-    constructor (parent: ChartParentType, chartGroup: string) {
+    constructor (parent: ChartParentType, chartGroup: ChartGroupType) {
         super();
 
         this._normalize = s => s.toLowerCase();

--- a/src/compat/core/chart-registry.ts
+++ b/src/compat/core/chart-registry.ts
@@ -1,1 +1,2 @@
 export * from '../../core/chart-registry';
+export * from '../../core/chart-group';

--- a/src/core/chart-group-types.ts
+++ b/src/core/chart-group-types.ts
@@ -1,0 +1,23 @@
+export interface IMinimalChart {
+    render(): void;
+
+    redraw(): void;
+
+    filterAll(): void;
+
+    focus?(): void;
+}
+
+export interface IChartGroup {
+    register(chart: IMinimalChart): void;
+
+    deregister(chart: IMinimalChart): void;
+
+    renderAll(): void;
+
+    redrawAll(): void;
+
+    filterAll(): void;
+
+    refocusAll(): void;
+}

--- a/src/core/chart-group-types.ts
+++ b/src/core/chart-group-types.ts
@@ -1,23 +1,23 @@
 export interface IMinimalChart {
-    render(): void;
+    render (): void;
 
-    redraw(): void;
+    redraw (): void;
 
-    filterAll(): void;
+    filterAll (): void;
 
-    focus?(): void;
+    focus? (): void;
 }
 
 export interface IChartGroup {
-    register(chart: IMinimalChart): void;
+    register (chart: IMinimalChart): void;
 
-    deregister(chart: IMinimalChart): void;
+    deregister (chart: IMinimalChart): void;
 
-    renderAll(): void;
+    renderAll (): void;
 
-    redrawAll(): void;
+    redrawAll (): void;
 
-    filterAll(): void;
+    filterAll (): void;
 
-    refocusAll(): void;
+    refocusAll (): void;
 }

--- a/src/core/chart-group-types.ts
+++ b/src/core/chart-group-types.ts
@@ -1,23 +1,15 @@
 export interface IMinimalChart {
     render (): void;
-
     redraw (): void;
-
     filterAll (): void;
-
     focus? (): void;
 }
 
 export interface IChartGroup {
     register (chart: IMinimalChart): void;
-
     deregister (chart: IMinimalChart): void;
-
     renderAll (): void;
-
     redrawAll (): void;
-
     filterAll (): void;
-
     refocusAll (): void;
 }

--- a/src/core/chart-group.ts
+++ b/src/core/chart-group.ts
@@ -12,7 +12,7 @@ export class ChartGroup implements IChartGroup {
     }
 
     public has (chart: IMinimalChart): boolean {
-        return this._charts.indexOf(chart) >= 0;
+        return this._charts.includes(chart);
     }
 
     public register (chart: IMinimalChart): void {

--- a/src/core/chart-group.ts
+++ b/src/core/chart-group.ts
@@ -1,0 +1,55 @@
+import {IChartGroup, IMinimalChart} from './chart-group-types';
+
+export class ChartGroup implements IChartGroup {
+    private _charts: IMinimalChart[];
+
+    constructor() {
+        this._charts = [];
+    }
+
+    public list(): IMinimalChart[] {
+        return this._charts;
+    }
+
+    public has(chart: IMinimalChart): boolean {
+        return this._charts.indexOf(chart) >= 0;
+    }
+
+    register(chart: IMinimalChart): void {
+        this._charts.push(chart);
+    }
+
+    deregister(chart: IMinimalChart): void {
+        this._charts = this._charts.filter(ch => ch !== chart);
+    }
+
+    public clear(): void {
+        this._charts = [];
+    }
+
+    renderAll(): void {
+        for (const chart of this._charts) {
+            chart.render();
+        }
+    }
+
+    redrawAll(): void {
+        for (const chart of this._charts) {
+            chart.redraw();
+        }
+    }
+
+    filterAll(): void {
+        for (const chart of this._charts) {
+            chart.filterAll();
+        }
+    }
+
+    refocusAll(): void {
+        for (const chart of this._charts) {
+            if (chart.focus) {
+                chart.focus();
+            }
+        }
+    }
+}

--- a/src/core/chart-group.ts
+++ b/src/core/chart-group.ts
@@ -3,49 +3,49 @@ import {IChartGroup, IMinimalChart} from './chart-group-types';
 export class ChartGroup implements IChartGroup {
     private _charts: IMinimalChart[];
 
-    constructor() {
+    constructor () {
         this._charts = [];
     }
 
-    public list(): IMinimalChart[] {
+    public list (): IMinimalChart[] {
         return this._charts;
     }
 
-    public has(chart: IMinimalChart): boolean {
+    public has (chart: IMinimalChart): boolean {
         return this._charts.indexOf(chart) >= 0;
     }
 
-    register(chart: IMinimalChart): void {
+    public register (chart: IMinimalChart): void {
         this._charts.push(chart);
     }
 
-    deregister(chart: IMinimalChart): void {
+    public deregister (chart: IMinimalChart): void {
         this._charts = this._charts.filter(ch => ch !== chart);
     }
 
-    public clear(): void {
+    public clear (): void {
         this._charts = [];
     }
 
-    renderAll(): void {
+    public renderAll (): void {
         for (const chart of this._charts) {
             chart.render();
         }
     }
 
-    redrawAll(): void {
+    public redrawAll (): void {
         for (const chart of this._charts) {
             chart.redraw();
         }
     }
 
-    filterAll(): void {
+    public filterAll (): void {
         for (const chart of this._charts) {
             chart.filterAll();
         }
     }
 
-    refocusAll(): void {
+    public refocusAll (): void {
         for (const chart of this._charts) {
             if (chart.focus) {
                 chart.focus();

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -22,7 +22,7 @@ class ChartGroup {
     }
 
     public deregister (chart): void {
-        this._charts = this._charts.filter(ch => ch.anchorName() !== chart.anchorName());
+        this._charts = this._charts.filter(ch => ch !== chart);
     }
 
     public clear (): void {

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -2,14 +2,21 @@ import {constants} from './constants';
 import {config} from './config';
 import {BaseMixin} from '../base/base-mixin';
 
-class ChartGroup {
-    private _charts: BaseMixin[];
+export interface MinimalChart {
+    render (): void;
+    redraw (): void;
+    filterAll (): void;
+    focus? (): void;
+}
+
+export class ChartGroup {
+    private _charts: MinimalChart[];
 
     constructor () {
         this._charts = [];
     }
 
-    public list (): BaseMixin[] {
+    public list (): MinimalChart[] {
         return this._charts;
     }
 
@@ -48,8 +55,7 @@ class ChartGroup {
     }
 
     public refocusAll (): void {
-        let chart: any; // disable type checking, BaseMixin does not have focus method
-        for (chart of this._charts) {
+        for (const chart of this._charts) {
             if (chart.focus) {
                 chart.focus();
             }
@@ -127,7 +133,7 @@ class ChartRegistry {
      * @returns {Array<Object>}
      */
     public list (group?: string): BaseMixin[] {
-        return this.chartGroup(group).list();
+        return this.chartGroup(group).list() as BaseMixin[];
     }
 }
 

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -49,16 +49,16 @@ class ChartRegistry {
         this._chartMap = {};
     }
 
-    public _initializeChartGroup (group?: string): string {
+    public chartGroup (group?: string): ChartGroup {
         if (!group) {
             group = constants.DEFAULT_CHART_GROUP;
         }
 
-        if (!(this._chartMap)[group]) {
-            (this._chartMap)[group] = new ChartGroup();
+        if (!this._chartMap[group]) {
+            this._chartMap[group] = new ChartGroup();
         }
 
-        return group;
+        return this._chartMap[group];
     }
 
     /**
@@ -67,8 +67,8 @@ class ChartRegistry {
      * @returns {Boolean}
      */
     public has (chart: BaseMixin): boolean {
-        for (const e in this._chartMap) {
-            if ((this._chartMap)[e].has(chart)) {
+        for (const chartGroupName in this._chartMap) {
+            if (this._chartMap[chartGroupName].has(chart)) {
                 return true;
             }
         }
@@ -82,9 +82,8 @@ class ChartRegistry {
      * @param {String} [group] Group name
      * @return {undefined}
      */
-    public register (chart: BaseMixin, group: string): void {
-        group = this._initializeChartGroup(group);
-        (this._chartMap)[group].register(chart);
+    public register (chart: BaseMixin, group?: string): void {
+        this.chartGroup(group).register(chart);
     }
 
     /**
@@ -94,9 +93,8 @@ class ChartRegistry {
      * @param {String} [group] Group name
      * @return {undefined}
      */
-    public deregister (chart: BaseMixin, group: string): void {
-        group = this._initializeChartGroup(group);
-        (this._chartMap)[group].deregister(chart);
+    public deregister (chart: BaseMixin, group?: string): void {
+        this.chartGroup(group).deregister(chart);
     }
 
     /**
@@ -104,11 +102,16 @@ class ChartRegistry {
      * @param {String} group Group name
      * @return {undefined}
      */
-    public clear (group: string): void {
+    public clear (group?: string): void {
         if (group) {
-            (this._chartMap)[group].clear();
-            delete (this._chartMap)[group];
+            if (this._chartMap[group]) {
+                this._chartMap[group].clear();
+                delete (this._chartMap)[group];
+            }
         } else {
+            for (const chartGroupName in this._chartMap) {
+                this._chartMap[chartGroupName].clear();
+            }
             this._chartMap = {};
         }
     }
@@ -119,9 +122,8 @@ class ChartRegistry {
      * @param {String} [group] Group name
      * @returns {Array<Object>}
      */
-    public list (group: string): BaseMixin[] {
-        group = this._initializeChartGroup(group);
-        return (this._chartMap)[group].list();
+    public list (group?: string): BaseMixin[] {
+        return this.chartGroup(group).list();
     }
 }
 
@@ -139,7 +141,7 @@ export const chartRegistry = new ChartRegistry();
  * @param {String} [group] Group name
  * @return {undefined}
  */
-export function registerChart (chart: BaseMixin, group: string): void {
+export function registerChart (chart: BaseMixin, group?: string): void {
     chartRegistry.register(chart, group);
 }
 
@@ -151,7 +153,7 @@ export function registerChart (chart: BaseMixin, group: string): void {
  * @param {String} [group] Group name
  * @return {undefined}
  */
-export function deregisterChart (chart: BaseMixin, group: string): void {
+export function deregisterChart (chart: BaseMixin, group?: string): void {
     chartRegistry.deregister(chart, group);
 }
 
@@ -171,9 +173,9 @@ export function hasChart (chart: BaseMixin): boolean {
  * @param {String} group Group name
  * @return {undefined}
  */
-export const deregisterAllCharts = function (group) {
+export function deregisterAllCharts (group?) {
     chartRegistry.clear(group);
-};
+}
 
 /**
  * Clear all filters on all charts within the given chart group. If the chart group is not given then
@@ -182,7 +184,7 @@ export const deregisterAllCharts = function (group) {
  * @param {String} [group]
  * @return {undefined}
  */
-export function filterAll (group: string): void {
+export function filterAll (group?: string): void {
     const charts = chartRegistry.list(group);
     for (let i = 0; i < charts.length; ++i) {
         charts[i].filterAll();
@@ -196,7 +198,7 @@ export function filterAll (group: string): void {
  * @param {String} [group]
  * @return {undefined}
  */
-export function refocusAll (group: string): void {
+export function refocusAll (group?: string): void {
     const charts = chartRegistry.list(group);
     for (let i = 0; i < charts.length; ++i) {
         // @ts-ignore
@@ -214,7 +216,7 @@ export function refocusAll (group: string): void {
  * @param {String} [group]
  * @return {undefined}
  */
-export function renderAll (group: string): void {
+export function renderAll (group?: string): void {
     const charts = chartRegistry.list(group);
     for (let i = 0; i < charts.length; ++i) {
         charts[i].render();
@@ -234,7 +236,7 @@ export function renderAll (group: string): void {
  * @param {String} [group]
  * @return {undefined}
  */
-export function redrawAll (group: string): void {
+export function redrawAll (group?: string): void {
     const charts = chartRegistry.list(group);
     for (let i = 0; i < charts.length; ++i) {
         charts[i].redraw();

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -41,8 +41,10 @@ class ChartRegistry {
      */
     public has (chart: BaseMixin): boolean {
         for (const chartGroupName in this._chartMap) {
-            if (this._chartMap[chartGroupName].has(chart)) {
-                return true;
+            if (this._chartMap.hasOwnProperty(chartGroupName)) {
+                if (this._chartMap[chartGroupName].has(chart)) {
+                    return true;
+                }
             }
         }
         return false;
@@ -60,7 +62,9 @@ class ChartRegistry {
             }
         } else {
             for (const chartGroupName in this._chartMap) {
-                this._chartMap[chartGroupName].clear();
+                if (this._chartMap.hasOwnProperty(chartGroupName)) {
+                    this._chartMap[chartGroupName].clear();
+                }
             }
             this._chartMap = {};
         }

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -101,29 +101,6 @@ class ChartRegistry {
         }
         return false;
     }
-
-    /**
-     * Add given chart instance to the given group, creating the group if necessary.
-     * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
-     * @param {Object} chart dc.js chart instance
-     * @param {String} [group] Group name
-     * @return {undefined}
-     */
-    public register (chart: BaseMixin, group?: string): void {
-        this.chartGroup(group).register(chart);
-    }
-
-    /**
-     * Remove given chart instance from the given group, creating the group if necessary.
-     * If no group is provided, the default group `constants.DEFAULT_CHART_GROUP` will be used.
-     * @param {Object} chart dc.js chart instance
-     * @param {String} [group] Group name
-     * @return {undefined}
-     */
-    public deregister (chart: BaseMixin, group?: string): void {
-        this.chartGroup(group).deregister(chart);
-    }
-
     /**
      * Clear given group if one is provided, otherwise clears all groups.
      * @param {String} group Group name
@@ -169,7 +146,7 @@ export const chartRegistry = new ChartRegistry();
  * @return {undefined}
  */
 export function registerChart (chart: BaseMixin, group?: string): void {
-    chartRegistry.register(chart, group);
+    chartRegistry.chartGroup(group).register(chart);
 }
 
 /**
@@ -181,7 +158,7 @@ export function registerChart (chart: BaseMixin, group?: string): void {
  * @return {undefined}
  */
 export function deregisterChart (chart: BaseMixin, group?: string): void {
-    chartRegistry.deregister(chart, group);
+    chartRegistry.chartGroup(group).deregister(chart);
 }
 
 /**

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -1,7 +1,7 @@
 import {constants} from './constants';
 import {config} from './config';
-import {BaseMixin} from '../base/base-mixin';
 import {ChartGroup} from './chart-group';
+import {IMinimalChart} from './chart-group-types';
 
 /**
  * The ChartRegistry maintains sets of all instantiated dc.js charts under named groups
@@ -39,7 +39,7 @@ class ChartRegistry {
      * @param {Object} chart dc.js chart instance
      * @returns {Boolean}
      */
-    public has (chart: BaseMixin): boolean {
+    public has (chart: IMinimalChart): boolean {
         for (const chartGroupName in this._chartMap) {
             if (this._chartMap.hasOwnProperty(chartGroupName)) {
                 if (this._chartMap[chartGroupName].has(chart)) {
@@ -76,8 +76,8 @@ class ChartRegistry {
      * @param {String} [group] Group name
      * @returns {Array<Object>}
      */
-    public list (group?: string): BaseMixin[] {
-        return this.chartGroup(group).list() as BaseMixin[];
+    public list (group?: string): IMinimalChart[] {
+        return this.chartGroup(group).list();
     }
 }
 
@@ -95,7 +95,7 @@ export const chartRegistry = new ChartRegistry();
  * @param {String} [group] Group name
  * @return {undefined}
  */
-export function registerChart (chart: BaseMixin, group?: string): void {
+export function registerChart (chart: IMinimalChart, group?: string): void {
     chartRegistry.chartGroup(group).register(chart);
 }
 
@@ -107,7 +107,7 @@ export function registerChart (chart: BaseMixin, group?: string): void {
  * @param {String} [group] Group name
  * @return {undefined}
  */
-export function deregisterChart (chart: BaseMixin, group?: string): void {
+export function deregisterChart (chart: IMinimalChart, group?: string): void {
     chartRegistry.chartGroup(group).deregister(chart);
 }
 
@@ -117,7 +117,7 @@ export function deregisterChart (chart: BaseMixin, group?: string): void {
  * @param {Object} chart dc.js chart instance
  * @returns {Boolean}
  */
-export function hasChart (chart: BaseMixin): boolean {
+export function hasChart (chart: IMinimalChart): boolean {
     return chartRegistry.has(chart);
 }
 

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -1,67 +1,7 @@
 import {constants} from './constants';
 import {config} from './config';
 import {BaseMixin} from '../base/base-mixin';
-
-export interface MinimalChart {
-    render (): void;
-    redraw (): void;
-    filterAll (): void;
-    focus? (): void;
-}
-
-export class ChartGroup {
-    private _charts: MinimalChart[];
-
-    constructor () {
-        this._charts = [];
-    }
-
-    public list (): MinimalChart[] {
-        return this._charts;
-    }
-
-    public has (chart): boolean {
-        return this._charts.indexOf(chart) >= 0;
-    }
-
-    public register (chart): void {
-        this._charts.push(chart);
-    }
-
-    public deregister (chart): void {
-        this._charts = this._charts.filter(ch => ch !== chart);
-    }
-
-    public clear (): void {
-        this._charts = [];
-    }
-
-    public renderAll (): void {
-        for (const chart of this._charts) {
-            chart.render();
-        }
-    }
-
-    public redrawAll (): void {
-        for (const chart of this._charts) {
-            chart.redraw();
-        }
-    }
-
-    public filterAll (): void {
-        for (const chart of this._charts) {
-            chart.filterAll();
-        }
-    }
-
-    public refocusAll (): void {
-        for (const chart of this._charts) {
-            if (chart.focus) {
-                chart.focus();
-            }
-        }
-    }
-}
+import {ChartGroup} from './chart-group';
 
 /**
  * The ChartRegistry maintains sets of all instantiated dc.js charts under named groups

--- a/src/core/chart-registry.ts
+++ b/src/core/chart-registry.ts
@@ -28,6 +28,33 @@ class ChartGroup {
     public clear (): void {
         this._charts = [];
     }
+
+    public renderAll (): void {
+        for (const chart of this._charts) {
+            chart.render();
+        }
+    }
+
+    public redrawAll (): void {
+        for (const chart of this._charts) {
+            chart.redraw();
+        }
+    }
+
+    public filterAll (): void {
+        for (const chart of this._charts) {
+            chart.filterAll();
+        }
+    }
+
+    public refocusAll (): void {
+        let chart: any; // disable type checking, BaseMixin does not have focus method
+        for (chart of this._charts) {
+            if (chart.focus) {
+                chart.focus();
+            }
+        }
+    }
 }
 
 /**
@@ -185,10 +212,7 @@ export function deregisterAllCharts (group?) {
  * @return {undefined}
  */
 export function filterAll (group?: string): void {
-    const charts = chartRegistry.list(group);
-    for (let i = 0; i < charts.length; ++i) {
-        charts[i].filterAll();
-    }
+    chartRegistry.chartGroup(group).filterAll();
 }
 
 /**
@@ -199,14 +223,7 @@ export function filterAll (group?: string): void {
  * @return {undefined}
  */
 export function refocusAll (group?: string): void {
-    const charts = chartRegistry.list(group);
-    for (let i = 0; i < charts.length; ++i) {
-        // @ts-ignore
-        if (charts[i].focus) {
-            // @ts-ignore
-            charts[i].focus();
-        }
-    }
+    chartRegistry.chartGroup(group).refocusAll();
 }
 
 /**
@@ -217,10 +234,7 @@ export function refocusAll (group?: string): void {
  * @return {undefined}
  */
 export function renderAll (group?: string): void {
-    const charts = chartRegistry.list(group);
-    for (let i = 0; i < charts.length; ++i) {
-        charts[i].render();
-    }
+    chartRegistry.chartGroup(group).renderAll();
 
     if (config._renderlet !== null) {
         config._renderlet(group);
@@ -237,10 +251,7 @@ export function renderAll (group?: string): void {
  * @return {undefined}
  */
 export function redrawAll (group?: string): void {
-    const charts = chartRegistry.list(group);
-    for (let i = 0; i < charts.length; ++i) {
-        charts[i].redraw();
-    }
+    chartRegistry.chartGroup(group).redrawAll();
 
     if (config._renderlet !== null) {
         config._renderlet(group);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,7 +1,10 @@
 import {Selection} from 'd3-selection';
 import {BaseMixin} from '../base/base-mixin';
+import {IChartGroup} from './chart-group-types';
 
 export type ChartParentType = string | BaseMixin | Selection<Element, undefined, Element, unknown>;
+
+export type ChartGroupType = string | IChartGroup;
 
 export type ColorsList = string[];
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,13 +9,13 @@ export type ChartGroupType = string | IChartGroup;
 export type ColorsList = string[];
 
 export interface MinimalCFDimension {
-    filter(value): this;
-    filterExact(value): this;
-    filterRange(value: any[]): this;
-    filterFunction(value: (k) => any): this;
+    filter (value): this;
+    filterExact (value): this;
+    filterRange (value: any[]): this;
+    filterFunction (value: (k) => any): this;
     // filterAll(): this; // unused
-    top(k: number): any[];
-    bottom(k: number): any[];
+    top (k: number): any[];
+    bottom (k: number): any[];
 }
 
 interface CFGrouping {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './core/bad-argument-exception';
+export * from './core/chart-group';
 export * from './core/chart-registry';
 export * from './core/config';
 export * from './core/constants';

--- a/web-src/index.html
+++ b/web-src/index.html
@@ -97,7 +97,7 @@
 <div class="row">
     <div id="yearly-bubble-chart" class="dc-chart">
         <strong>Yearly Performance</strong> (radius: fluctuation/index ratio, color: gain/loss)
-        <a class="reset" href="javascript:yearlyBubbleChart.filterAll();dc.redrawAll();"
+        <a class="reset" href="javascript:yearlyBubbleChart.filterAll();chartGroup.redrawAll();"
            style="display: none;">reset</a>
 
         <div class="clearfix"></div>
@@ -107,21 +107,21 @@
 <div class="row">
     <div id="gain-loss-chart">
         <strong>Days by Gain/Loss</strong>
-        <a class="reset" href="javascript:gainOrLossChart.filterAll();dc.redrawAll();" style="display: none;">reset</a>
+        <a class="reset" href="javascript:gainOrLossChart.filterAll();chartGroup.redrawAll();" style="display: none;">reset</a>
 
         <div class="clearfix"></div>
     </div>
 
     <div id="quarter-chart">
         <strong>Quarters</strong>
-        <a class="reset" href="javascript:quarterChart.filterAll();dc.redrawAll();" style="display: none;">reset</a>
+        <a class="reset" href="javascript:quarterChart.filterAll();chartGroup.redrawAll();" style="display: none;">reset</a>
 
         <div class="clearfix"></div>
     </div>
 
     <div id="day-of-week-chart">
         <strong>Day of Week</strong>
-        <a class="reset" href="javascript:dayOfWeekChart.filterAll();dc.redrawAll();" style="display: none;">reset</a>
+        <a class="reset" href="javascript:dayOfWeekChart.filterAll();chartGroup.redrawAll();" style="display: none;">reset</a>
 
         <div class="clearfix"></div>
     </div>
@@ -129,7 +129,7 @@
     <div id="fluctuation-chart">
         <strong>Days by Fluctuation(%)</strong>
         <span class="reset" style="display: none;">range: <span class="filter"></span></span>
-        <a class="reset" href="javascript:fluctuationChart.filterAll();dc.redrawAll();" style="display: none;">reset</a>
+        <a class="reset" href="javascript:fluctuationChart.filterAll();chartGroup.redrawAll();" style="display: none;">reset</a>
 
         <div class="clearfix"></div>
     </div>
@@ -139,7 +139,7 @@
     <div id="monthly-move-chart">
         <strong>Monthly Index Abs Move & Volume/500,000 Chart</strong>
         <span class="reset" style="display: none;">range: <span class="filter"></span></span>
-        <a class="reset" href="javascript:moveChart.filterAll();volumeChart.filterAll();dc.redrawAll();"
+        <a class="reset" href="javascript:moveChart.filterAll();volumeChart.filterAll();chartGroup.redrawAll();"
            style="display: none;">reset</a>
 
         <div class="clearfix"></div>
@@ -156,7 +156,7 @@
     <div>
         <div class="dc-data-count">
             <span class="filter-count"></span> selected out of <span class="total-count"></span> records | <a
-                href="javascript:dc.filterAll(); dc.renderAll();">Reset All</a>
+                href="javascript:chartGroup.filterAll(); chartGroup.redrawAll();">Reset All</a>
         </div>
     </div>
     <table class="table table-hover dc-data-table">

--- a/web-src/stock.js
+++ b/web-src/stock.js
@@ -1,20 +1,25 @@
 //# dc.js Getting Started and How-To Guide
 'use strict';
 
+// ### Create Chart group
+
+// This allows associating all charts that are linked together and should respond to changes in other charts
+const chartGroup = new dc.ChartGroup();
+
 // ### Create Chart Objects
 
 // Create chart objects associated with the container elements identified by the css selector.
 // Note: It is often a good idea to have these objects accessible at the global scope so that they can be modified or
 // filtered by other page controls.
-const gainOrLossChart = new dc.PieChart('#gain-loss-chart');
-const fluctuationChart = new dc.BarChart('#fluctuation-chart');
-const quarterChart = new dc.PieChart('#quarter-chart');
-const dayOfWeekChart = new dc.RowChart('#day-of-week-chart');
-const moveChart = new dc.LineChart('#monthly-move-chart');
-const volumeChart = new dc.BarChart('#monthly-volume-chart');
-const yearlyBubbleChart = new dc.BubbleChart('#yearly-bubble-chart');
-const nasdaqCount = new dc.DataCount('.dc-data-count');
-const nasdaqTable = new dc.DataTable('.dc-data-table');
+const gainOrLossChart = new dc.PieChart('#gain-loss-chart', chartGroup);
+const fluctuationChart = new dc.BarChart('#fluctuation-chart', chartGroup);
+const quarterChart = new dc.PieChart('#quarter-chart', chartGroup);
+const dayOfWeekChart = new dc.RowChart('#day-of-week-chart', chartGroup);
+const moveChart = new dc.LineChart('#monthly-move-chart', chartGroup);
+const volumeChart = new dc.BarChart('#monthly-volume-chart', chartGroup);
+const yearlyBubbleChart = new dc.BubbleChart('#yearly-bubble-chart', chartGroup);
+const nasdaqCount = new dc.DataCount('.dc-data-count', chartGroup);
+const nasdaqTable = new dc.DataTable('.dc-data-table', chartGroup);
 
 // ### Anchor Div for Charts
 /*
@@ -446,7 +451,7 @@ d3.csv('ndx.csv').then(data => {
         // `%filter-count` and `%total-count` are replaced with the values obtained.
         .html({
             some: '<strong>%filter-count</strong> selected out of <strong>%total-count</strong> records' +
-                ' | <a href=\'javascript:dc.filterAll(); dc.renderAll();\'>Reset All</a>',
+                ' | <a href=\'javascript:chartGroup.filterAll(); chartGroup.redrawAll();\'>Reset All</a>',
             all: 'All records selected. Please click on the graph to apply filters.'
         });
 
@@ -516,7 +521,7 @@ d3.csv('ndx.csv').then(data => {
     //#### Rendering
 
     //simply call `.renderAll()` to render all charts on the page
-    dc.renderAll();
+    chartGroup.renderAll();
     /*
     // Or you can render charts belonging to a specific chart group
     dc.renderAll('group');


### PR DESCRIPTION
A simple and localized factoring out ChartGroup class. This class holds all information related to a chart group.

@gordonwoodhull I have a few questions which you might have answers to:

1.  We have two different ways to check if two charts are same, any idea why?
https://github.com/dc-js/dc.js/blob/82469c9c9cdc27bdca1d5b1b4f1e8ac79c41f9d9/src/core/chart-registry.js#L70
https://github.com/dc-js/dc.js/blob/82469c9c9cdc27bdca1d5b1b4f1e8ac79c41f9d9/src/core/chart-registry.js#L40
2. There is a call `has` (https://github.com/dc-js/dc.js/blob/develop/src/core/chart-registry.js#L138). Any reason this does not take a group as an argument?
3. The `deregisterAllCharts` behaves differently `*All` functions that it works across groups when no group is passed, is that intentional?