### PR TITLE
Make Utils functions as top level

### DIFF
--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -44,7 +44,7 @@ describe('dc utils', () => {
             expect(printer(null)).toEqual('');
         });
         it('print zero', () => {
-            expect(printer(0)).toEqual(0);
+            expect(printer(0)).toEqual('0');
         });
         it('print a multi-element array', () => {
             expect(printer(['this', 'that', 'and', 'the', 'other'])).toEqual('[this -> that -> and -> the -> other]');

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -2,7 +2,7 @@ import {BaseType, select, Selection} from 'd3-selection';
 import {dispatch, Dispatch} from 'd3-dispatch';
 import {ascending} from 'd3-array';
 
-import {constant, isNumber, uniqueId} from '../core/utils';
+import {isNumber, uniqueId} from '../core/utils';
 import {instanceOfChart} from '../core/core';
 import {deregisterChart, redrawAll, registerChart, renderAll} from '../core/chart-registry';
 import {constants} from '../core/constants';
@@ -234,7 +234,7 @@ export class BaseMixin {
             }
             return this._height;
         }
-        this._heightCalc = height ? (typeof height === 'function' ? height : constant(height)) : this._defaultHeightCalc;
+        this._heightCalc = height ? (typeof height === 'function' ? height : () => height) : this._defaultHeightCalc;
         this._height = undefined;
         return this;
     }
@@ -262,7 +262,7 @@ export class BaseMixin {
             }
             return this._width;
         }
-        this._widthCalc = width ? (typeof width === 'function' ? width : constant(width)) : this._defaultWidthCalc;
+        this._widthCalc = width ? (typeof width === 'function' ? width : () => width) : this._defaultWidthCalc;
         this._width = undefined;
         return this;
     }
@@ -377,7 +377,7 @@ export class BaseMixin {
         if (!arguments.length) {
             return this._data(this._group);
         }
-        this._data = typeof callback === 'function' ? callback : constant(callback);
+        this._data = typeof callback === 'function' ? callback : () => callback;
         this.expireCache();
         return this;
     }

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -2,7 +2,7 @@ import {BaseType, select, Selection} from 'd3-selection';
 import {dispatch, Dispatch} from 'd3-dispatch';
 import {ascending} from 'd3-array';
 
-import {utils} from '../core/utils';
+import {constant, isNumber, uniqueId} from '../core/utils';
 import {instanceOfChart} from '../core/core';
 import {deregisterChart, redrawAll, registerChart, renderAll} from '../core/chart-registry';
 import {constants} from '../core/constants';
@@ -15,7 +15,8 @@ import {
     BaseAccessor,
     ChartParentType,
     KeyAccessor,
-    LabelAccessor, LegendItem,
+    LabelAccessor,
+    LegendItem,
     MinimalCFDimension,
     MinimalCFGroup,
     TitleAccessor,
@@ -124,7 +125,7 @@ export class BaseMixin {
     protected _groupName: string; // StackMixin needs it
 
     constructor () {
-        this.__dcFlag__ = utils.uniqueId().toString();
+        this.__dcFlag__ = uniqueId().toString();
 
         this._dimension = undefined;
         this._group = undefined;
@@ -227,13 +228,13 @@ export class BaseMixin {
     public height (height: number|(() => number)): this;
     public height (height?) {
         if (!arguments.length) {
-            if (!utils.isNumber(this._height)) {
+            if (!isNumber(this._height)) {
                 // only calculate once
                 this._height = this._heightCalc(this._root.node());
             }
             return this._height;
         }
-        this._heightCalc = height ? (typeof height === 'function' ? height : utils.constant(height)) : this._defaultHeightCalc;
+        this._heightCalc = height ? (typeof height === 'function' ? height : constant(height)) : this._defaultHeightCalc;
         this._height = undefined;
         return this;
     }
@@ -255,13 +256,13 @@ export class BaseMixin {
     public width (width: number|(() => number)): this;
     public width (width?) {
         if (!arguments.length) {
-            if (!utils.isNumber(this._width)) {
+            if (!isNumber(this._width)) {
                 // only calculate once
                 this._width = this._widthCalc(this._root.node());
             }
             return this._width;
         }
-        this._widthCalc = width ? (typeof width === 'function' ? width : utils.constant(width)) : this._defaultWidthCalc;
+        this._widthCalc = width ? (typeof width === 'function' ? width : constant(width)) : this._defaultWidthCalc;
         this._width = undefined;
         return this;
     }
@@ -376,7 +377,7 @@ export class BaseMixin {
         if (!arguments.length) {
             return this._data(this._group);
         }
-        this._data = typeof callback === 'function' ? callback : utils.constant(callback);
+        this._data = typeof callback === 'function' ? callback : constant(callback);
         this.expireCache();
         return this;
     }
@@ -617,8 +618,8 @@ export class BaseMixin {
      * });
      * // for a chart with a range brush, print the filter as start and extent
      * chart.filterPrinter(function(filters) {
-     *   return 'start ' + utils.printSingleValue(filters[0][0]) +
-     *     ' extent ' + utils.printSingleValue(filters[0][1] - filters[0][0]);
+     *   return 'start ' + printSingleValue(filters[0][0]) +
+     *     ' extent ' + printSingleValue(filters[0][1] - filters[0][0]);
      * });
      * @param {Function} [filterPrinterFunction=printers.filters]
      * @returns {Function|BaseMixin}
@@ -1545,7 +1546,7 @@ export class BaseMixin {
      */
     public renderlet (renderletFunction): this {
         logger.warnOnce('chart.renderlet has been deprecated. Please use chart.on("renderlet.<renderletKey>", renderletFunction)');
-        this.on(`renderlet.${utils.uniqueId()}`, renderletFunction);
+        this.on(`renderlet.${uniqueId()}`, renderletFunction);
         return this;
     }
 }

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -3,7 +3,7 @@ import {interpolateHcl} from 'd3-interpolate';
 import {max, min} from 'd3-array';
 
 import {config} from '../core/config';
-import {utils} from '../core/utils';
+import {constant} from '../core/utils';
 import {ColorCommonInstance} from 'd3-color';
 import {BaseMixin} from './base-mixin';
 import {ColorAccessor, Constructor, MinimalColorScale} from '../core/types';
@@ -87,7 +87,7 @@ export function ColorMixin<TBase extends Constructor<BaseMixin>> (Base: TBase) {
             if (colorScale instanceof Array) {
                 this._colors = scaleQuantize<string>().range(colorScale); // deprecated legacy support, note: this fails for ordinal domains
             } else {
-                this._colors = typeof colorScale === 'function' ? colorScale : utils.constant(colorScale);
+                this._colors = typeof colorScale === 'function' ? colorScale : constant(colorScale);
             }
             return this;
         }

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -3,7 +3,6 @@ import {interpolateHcl} from 'd3-interpolate';
 import {max, min} from 'd3-array';
 
 import {config} from '../core/config';
-import {constant} from '../core/utils';
 import {ColorCommonInstance} from 'd3-color';
 import {BaseMixin} from './base-mixin';
 import {ColorAccessor, Constructor, MinimalColorScale} from '../core/types';
@@ -87,7 +86,7 @@ export function ColorMixin<TBase extends Constructor<BaseMixin>> (Base: TBase) {
             if (colorScale instanceof Array) {
                 this._colors = scaleQuantize<string>().range(colorScale); // deprecated legacy support, note: this fails for ordinal domains
             } else {
-                this._colors = typeof colorScale === 'function' ? colorScale : constant(colorScale);
+                this._colors = typeof colorScale === 'function' ? colorScale : () => colorScale;
             }
             return this;
         }

--- a/src/base/coordinate-grid-mixin.ts
+++ b/src/base/coordinate-grid-mixin.ts
@@ -12,7 +12,7 @@ import {MarginMixin} from './margin-mixin';
 import {optionalTransition, transition} from '../core/core';
 import {units} from '../core/units';
 import {constants} from '../core/constants';
-import {utils} from '../core/utils';
+import {add, appendOrSelect, arraysEqual, subtract} from '../core/utils';
 import {logger} from '../core/logger';
 import {filters} from '../core/filters';
 import {events} from '../core/events';
@@ -542,7 +542,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
 
         // has the domain changed?
         const xdom = this._x.domain();
-        if (render || !utils.arraysEqual(this._lastXDomain, xdom)) {
+        if (render || !arraysEqual(this._lastXDomain, xdom)) {
             this.rescale();
         }
         this._lastXDomain = xdom;
@@ -897,7 +897,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
      */
     public xAxisMin () { // TODO: can these be anything other than number and Date
         const m = min(this.data(), e => this.keyAccessor()(e));
-        return utils.subtract(m, this._xAxisPadding, this._xAxisPaddingUnit);
+        return subtract(m, this._xAxisPadding, this._xAxisPaddingUnit);
     }
 
     /**
@@ -906,7 +906,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
      */
     public xAxisMax () { // TODO: can these be anything other than number and Date
         const m = max(this.data(), e => this.keyAccessor()(e));
-        return utils.add(m, this._xAxisPadding, this._xAxisPaddingUnit);
+        return add(m, this._xAxisPadding, this._xAxisPaddingUnit);
     }
 
     /**
@@ -915,7 +915,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
      */
     public yAxisMin () { // TODO: can these be anything other than number
         const m = min(this.data(), e => this.valueAccessor()(e));
-        return utils.subtract(m, this._yAxisPadding);
+        return subtract(m, this._yAxisPadding);
     }
 
     /**
@@ -924,7 +924,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
      */
     public yAxisMax () { // TODO: can these be anything other than number
         const m = max(this.data(), e => this.valueAccessor()(e));
-        return utils.add(m, this._yAxisPadding);
+        return add(m, this._yAxisPadding);
     }
 
     /**
@@ -1191,15 +1191,15 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
     }
 
     public _generateClipPath (): void {
-        const defs = utils.appendOrSelect(this._parent, 'defs');
+        const defs = appendOrSelect(this._parent, 'defs');
         // cannot select <clippath> elements; bug in WebKit, must select by id
         // https://groups.google.com/forum/#!topic/d3-js/6EpAzQ2gU9I
         const id = this._getClipPathId();
-        const chartBodyClip = utils.appendOrSelect(defs, `#${id}`, 'clipPath').attr('id', id);
+        const chartBodyClip = appendOrSelect(defs, `#${id}`, 'clipPath').attr('id', id);
 
         const padding = this._clipPadding * 2;
 
-        utils.appendOrSelect(chartBodyClip, 'rect')
+        appendOrSelect(chartBodyClip, 'rect')
             .attr('width', this.xAxisLength() + padding)
             .attr('height', this.yAxisHeight() + padding)
             .attr('transform', `translate(-${this._clipPadding}, -${this._clipPadding})`);
@@ -1320,7 +1320,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
         this.redraw();
 
         if (!noRaiseEvents) {
-            if (this._rangeChart && !utils.arraysEqual(this.filter(), this._rangeChart.filter())) {
+            if (this._rangeChart && !arraysEqual(this.filter(), this._rangeChart.filter())) {
                 events.trigger(() => {
                     this._rangeChart.replaceFilter(domFilter);
                     this._rangeChart.redraw();
@@ -1420,7 +1420,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
     }
 
     public refocused (): boolean {
-        return !utils.arraysEqual(this.x().domain(), this._xOriginalDomain);
+        return !arraysEqual(this.x().domain(), this._xOriginalDomain);
     }
 
     public focusChart (): CoordinateGridMixin;
@@ -1435,7 +1435,7 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
                 events.trigger(() => {
                     this._focusChart.x().domain(this._focusChart.xOriginalDomain());
                 });
-            } else if (!utils.arraysEqual(chart.filter(), this._focusChart.filter())) {
+            } else if (!arraysEqual(chart.filter(), this._focusChart.filter())) {
                 events.trigger(() => {
                     this._focusChart.focus(chart.filter(), true);
                 });

--- a/src/base/d3.box.ts
+++ b/src/base/d3.box.ts
@@ -38,7 +38,7 @@ import {select} from 'd3-selection';
 import {scaleLinear} from 'd3-scale';
 import {timerFlush} from 'd3-timer';
 
-import {utils} from '../core/utils';
+import {constant} from '../core/utils';
 
 export const d3Box = function () {
     let width = 1;
@@ -477,7 +477,7 @@ export const d3Box = function () {
         if (!arguments.length) {
             return domain;
         }
-        domain = x === null ? x : typeof x === 'function' ? x : utils.constant(x);
+        domain = x === null ? x : typeof x === 'function' ? x : constant(x);
         return box;
     };
 

--- a/src/base/d3.box.ts
+++ b/src/base/d3.box.ts
@@ -38,8 +38,6 @@ import {select} from 'd3-selection';
 import {scaleLinear} from 'd3-scale';
 import {timerFlush} from 'd3-timer';
 
-import {constant} from '../core/utils';
-
 export const d3Box = function () {
     let width = 1;
     let height = 1;
@@ -477,7 +475,7 @@ export const d3Box = function () {
         if (!arguments.length) {
             return domain;
         }
-        domain = x === null ? x : typeof x === 'function' ? x : constant(x);
+        domain = x === null ? x : typeof x === 'function' ? x : () => x;
         return box;
     };
 

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -1,7 +1,7 @@
 import {Stack, stack} from 'd3-shape';
 import {max, min} from 'd3-array';
 
-import {utils} from '../core/utils';
+import {add, constant, subtract} from '../core/utils';
 import {CoordinateGridMixin} from './coordinate-grid-mixin';
 import {BaseAccessor, LegendItem, MinimalCFGroup, TitleAccessor} from '../core/types';
 
@@ -72,7 +72,7 @@ export class StackMixin extends CoordinateGridMixin {
 
     public _domainFilter () {
         if (!this.x()) {
-            return utils.constant(true);
+            return constant(true);
         }
         const xDomain = this.x().domain();
         if (this.isOrdinal()) {
@@ -192,12 +192,12 @@ export class StackMixin extends CoordinateGridMixin {
 
     public yAxisMin () {
         const m = min(this._flattenStack(), p => (p.y < 0) ? (p.y + p.y0) : p.y0);
-        return utils.subtract(m, this.yAxisPadding());
+        return subtract(m, this.yAxisPadding());
     }
 
     public yAxisMax () {
         const m = max(this._flattenStack(), p => (p.y > 0) ? (p.y + p.y0) : p.y0);
-        return utils.add(m, this.yAxisPadding());
+        return add(m, this.yAxisPadding());
     }
 
     public _flattenStack () {
@@ -209,12 +209,12 @@ export class StackMixin extends CoordinateGridMixin {
 
     public xAxisMin () {
         const m = min(this._flattenStack(), d => d.x);
-        return utils.subtract(m, this.xAxisPadding(), this.xAxisPaddingUnit());
+        return subtract(m, this.xAxisPadding(), this.xAxisPaddingUnit());
     }
 
     public xAxisMax () {
         const m = max(this._flattenStack(), d => d.x);
-        return utils.add(m, this.xAxisPadding(), this.xAxisPaddingUnit());
+        return add(m, this.xAxisPadding(), this.xAxisPaddingUnit());
     }
 
     /**

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -1,7 +1,7 @@
 import {Stack, stack} from 'd3-shape';
 import {max, min} from 'd3-array';
 
-import {add, constant, subtract} from '../core/utils';
+import {add, subtract} from '../core/utils';
 import {CoordinateGridMixin} from './coordinate-grid-mixin';
 import {BaseAccessor, LegendItem, MinimalCFGroup, TitleAccessor} from '../core/types';
 
@@ -72,7 +72,7 @@ export class StackMixin extends CoordinateGridMixin {
 
     public _domainFilter () {
         if (!this.x()) {
-            return constant(true);
+            return () => true;
         }
         const xDomain = this.x().domain();
         if (this.isOrdinal()) {

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -4,7 +4,7 @@ import {StackMixin} from '../base/stack-mixin';
 import {transition} from '../core/core';
 import {constants} from '../core/constants';
 import {logger} from '../core/logger';
-import {pluck2, utils} from '../core/utils';
+import {pluck2, printSingleValue, safeNumber} from '../core/utils';
 import {ChartParentType, DCBrushSelection, SVGGElementSelection} from '../core/types';
 
 const MIN_BAR_WIDTH = 1;
@@ -51,7 +51,7 @@ export class BarChart extends StackMixin {
 
         this._barWidth = undefined;
 
-        this.label(d => utils.printSingleValue(d.y0 + d.y), false);
+        this.label(d => printSingleValue(d.y0 + d.y), false);
 
         this.anchor(parent, chartGroup);
     }
@@ -114,7 +114,7 @@ export class BarChart extends StackMixin {
     }
 
     public _barHeight (d): number {
-        return utils.safeNumber(Math.abs(this.y()(d.y + d.y0) - this.y()(d.y0)));
+        return safeNumber(Math.abs(this.y()(d.y + d.y0) - this.y()(d.y0)));
     }
 
     public _labelXPos (d): number {
@@ -125,7 +125,7 @@ export class BarChart extends StackMixin {
         if (this.isOrdinal() && this._gap !== undefined) {
             x += this._gap / 2;
         }
-        return utils.safeNumber(x);
+        return safeNumber(x);
     }
 
     public _labelYPos (d): number {
@@ -135,7 +135,7 @@ export class BarChart extends StackMixin {
             y -= this._barHeight(d);
         }
 
-        return utils.safeNumber(y - LABEL_PADDING);
+        return safeNumber(y - LABEL_PADDING);
     }
 
     public _renderLabels (layer: SVGGElementSelection, layerIndex: number, data): void {
@@ -174,7 +174,7 @@ export class BarChart extends StackMixin {
         if (this.isOrdinal() && this._gap !== undefined) {
             x += this._gap / 2;
         }
-        return utils.safeNumber(x);
+        return safeNumber(x);
     }
 
     public _renderBars (layer: SVGGElementSelection, layerIndex: number, data): void {
@@ -208,7 +208,7 @@ export class BarChart extends StackMixin {
                     y -= this._barHeight(d);
                 }
 
-                return utils.safeNumber(y);
+                return safeNumber(y);
             })
             .attr('width', this._barWidth)
             .attr('height', d => this._barHeight(d))

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -6,7 +6,7 @@ import {d3Box} from '../base/d3.box'
 import {CoordinateGridMixin} from '../base/coordinate-grid-mixin';
 import {transition} from '../core/core';
 import {units} from '../core/units';
-import {add, constant, subtract} from '../core/utils';
+import {add, subtract} from '../core/utils';
 import {BoxWidthFn, ChartParentType, DCBrushSelection, NumberFormatFn, SVGGElementSelection} from '../core/types';
 
 // Returns a function to compute the interquartile range.
@@ -168,7 +168,7 @@ export class BoxPlot extends CoordinateGridMixin {
         if (!arguments.length) {
             return this._boxWidth;
         }
-        this._boxWidth = typeof boxWidth === 'function' ? boxWidth : constant(boxWidth);
+        this._boxWidth = typeof boxWidth === 'function' ? boxWidth : () => boxWidth;
         return this;
     }
 

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -6,7 +6,7 @@ import {d3Box} from '../base/d3.box'
 import {CoordinateGridMixin} from '../base/coordinate-grid-mixin';
 import {transition} from '../core/core';
 import {units} from '../core/units';
-import {utils} from '../core/utils';
+import {add, constant, subtract} from '../core/utils';
 import {BoxWidthFn, ChartParentType, DCBrushSelection, NumberFormatFn, SVGGElementSelection} from '../core/types';
 
 // Returns a function to compute the interquartile range.
@@ -168,7 +168,7 @@ export class BoxPlot extends CoordinateGridMixin {
         if (!arguments.length) {
             return this._boxWidth;
         }
-        this._boxWidth = typeof boxWidth === 'function' ? boxWidth : utils.constant(boxWidth);
+        this._boxWidth = typeof boxWidth === 'function' ? boxWidth : constant(boxWidth);
         return this;
     }
 
@@ -290,12 +290,12 @@ export class BoxPlot extends CoordinateGridMixin {
 
     public yAxisMin (): number {
         const padding = this._yRangePadding * this._yAxisRangeRatio();
-        return utils.subtract(this._minDataValue() - padding, this.yAxisPadding()) as number;
+        return subtract(this._minDataValue() - padding, this.yAxisPadding()) as number;
     }
 
     public yAxisMax (): number {
         const padding = this._yRangePadding * this._yAxisRangeRatio();
-        return utils.add(this._maxDataValue() + padding, this.yAxisPadding()) as number;
+        return add(this._maxDataValue() + padding, this.yAxisPadding()) as number;
     }
 
     /**

--- a/src/charts/bubble-overlay.ts
+++ b/src/charts/bubble-overlay.ts
@@ -4,7 +4,7 @@ import {BaseMixin} from '../base/base-mixin';
 import {BubbleMixin} from '../base/bubble-mixin';
 import {transition} from '../core/core';
 import {constants} from '../core/constants';
-import {utils} from '../core/utils';
+import {nameToId} from '../core/utils';
 import {ColorMixin} from '../base/color-mixin';
 import {ChartParentType, SVGGElementSelection} from '../core/types';
 
@@ -140,9 +140,9 @@ export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
     }
 
     public _getNodeG (point: { name: string; x: number; y: number }, data): SVGGElementSelection {
-        const bubbleNodeClass = `${BUBBLE_NODE_CLASS} ${utils.nameToId(point.name)}`;
+        const bubbleNodeClass = `${BUBBLE_NODE_CLASS} ${nameToId(point.name)}`;
 
-        let nodeG: SVGGElementSelection = this._g.select(`g.${utils.nameToId(point.name)}`);
+        let nodeG: SVGGElementSelection = this._g.select(`g.${nameToId(point.name)}`);
 
         if (nodeG.empty()) {
             nodeG = this._g.append('g')

--- a/src/charts/cbox-menu.ts
+++ b/src/charts/cbox-menu.ts
@@ -2,7 +2,7 @@ import {event, select, Selection} from 'd3-selection';
 
 import {events} from '../core/events';
 import {BaseMixin} from '../base/base-mixin';
-import {utils} from '../core/utils'
+import {uniqueId} from '../core/utils'
 import {ChartParentType, CompareFn} from '../core/types';
 
 const GROUP_CSS_CLASS = 'dc-cbox-group';
@@ -50,7 +50,7 @@ export class CboxMenu extends BaseMixin {
         this._multiple = false;
         this._promptValue = null;
 
-        this._uniqueId = utils.uniqueId();
+        this._uniqueId = uniqueId();
 
         this.data(group => group.all().filter(this._filterDisplayed));
 

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -2,7 +2,7 @@ import {max, min} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
 import {Axis, axisRight} from 'd3-axis';
 
-import {utils} from '../core/utils';
+import {add, subtract} from '../core/utils';
 import {CoordinateGridMixin} from '../base/coordinate-grid-mixin';
 import {ChartParentType, Margins, MinimalXYScale, SVGGElementSelection} from '../core/types';
 
@@ -530,11 +530,11 @@ export class CompositeChart extends CoordinateGridMixin {
     }
 
     public _yAxisMax () {
-        return utils.add(max(this._getYAxisMax(this._leftYAxisChildren())), this.yAxisPadding());
+        return add(max(this._getYAxisMax(this._leftYAxisChildren())), this.yAxisPadding());
     }
 
     public _rightYAxisMax () {
-        return utils.add(max(this._getYAxisMax(this._rightYAxisChildren())), this.yAxisPadding());
+        return add(max(this._getYAxisMax(this._rightYAxisChildren())), this.yAxisPadding());
     }
 
     public _getAllXAxisMinFromChildCharts () {
@@ -542,7 +542,7 @@ export class CompositeChart extends CoordinateGridMixin {
     }
 
     public xAxisMin () {
-        return utils.subtract(min(this._getAllXAxisMinFromChildCharts()), this.xAxisPadding(), this.xAxisPaddingUnit());
+        return subtract(min(this._getAllXAxisMinFromChildCharts()), this.xAxisPadding(), this.xAxisPaddingUnit());
     }
 
     public _getAllXAxisMaxFromChildCharts () {
@@ -550,7 +550,7 @@ export class CompositeChart extends CoordinateGridMixin {
     }
 
     public xAxisMax () {
-        return utils.add(max(this._getAllXAxisMaxFromChildCharts()), this.xAxisPadding(), this.xAxisPaddingUnit());
+        return add(max(this._getAllXAxisMaxFromChildCharts()), this.xAxisPadding(), this.xAxisPaddingUnit());
     }
 
     public legendables () {

--- a/src/charts/geo-choropleth-chart.ts
+++ b/src/charts/geo-choropleth-chart.ts
@@ -6,7 +6,7 @@ import {ColorMixin} from '../base/color-mixin';
 import {transition} from '../core/core';
 import {logger} from '../core/logger';
 import {events} from '../core/events';
-import {utils} from '../core/utils';
+import {nameToId} from '../core/utils';
 import {BaseAccessor, ChartParentType} from '../core/types';
 
 interface GeoJson {
@@ -118,7 +118,7 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
             .classed('deselected', d => this._isDeselected(layerIndex, d))
             .attr('class', d => {
                 const layerNameClass = this._geoJson(layerIndex).name;
-                const regionClass = utils.nameToId(this._geoJson(layerIndex).keyAccessor(d));
+                const regionClass = nameToId(this._geoJson(layerIndex).keyAccessor(d));
                 let baseClasses = `${layerNameClass} ${regionClass}`;
                 if (this._isSelected(layerIndex, d)) {
                     baseClasses += ' selected';

--- a/src/charts/html-legend.ts
+++ b/src/charts/html-legend.ts
@@ -1,6 +1,6 @@
 import {select, Selection} from 'd3-selection';
 
-import {utils} from '../core/utils';
+import {isNumber} from '../core/utils';
 import {constants} from '../core/constants';
 import {LegendItem, LegendTextAccessor, ParentOfLegend} from '../core/types';
 
@@ -188,7 +188,7 @@ export class HtmlLegend {
         if (!arguments.length) {
             return this._maxItems;
         }
-        this._maxItems = utils.isNumber(maxItems) ? maxItems : undefined;
+        this._maxItems = isNumber(maxItems) ? maxItems : undefined;
         return this;
     }
 }

--- a/src/charts/legend.ts
+++ b/src/charts/legend.ts
@@ -1,4 +1,4 @@
-import {utils} from '../core/utils';
+import {isNumber} from '../core/utils';
 import {constants} from '../core/constants';
 import {LegendItem, LegendTextAccessor, ParentOfLegend} from '../core/types';
 import {Selection} from 'd3-selection';
@@ -232,7 +232,7 @@ export class Legend {
         if (!arguments.length) {
             return this._maxItems;
         }
-        this._maxItems = utils.isNumber(maxItems) ? maxItems : undefined;
+        this._maxItems = isNumber(maxItems) ? maxItems : undefined;
         return this;
     }
 

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -20,7 +20,7 @@ import {
 import {select, Selection} from 'd3-selection';
 
 import {logger} from '../core/logger';
-import {pluck2, utils} from '../core/utils';
+import {pluck2, printSingleValue, safeNumber} from '../core/utils';
 import {StackMixin} from '../base/stack-mixin';
 import {transition} from '../core/core';
 import {BaseAccessor, ChartParentType, LegendItem, SVGGElementSelection} from '../core/types';
@@ -91,7 +91,7 @@ export class LineChart extends StackMixin {
         this.transitionDelay(0);
         this._rangeBandPadding(1);
 
-        this.label(d => utils.printSingleValue(d.y0 + d.y), false);
+        this.label(d => printSingleValue(d.y0 + d.y), false);
 
         this.anchor(parent, chartGroup);
     }
@@ -408,8 +408,8 @@ export class LineChart extends StackMixin {
                     .enter()
                     .append('circle')
                     .attr('class', DOT_CIRCLE_CLASS)
-                    .attr('cx', d => utils.safeNumber(this.x()(d.x)))
-                    .attr('cy', d => utils.safeNumber(this.y()(d.y + d.y0)))
+                    .attr('cx', d => safeNumber(this.x()(d.x)))
+                    .attr('cy', d => safeNumber(this.y()(d.y + d.y0)))
                     .attr('r', this._getDotRadius())
                     .style('fill-opacity', this._dataPointFillOpacity)
                     .style('stroke-opacity', this._dataPointStrokeOpacity)
@@ -430,8 +430,8 @@ export class LineChart extends StackMixin {
                 dotsEnterModify.call(dot => this._doRenderTitle(dot, data));
 
                 transition(dotsEnterModify, this.transitionDuration())
-                    .attr('cx', d => utils.safeNumber(this.x()(d.x)))
-                    .attr('cy', d => utils.safeNumber(this.y()(d.y + d.y0)))
+                    .attr('cx', d => safeNumber(this.x()(d.x)))
+                    .attr('cy', d => safeNumber(this.y()(d.y + d.y0)))
                     .attr('fill', (d, i) => this.getColor(d, i));
 
                 dots.exit().remove();
@@ -454,10 +454,10 @@ export class LineChart extends StackMixin {
                 .merge(labels);
 
             transition(labelsEnterModify, chart.transitionDuration())
-                .attr('x', d => utils.safeNumber(chart.x()(d.x)))
+                .attr('x', d => safeNumber(chart.x()(d.x)))
                 .attr('y', d => {
                     const y = chart.y()(d.y + d.y0) - LABEL_PADDING;
-                    return utils.safeNumber(y);
+                    return safeNumber(y);
                 })
                 .text(d => chart.label()(d));
 

--- a/src/charts/series-chart.ts
+++ b/src/charts/series-chart.ts
@@ -3,7 +3,7 @@ import {nest} from 'd3-collection';
 
 import {CompositeChart} from './composite-chart';
 import {LineChart} from './line-chart';
-import {utils} from '../core/utils';
+import {constant} from '../core/utils';
 import {BaseAccessor, ChartParentType, CompareFn} from '../core/types';
 
 export type LineChartFunction = (parent, chartGroup) => LineChart;
@@ -86,7 +86,7 @@ export class SeriesChart extends CompositeChart {
                 return subChart
                     .dimension(this.dimension())
                     .group({
-                        all: typeof sub.values === 'function' ? sub.values : utils.constant(sub.values)
+                        all: typeof sub.values === 'function' ? sub.values : constant(sub.values)
                     }, sub.key)
                     .keyAccessor(this.keyAccessor())
                     .valueAccessor(this.valueAccessor())

--- a/src/charts/series-chart.ts
+++ b/src/charts/series-chart.ts
@@ -3,7 +3,6 @@ import {nest} from 'd3-collection';
 
 import {CompositeChart} from './composite-chart';
 import {LineChart} from './line-chart';
-import {constant} from '../core/utils';
 import {BaseAccessor, ChartParentType, CompareFn} from '../core/types';
 
 export type LineChartFunction = (parent, chartGroup) => LineChart;
@@ -86,7 +85,7 @@ export class SeriesChart extends CompositeChart {
                 return subChart
                     .dimension(this.dimension())
                     .group({
-                        all: typeof sub.values === 'function' ? sub.values : constant(sub.values)
+                        all: typeof sub.values === 'function' ? sub.values : () => sub.values
                     }, sub.key)
                     .keyAccessor(this.keyAccessor())
                     .valueAccessor(this.valueAccessor())

--- a/src/charts/sunburst-chart.ts
+++ b/src/charts/sunburst-chart.ts
@@ -6,7 +6,7 @@ import {interpolate} from 'd3-interpolate';
 
 import {transition} from '../core/core';
 import {filters} from '../core/filters';
-import {utils} from '../core/utils';
+import {arraysIdentical, toHierarchy} from '../core/utils';
 import {events} from '../core/events';
 import {ColorMixin} from '../base/color-mixin';
 import {BaseMixin} from '../base/base-mixin';
@@ -145,7 +145,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
 
         // if we have data...
         if (sum(this.data(), this.valueAccessor())) {
-            cdata = utils.toHierarchy(this.data(), this.valueAccessor());
+            cdata = toHierarchy(this.data(), this.valueAccessor());
             partitionedNodes = this._partitionNodes(cdata);
             // First one is the root, which is not needed
             partitionedNodes.nodes.shift();
@@ -153,7 +153,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
         } else {
             // otherwise we'd be getting NaNs, so override
             // note: abuse others for its ignoring the value accessor
-            cdata = utils.toHierarchy([], d => d.value);
+            cdata = toHierarchy([], d => d.value);
             partitionedNodes = this._partitionNodes(cdata);
             this._g.classed(this._emptyCssClass, true);
         }
@@ -662,7 +662,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
         // clear out any filters that cover the path filtered.
         for (let j = filtersList.length - 1; j >= 0; j--) {
             const currentFilter = filtersList[j];
-            if (utils.arraysIdentical(currentFilter, path)) {
+            if (arraysIdentical(currentFilter, path)) {
                 exactMatch = true;
             }
             this.filter(filtersList[j]);

--- a/src/compat/core/utils.ts
+++ b/src/compat/core/utils.ts
@@ -5,7 +5,6 @@ import {
     arraysEqual,
     arraysIdentical,
     clamp,
-    constant,
     getAncestors,
     isFloat,
     isInteger,
@@ -59,7 +58,9 @@ export const utils = {
     arraysEqual: arraysEqual,
     arraysIdentical: arraysIdentical,
     clamp: clamp,
-    constant: constant,
+    constant: function (x) {
+        return () => x;
+    },
     getAncestors: getAncestors,
     isFloat: isFloat,
     isInteger: isInteger,

--- a/src/compat/core/utils.ts
+++ b/src/compat/core/utils.ts
@@ -1,4 +1,23 @@
-export * from '../../core/utils';
+import {
+    add,
+    allChildren,
+    appendOrSelect,
+    arraysEqual,
+    arraysIdentical,
+    clamp,
+    constant,
+    getAncestors,
+    isFloat,
+    isInteger,
+    isNegligible,
+    isNumber,
+    nameToId,
+    printSingleValue,
+    safeNumber,
+    subtract,
+    toHierarchy,
+    uniqueId
+} from '../../core/utils';
 
 /**
  * Returns a function that given a string property name, can be used to pluck the property off an object.  A function
@@ -27,4 +46,29 @@ export const pluck = function (n, f?) {
         return function (d) { return d[n]; };
     }
     return function (d, i) { return f.call(d, d[n], i); };
+};
+
+/**
+ * @namespace utils
+ * @type {{}}
+ */
+export const utils = {
+    add: add,
+    allChildren: allChildren,
+    appendOrSelect: appendOrSelect,
+    arraysEqual: arraysEqual,
+    arraysIdentical: arraysIdentical,
+    clamp: clamp,
+    constant: constant,
+    getAncestors: getAncestors,
+    isFloat: isFloat,
+    isInteger: isInteger,
+    isNegligible: isNegligible,
+    isNumber: isNumber,
+    nameToId: nameToId,
+    printSingleValue: printSingleValue,
+    safeNumber: safeNumber,
+    subtract: subtract,
+    toHierarchy: toHierarchy,
+    uniqueId: uniqueId
 };

--- a/src/core/printers.ts
+++ b/src/core/printers.ts
@@ -1,4 +1,4 @@
-import {utils} from './utils';
+import {printSingleValue} from './utils';
 
 interface IPrinters {
     filters: (filters) => string;
@@ -50,12 +50,12 @@ printers.filter = function (filter) {
     if (typeof filter !== 'undefined' && filter !== null) {
         if (filter instanceof Array) {
             if (filter.length >= 2) {
-                s = `[${filter.map(e => utils.printSingleValue(e)).join(' -> ')}]`;
+                s = `[${filter.map(e => printSingleValue(e)).join(' -> ')}]`;
             } else if (filter.length >= 1) {
-                s = utils.printSingleValue(filter[0]);
+                s = printSingleValue(filter[0]);
             }
         } else {
-            s = utils.printSingleValue(filter);
+            s = printSingleValue(filter);
         }
     }
 

--- a/src/core/units.ts
+++ b/src/core/units.ts
@@ -1,4 +1,4 @@
-import {utils} from './utils';
+import {isNegligible} from './utils';
 import {Units} from './types';
 
 /**
@@ -75,7 +75,7 @@ units.fp = {};
 units.fp.precision = function (precision: number): Units {
     const _f: Units = function (s: number, e:number): number {
         const d = Math.abs((e - s) / _f.resolution);
-        if (utils.isNegligible(d - Math.floor(d))) {
+        if (isNegligible(d - Math.floor(d))) {
             return Math.floor(d);
         } else {
             return Math.ceil(d);

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -4,56 +4,8 @@ import {format} from 'd3-format';
 import {constants} from './constants';
 import {config} from './config';
 
-// TODO: revisit all types after refactoring
-
-interface IUtils {
-    printSingleValue: any;
-    add: (l, r, t?) => (Date|number);
-    subtract: (l, r, t?) => (Date|number);
-    isNumber: (n) => boolean;
-    isFloat: (n) => boolean;
-    isInteger: (n) => boolean;
-    isNegligible: (n) => boolean;
-    constant: (x) => () => any;
-    clamp: (val, min, max) => any;
-    uniqueId: () => number;
-    nameToId: (name) => string;
-    appendOrSelect: (parent, selector, tag?) => any;
-    safeNumber: (n) => number;
-    arraysEqual: (a1, a2) => (boolean | any);
-    allChildren: (node) => any[];
-    toHierarchy: (list, accessor) => { children: any[]; key: string };
-    getAncestors: (node) => any[];
-    arraysIdentical: (a, b) => (boolean);
-}
-
 export const pluck2 = function (n, f) {
     return function (d, i) { return f.call(d, d[n], i); };
-};
-
-/**
- * @namespace utils
- * @type {{}}
- */
-export const utils: IUtils = {
-    add: add,
-    allChildren: allChildren,
-    appendOrSelect: appendOrSelect,
-    arraysEqual: arraysEqual,
-    arraysIdentical: arraysIdentical,
-    clamp: clamp,
-    constant: constant,
-    getAncestors: getAncestors,
-    isFloat: isFloat,
-    isInteger: isInteger,
-    isNegligible: isNegligible,
-    isNumber: isNumber,
-    nameToId: nameToId,
-    printSingleValue: printSingleValue,
-    safeNumber: safeNumber,
-    subtract: subtract,
-    toHierarchy: toHierarchy,
-    uniqueId: uniqueId
 };
 
 /**
@@ -63,17 +15,17 @@ export const utils: IUtils = {
  * @param {any} filter
  * @returns {String}
  */
-export function printSingleValue (filter) {
-    let s: string|number = `${filter}`;
+export function printSingleValue (filter): string {
+    let s: string = `${filter}`;
 
     if (filter instanceof Date) {
         s = config.dateFormat(filter);
     } else if (typeof (filter) === 'string') {
         s = filter;
-    } else if (utils.isFloat(filter)) {
-        s = utils.printSingleValue.fformat(filter);
-    } else if (utils.isInteger(filter)) {
-        s = Math.round(filter);
+    } else if (isFloat(filter)) {
+        s = printSingleValue.fformat(filter);
+    } else if (isInteger(filter)) {
+        s = `${Math.round(filter)}`;
     }
 
     return s;
@@ -99,11 +51,11 @@ function _toTimeFunc (t) {
  * Arbitrary add one value to another.
  *
  * If the value l is of type Date, adds r units to it. t becomes the unit.
- * For example utils.add(dt, 3, 'week') will add 3 (r = 3) weeks (t= 'week') to dt.
+ * For example add(dt, 3, 'week') will add 3 (r = 3) weeks (t= 'week') to dt.
  *
  * If l is of type numeric, t is ignored. In this case if r is of type string,
  * it is assumed to be percentage (whether or not it includes %). For example
- * utils.add(30, 10) will give 40 and utils.add(30, '10') will give 33.
+ * add(30, 10) will give 40 and add(30, '10') will give 33.
  *
  * They also generate strange results if l is a string.
  * @method add
@@ -145,11 +97,11 @@ export function add (l, r, t?) {
  * Arbitrary subtract one value from another.
  *
  * If the value l is of type Date, subtracts r units from it. t becomes the unit.
- * For example utils.subtract(dt, 3, 'week') will subtract 3 (r = 3) weeks (t= 'week') from dt.
+ * For example subtract(dt, 3, 'week') will subtract 3 (r = 3) weeks (t= 'week') from dt.
  *
  * If l is of type numeric, t is ignored. In this case if r is of type string,
  * it is assumed to be percentage (whether or not it includes %). For example
- * utils.subtract(30, 10) will give 20 and utils.subtract(30, '10') will give 27.
+ * subtract(30, 10) will give 20 and subtract(30, '10') will give 27.
  *
  * They also generate strange results if l is a string.
  * @method subtract
@@ -230,7 +182,7 @@ export function isInteger (n) {
  * @returns {Boolean}
  */
 export function isNegligible (n) {
-    return !utils.isNumber(n) || (n < constants.NEGLIGIBLE_NUMBER && n > -constants.NEGLIGIBLE_NUMBER);
+    return !isNumber(n) || (n < constants.NEGLIGIBLE_NUMBER && n > -constants.NEGLIGIBLE_NUMBER);
 }
 
 /**
@@ -251,7 +203,7 @@ export function clamp (val, min, max) {
  *
  * {@link https://github.com/d3/d3/blob/master/CHANGES.md#internals `d3.functor` was removed in d3 version 4}.
  * This function helps to implement the replacement,
- * `typeof x === "function" ? x : utils.constant(x)`
+ * `typeof x === "function" ? x : constant(x)`
  * @method constant
  * @memberof utils
  * @param {any} x
@@ -311,7 +263,7 @@ export function appendOrSelect (parent, selector, tag?) {
  * @returns {Number}
  */
 export function safeNumber (n) {
-    return utils.isNumber(+n) ? +n : 0;
+    return isNumber(+n) ? +n : 0;
 }
 
 /**
@@ -344,7 +296,7 @@ export function allChildren (node) {
     console.log('currentNode', node);
     if (node.children) {
         for (let i = 0; i < node.children.length; i++) {
-            paths = paths.concat(utils.allChildren(node.children[i]));
+            paths = paths.concat(allChildren(node.children[i]));
         }
     }
     return paths;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -19,7 +19,6 @@ interface IUtils {
     uniqueId: () => number;
     nameToId: (name) => string;
     appendOrSelect: (parent, selector, tag?) => any;
-    _toTimeFunc: (t) => any;
     safeNumber: (n) => number;
     arraysEqual: (a1, a2) => (boolean | any);
     allChildren: (node) => any[];
@@ -37,40 +36,24 @@ export const pluck2 = function (n, f) {
  * @type {{}}
  */
 export const utils: IUtils = {
-    _toTimeFunc (t): any {
-    }, add (l, r, t?): Date {
-        return undefined;
-    }, allChildren (node): any[] {
-        return [];
-    }, appendOrSelect (parent, selector, tag?): any {
-    }, arraysEqual (a1, a2): any {
-    }, arraysIdentical (a, b): boolean {
-        return false;
-    }, clamp (val, min, max): any {
-    }, constant (x): () => any {
-        return function () {
-        };
-    }, getAncestors (node): any[] {
-        return [];
-    }, isFloat (n): boolean {
-        return false;
-    }, isInteger (n): boolean {
-        return false;
-    }, isNegligible (n): boolean {
-        return false;
-    }, isNumber (n): boolean {
-        return false;
-    }, nameToId (name): string {
-        return '';
-    }, printSingleValue: undefined, safeNumber (n): number {
-        return 0;
-    }, subtract (l, r, t?): Date {
-        return undefined;
-    }, toHierarchy (list, accessor): { children: any[]; key: string } {
-        return {children: [], key: ''};
-    }, uniqueId (): number {
-        return 0;
-    }
+    add: add,
+    allChildren: allChildren,
+    appendOrSelect: appendOrSelect,
+    arraysEqual: arraysEqual,
+    arraysIdentical: arraysIdentical,
+    clamp: clamp,
+    constant: constant,
+    getAncestors: getAncestors,
+    isFloat: isFloat,
+    isInteger: isInteger,
+    isNegligible: isNegligible,
+    isNumber: isNumber,
+    nameToId: nameToId,
+    printSingleValue: printSingleValue,
+    safeNumber: safeNumber,
+    subtract: subtract,
+    toHierarchy: toHierarchy,
+    uniqueId: uniqueId
 };
 
 /**
@@ -80,7 +63,7 @@ export const utils: IUtils = {
  * @param {any} filter
  * @returns {String}
  */
-utils.printSingleValue = function (filter) {
+export function printSingleValue (filter) {
     let s: string|number = `${filter}`;
 
     if (filter instanceof Date) {
@@ -94,11 +77,12 @@ utils.printSingleValue = function (filter) {
     }
 
     return s;
-};
-utils.printSingleValue.fformat = format('.2f');
+}
+// TODO: move it to config
+printSingleValue.fformat = format('.2f');
 
 // convert 'day' to d3.timeDay and similar
-utils._toTimeFunc = function (t) {
+function _toTimeFunc (t) {
     const mappings = {
         'second': timeSecond,
         'minute': timeMinute,
@@ -109,7 +93,7 @@ utils._toTimeFunc = function (t) {
         'year': timeYear
     };
     return mappings[t];
-};
+}
 
 /**
  * Arbitrary add one value to another.
@@ -132,7 +116,7 @@ utils._toTimeFunc = function (t) {
  * 'millis', 'second', 'minute', 'hour', 'day', 'week', 'month', or 'year'
  * @returns {Date|Number}
  */
-utils.add = function (l, r, t?) {
+export function add (l, r, t?) {
     if (typeof r === 'string') {
         r = r.replace('%', '');
     }
@@ -146,7 +130,7 @@ utils.add = function (l, r, t?) {
         }
         t = t || timeDay;
         if (typeof t !== 'function') {
-            t = utils._toTimeFunc(t);
+            t = _toTimeFunc(t);
         }
         return t.offset(l, r);
     } else if (typeof r === 'string') {
@@ -155,7 +139,7 @@ utils.add = function (l, r, t?) {
     } else {
         return l + r;
     }
-};
+}
 
 /**
  * Arbitrary subtract one value from another.
@@ -178,7 +162,7 @@ utils.add = function (l, r, t?) {
  * 'millis', 'second', 'minute', 'hour', 'day', 'week', 'month', or 'year'
  * @returns {Date|Number}
  */
-utils.subtract = function (l, r, t?) {
+export function subtract (l, r, t?) {
     if (typeof r === 'string') {
         r = r.replace('%', '');
     }
@@ -192,7 +176,7 @@ utils.subtract = function (l, r, t?) {
         }
         t = t || timeDay;
         if (typeof t !== 'function') {
-            t = utils._toTimeFunc(t);
+            t = _toTimeFunc(t);
         }
         return t.offset(l, -r);
     } else if (typeof r === 'string') {
@@ -201,7 +185,7 @@ utils.subtract = function (l, r, t?) {
     } else {
         return l - r;
     }
-};
+}
 
 /**
  * Is the value a number?
@@ -210,9 +194,9 @@ utils.subtract = function (l, r, t?) {
  * @param {any} n
  * @returns {Boolean}
  */
-utils.isNumber = function (n) {
+export function isNumber (n) {
     return n === +n;
-};
+}
 
 /**
  * Is the value a float?
@@ -221,10 +205,10 @@ utils.isNumber = function (n) {
  * @param {any} n
  * @returns {Boolean}
  */
-utils.isFloat = function (n) {
+export function isFloat (n) {
     // tslint:disable-next-line:no-bitwise
     return n === +n && n !== (n | 0);
-};
+}
 
 /**
  * Is the value an integer?
@@ -233,10 +217,10 @@ utils.isFloat = function (n) {
  * @param {any} n
  * @returns {Boolean}
  */
-utils.isInteger = function (n) {
+export function isInteger (n) {
     // tslint:disable-next-line:no-bitwise
     return n === +n && n === (n | 0);
-};
+}
 
 /**
  * Is the value very close to zero?
@@ -245,9 +229,9 @@ utils.isInteger = function (n) {
  * @param {any} n
  * @returns {Boolean}
  */
-utils.isNegligible = function (n) {
+export function isNegligible (n) {
     return !utils.isNumber(n) || (n < constants.NEGLIGIBLE_NUMBER && n > -constants.NEGLIGIBLE_NUMBER);
-};
+}
 
 /**
  * Ensure the value is no greater or less than the min/max values.  If it is return the boundary value.
@@ -258,9 +242,9 @@ utils.isNegligible = function (n) {
  * @param {any} max
  * @returns {any}
  */
-utils.clamp = function (val, min, max) {
+export function clamp (val, min, max) {
     return val < min ? min : (val > max ? max : val);
-};
+}
 
 /**
  * Given `x`, return a function that always returns `x`.
@@ -273,11 +257,11 @@ utils.clamp = function (val, min, max) {
  * @param {any} x
  * @returns {Function}
  */
-utils.constant = function (x) {
+export function constant (x) {
     return function () {
         return x;
     };
-};
+}
 
 /**
  * Using a simple static counter, provide a unique integer id.
@@ -286,9 +270,9 @@ utils.constant = function (x) {
  * @returns {Number}
  */
 let _idCounter = 0;
-utils.uniqueId = function () {
+export function uniqueId () {
     return ++_idCounter;
-};
+}
 
 /**
  * Convert a name to an ID.
@@ -297,9 +281,9 @@ utils.uniqueId = function () {
  * @param {String} name
  * @returns {String}
  */
-utils.nameToId = function (name) {
+export function nameToId (name) {
     return name.toLowerCase().replace(/[\s]/g, '_').replace(/[\.']/g, '');
-};
+}
 
 /**
  * Append or select an item on a parent element.
@@ -310,14 +294,14 @@ utils.nameToId = function (name) {
  * @param {String} tag
  * @returns {d3.selection}
  */
-utils.appendOrSelect = function (parent, selector, tag?) {
+export function appendOrSelect (parent, selector, tag?) {
     tag = tag || selector;
     let element = parent.select(selector);
     if (element.empty()) {
         element = parent.append(tag);
     }
     return element;
-};
+}
 
 /**
  * Return the number if the value is a number; else 0.
@@ -326,7 +310,9 @@ utils.appendOrSelect = function (parent, selector, tag?) {
  * @param {Number|any} n
  * @returns {Number}
  */
-utils.safeNumber = function (n) { return utils.isNumber(+n) ? +n : 0;};
+export function safeNumber (n) {
+    return utils.isNumber(+n) ? +n : 0;
+}
 
 /**
  * Return true if both arrays are equal, if both array are null these are considered equal
@@ -336,7 +322,7 @@ utils.safeNumber = function (n) { return utils.isNumber(+n) ? +n : 0;};
  * @param {Array|null} a2
  * @returns {Boolean}
  */
-utils.arraysEqual = function (a1, a2) {
+export function arraysEqual (a1, a2) {
     if (!a1 && !a2) {
         return true;
     }
@@ -349,10 +335,10 @@ utils.arraysEqual = function (a1, a2) {
         // If elements are not integers/strings, we hope that it will match because of toString
         // Test cases cover dates as well.
         a1.every((elem, i) => elem.valueOf() === a2[i].valueOf());
-};
+}
 
 // ******** Sunburst Chart ********
-utils.allChildren = function (node) {
+export function allChildren (node) {
     let paths = [];
     paths.push(node.path);
     console.log('currentNode', node);
@@ -362,11 +348,11 @@ utils.allChildren = function (node) {
         }
     }
     return paths;
-};
+}
 
 // builds a d3 Hierarchy from a collection
 // TODO: turn this monster method something better.
-utils.toHierarchy = function (list, accessor) {
+export function toHierarchy (list, accessor) {
     const root = {'key': 'root', 'children': []};
     for (let i = 0; i < list.length; i++) {
         const data = list[i];
@@ -380,7 +366,7 @@ utils.toHierarchy = function (list, accessor) {
             let childNode;
             if (j + 1 < parts.length) {
                 // Not yet at the end of the sequence; move down the tree.
-                childNode = findChild(children, nodeName);
+                childNode = _findChild(children, nodeName);
 
                 // If we don't already have a child node for this branch, create it.
                 if (childNode === void 0) {
@@ -396,9 +382,9 @@ utils.toHierarchy = function (list, accessor) {
         }
     }
     return root;
-};
+}
 
-function findChild (children, nodeName) {
+function _findChild (children, nodeName) {
     for (let k = 0; k < children.length; k++) {
         if (children[k].key === nodeName) {
             return children[k];
@@ -406,7 +392,7 @@ function findChild (children, nodeName) {
     }
 }
 
-utils.getAncestors = function (node) {
+export function getAncestors (node) {
     const path = [];
     let current = node;
     while (current.parent) {
@@ -414,9 +400,9 @@ utils.getAncestors = function (node) {
         current = current.parent;
     }
     return path;
-};
+}
 
-utils.arraysIdentical = function (a, b) {
+export function arraysIdentical (a, b) {
     let i = a.length;
     if (i !== b.length) {
         return false;
@@ -427,4 +413,4 @@ utils.arraysIdentical = function (a, b) {
         }
     }
     return true;
-};
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -199,23 +199,6 @@ export function clamp (val, min, max) {
 }
 
 /**
- * Given `x`, return a function that always returns `x`.
- *
- * {@link https://github.com/d3/d3/blob/master/CHANGES.md#internals `d3.functor` was removed in d3 version 4}.
- * This function helps to implement the replacement,
- * `typeof x === "function" ? x : constant(x)`
- * @method constant
- * @memberof utils
- * @param {any} x
- * @returns {Function}
- */
-export function constant (x) {
-    return function () {
-        return x;
-    };
-}
-
-/**
  * Using a simple static counter, provide a unique integer id.
  * @method uniqueId
  * @memberof utils


### PR DESCRIPTION
This is a fairly mechanical conversion. Backward compatibility has been maintained via the compat layer.

While doing the conversion I realized that the function `utils.constant` can be inlined easily (this has been put as a separate commit).