### PR TITLE
Support for adding accessibility features at chart generation

### DIFF
--- a/docs/api-latest.md
+++ b/docs/api-latest.md
@@ -3894,6 +3894,7 @@ and available on all chart implementations in the `dc` library.
     * [.root([rootElement])](#BaseMixin+root) ⇒ <code>HTMLElement</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.svg([svgElement])](#BaseMixin+svg) ⇒ <code>SVGElement</code> \| <code>d3.selection</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.resetSvg()](#BaseMixin+resetSvg) ⇒ <code>SVGElement</code>
+    * [.svgDescription([description])](#BaseMixin+svgDescription) ⇒ <code>String</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.filterPrinter([filterPrinterFunction])](#BaseMixin+filterPrinter) ⇒ <code>function</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.controlsUseVisibility([controlsUseVisibility])](#BaseMixin+controlsUseVisibility) ⇒ <code>Boolean</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.turnOnControls()](#BaseMixin+turnOnControls) ⇒ [<code>BaseMixin</code>](#BaseMixin)
@@ -4235,6 +4236,17 @@ Remove the chart's SVGElements from the dom and recreate the container SVGElemen
 
 **Kind**: instance method of [<code>BaseMixin</code>](#BaseMixin)  
 **See**: [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement)  
+<a name="BaseMixin+svgDescription"></a>
+
+### baseMixin.svgDescription([description]) ⇒ <code>String</code> \| [<code>BaseMixin</code>](#BaseMixin)
+Set description text for the entire SVG graphic to be read out by assistive technologies.
+
+**Kind**: instance method of [<code>BaseMixin</code>](#BaseMixin)  
+
+| Param | Type | Default |
+| --- | --- | --- |
+| [description] | <code>String</code> | <code>&#x27;&#x27;</code> | 
+
 <a name="BaseMixin+filterPrinter"></a>
 
 ### baseMixin.filterPrinter([filterPrinterFunction]) ⇒ <code>function</code> \| [<code>BaseMixin</code>](#BaseMixin)

--- a/docs/api-latest.md
+++ b/docs/api-latest.md
@@ -3894,7 +3894,6 @@ and available on all chart implementations in the `dc` library.
     * [.root([rootElement])](#BaseMixin+root) ⇒ <code>HTMLElement</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.svg([svgElement])](#BaseMixin+svg) ⇒ <code>SVGElement</code> \| <code>d3.selection</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.resetSvg()](#BaseMixin+resetSvg) ⇒ <code>SVGElement</code>
-    * [.svgDescription([description])](#BaseMixin+svgDescription) ⇒ <code>String</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.filterPrinter([filterPrinterFunction])](#BaseMixin+filterPrinter) ⇒ <code>function</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.controlsUseVisibility([controlsUseVisibility])](#BaseMixin+controlsUseVisibility) ⇒ <code>Boolean</code> \| [<code>BaseMixin</code>](#BaseMixin)
     * [.turnOnControls()](#BaseMixin+turnOnControls) ⇒ [<code>BaseMixin</code>](#BaseMixin)
@@ -4236,17 +4235,6 @@ Remove the chart's SVGElements from the dom and recreate the container SVGElemen
 
 **Kind**: instance method of [<code>BaseMixin</code>](#BaseMixin)  
 **See**: [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement)  
-<a name="BaseMixin+svgDescription"></a>
-
-### baseMixin.svgDescription([description]) ⇒ <code>String</code> \| [<code>BaseMixin</code>](#BaseMixin)
-Set description text for the entire SVG graphic to be read out by assistive technologies.
-
-**Kind**: instance method of [<code>BaseMixin</code>](#BaseMixin)  
-
-| Param | Type | Default |
-| --- | --- | --- |
-| [description] | <code>String</code> | <code>&#x27;&#x27;</code> | 
-
 <a name="BaseMixin+filterPrinter"></a>
 
 ### baseMixin.filterPrinter([filterPrinterFunction]) ⇒ <code>function</code> \| [<code>BaseMixin</code>](#BaseMixin)

--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -1280,12 +1280,80 @@ describe('dc.BarChart', () => {
 
     describe('accessibility bar chart', () => {
 
-        beforeEach(() => {
-            chart.render();
-        });
+        function removeEmptyBins (sourceGroup) {
+            return {
+                all:function () {
+                    return sourceGroup.all().filter( d => d.value !== 0);
+                }
+            };
+        }
 
         it('default description should match class name', () => {
+            chart.render()
             expect(chart.svg().node().firstChild.innerHTML).toEqual('BarChart');
+        });
+
+        it('internal elements are focusable by keyboard', () => {
+            chart.keyboardAccessible(true);
+            chart.render();
+            chart.selectAll('rect.bar').each(function () {
+                const bar = d3.select(this);
+                expect(bar.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('initial internal elements are clickable by pressing enter', () => {
+            chart.keyboardAccessible(true);
+            const clickHandlerSpy = jasmine.createSpy();
+            chart.onClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+                     
+            chart.selectAll('rect.bar').each(function () {
+                const bar = d3.select(this).node();
+                bar.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+
+        it('newly added internal elements are also clickable from keyboard', () => {
+            chart.keyboardAccessible(true);
+            const clickHandlerSpy = jasmine.createSpy();
+            chart.onClick = clickHandlerSpy;
+
+            const event = new Event('keydown');
+            event.keyCode = 13;
+
+            const stateDimension = data.dimension(d => d.state);
+            const regionDimension = data.dimension(d => d.region);
+            const stateGroup = stateDimension.group().reduceSum(d => +d.value);
+            const ordinalDomainValues = ['California', 'Colorado', 'Delaware', 'Ontario', 'Mississippi', 'Oklahoma'];
+            
+            chart
+                .dimension(stateDimension)
+                .group(removeEmptyBins(stateGroup))
+                .xUnits(dc.units.ordinal)
+                .x(d3.scaleBand().domain(ordinalDomainValues))
+                .elasticX(true)
+                .barPadding(0)
+                .outerPadding(0.1)
+                .transitionDuration(0)
+                .render();
+
+            //force creation of new <rect> elements on existing chart
+            regionDimension.filterExact('West');
+            chart.redraw();
+            regionDimension.filterAll();
+            chart.redraw();
+                    
+            chart.selectAll('rect.bar').each(function () {
+                const bar = d3.select(this).node();
+                bar.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+
         });
 
     });

--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -1288,11 +1288,6 @@ describe('dc.BarChart', () => {
             };
         }
 
-        it('default description should match class name', () => {
-            chart.render()
-            expect(chart.svg().node().firstChild.innerHTML).toEqual('BarChart');
-        });
-
         it('internal elements are focusable by keyboard', () => {
             chart.keyboardAccessible(true);
             chart.render();

--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -1278,6 +1278,18 @@ describe('dc.BarChart', () => {
         }
     });
 
+    describe('accessibility bar chart', () => {
+
+        beforeEach(() => {
+            chart.render();
+        });
+
+        it('default description should match class name', () => {
+            expect(chart.svg().node().firstChild.innerHTML).toEqual('BarChart');
+        });
+
+    });
+
     function nthStack (n) {
         const stack = d3.select(chart.selectAll('.stack').nodes()[n]);
 

--- a/spec/bar-chart-spec.js
+++ b/spec/bar-chart-spec.js
@@ -1306,10 +1306,10 @@ describe('dc.BarChart', () => {
             const event = new Event('keydown');
             event.keyCode = 13;
                      
-            chart.selectAll('rect.bar').each(function () {
-                const bar = d3.select(this).node();
-                bar.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('rect.bar').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();    
             });
         });
 
@@ -1343,10 +1343,10 @@ describe('dc.BarChart', () => {
             regionDimension.filterAll();
             chart.redraw();
                     
-            chart.selectAll('rect.bar').each(function () {
-                const bar = d3.select(this).node();
-                bar.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('rect.bar').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();
             });
 
         });

--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -680,19 +680,31 @@ describe('dc.baseMixin', () => {
 
     describe('accessibility base svg', () => {
 
-        beforeEach(() => {
+        it('should have default description when keyboardAccessible is true', () => {
+            chart
+                .keyboardAccessible(true)
+                .resetSvg();
+
+            expect(chart.svg().attr('tabindex')).toEqual('0');
+            expect(chart.svg().node().firstChild.innerHTML).toEqual('BaseMixin');
+        });
+
+        it('should have custom description if svgDescription is set', () => {
             chart
                 .svgDescription('I am a chart')
                 .resetSvg();
-        });
-
-        it('should have a tabindex', () => {
+            
             expect(chart.svg().attr('tabindex')).toEqual('0');
-        });
-
-        it('should have a description for AT', () => {
             expect(chart.svg().node().firstChild.innerHTML).toEqual('I am a chart');
         });
+
+        it('should not have accessibility features if not explicitly enabled', () => {
+            chart
+                .resetSvg();
+            
+            expect(chart.svg().attr('tabindex')).toBeNull();
+        });
+
 
     })
 });

--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -677,4 +677,22 @@ describe('dc.baseMixin', () => {
             expect(chart.filters().length).toEqual(0);
         });
     });
+
+    describe('accessibility base svg', () => {
+
+        beforeEach(() => {
+            chart
+                .svgDescription('I am a chart')
+                .resetSvg();
+        });
+
+        it('should have a tabindex', () => {
+            expect(chart.svg().attr('tabindex')).toEqual('0');
+        });
+
+        it('should have a description for AT', () => {
+            expect(chart.svg().node().firstChild.innerHTML).toEqual('I am a chart');
+        });
+
+    })
 });

--- a/spec/box-plot-spec.js
+++ b/spec/box-plot-spec.js
@@ -291,6 +291,37 @@ describe('dc.BoxPlot', () => {
         });
     });
 
+    describe('accessibility scatter plot', () => {
+
+        it('internal elements are focusable by keyboard', () => {
+            chart.keyboardAccessible(true);
+            chart.render();
+            chart.selectAll('circle').each(function () {
+                const circle = d3.select(this);
+                expect(circle.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('internal elements are clickable by pressing enter', () => {
+    
+            chart.keyboardAccessible(true);
+            const clickHandlerSpy = jasmine.createSpy();
+            chart.onClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+            
+            // only boxes are valid targets for keydown events
+            chart.selectAll('g.box').each(function () {
+                const circle = d3.select(this).node();
+                circle.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+
+    });
+
     function box (n) {
         const nthBox = d3.select(chart.selectAll('g.box').nodes()[n]);
         nthBox.boxText = function (i) {

--- a/spec/box-plot-spec.js
+++ b/spec/box-plot-spec.js
@@ -313,10 +313,10 @@ describe('dc.BoxPlot', () => {
             event.keyCode = 13;
             
             // only boxes are valid targets for keydown events
-            chart.selectAll('g.box').each(function () {
-                const circle = d3.select(this).node();
-                circle.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('g.box').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();      
             });
         });
 

--- a/spec/bubble-chart-spec.js
+++ b/spec/bubble-chart-spec.js
@@ -740,10 +740,10 @@ describe('dc.bubbleChart', () => {
             const event = new Event('keydown');
             event.keyCode = 13;
                      
-            chart.selectAll('circle').each(function () {
-                const bubble = d3.select(this).node();
-                bubble.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('circle').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();           
             });
         });
 

--- a/spec/bubble-chart-spec.js
+++ b/spec/bubble-chart-spec.js
@@ -721,5 +721,31 @@ describe('dc.bubbleChart', () => {
             chart.render();
             expect(document.querySelectorAll('.node text')[0].innerHTML).toEqual('T')
         });
+
+        it('internal elements are focusable by keyboard', () => {
+            chart.keyboardAccessible(true);
+            chart.render();
+            chart.selectAll('circle').each(function () {
+                const bubble = d3.select(this);
+                expect(bubble.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('internal elements are clickable by pressing enter', () => {
+            chart.keyboardAccessible(true);
+            const clickHandlerSpy = jasmine.createSpy();
+            chart.onClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+                     
+            chart.selectAll('circle').each(function () {
+                const bubble = d3.select(this).node();
+                bubble.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+
     });
 });

--- a/spec/bubble-chart-spec.js
+++ b/spec/bubble-chart-spec.js
@@ -710,4 +710,16 @@ describe('dc.bubbleChart', () => {
             });
         });
     });
+
+    describe('accessibility bubble chart', () => {
+
+        it('DOM order follows x values if keyboardAccessible is set', () => {
+            // default (alphabetical) sort order would put F ahead of T in DOM order
+            // keyboardAccessible should instead re-order DOM elements based on x-value
+            // T value is 198; F value is 220
+            chart.keyboardAccessible(true);
+            chart.render();
+            expect(document.querySelectorAll('.node text')[0].innerHTML).toEqual('T')
+        });
+    });
 });

--- a/spec/geo-choropleth-chart-spec.js
+++ b/spec/geo-choropleth-chart-spec.js
@@ -308,10 +308,10 @@ describe('dc.geoChoropleth', () => {
             const event = new Event('keydown');
             event.keyCode = 13;
                      
-            chart.selectAll('path.dc-tabbable').each(function () {
-                const state = d3.select(this).node();
-                state.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('path.dc-tabbable').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();
             });
         });
 

--- a/spec/geo-choropleth-chart-spec.js
+++ b/spec/geo-choropleth-chart-spec.js
@@ -268,4 +268,53 @@ describe('dc.geoChoropleth', () => {
             expect(chart.geoJsons().filter(e => e.name === 'state').length).toEqual(0);
         });
     });
+
+    describe('accessibility choropleth', () => {
+        // create chart without rendering it
+        let chart;
+        beforeEach(() => {
+            const id = 'accessible-choropleth-chart'
+            chart = new dc.GeoChoroplethChart(`#${id}`);
+            appendChartID(id);
+
+            chart.dimension(stateDimension)
+                .group(stateValueSumGroup)
+                .width(990)
+                .height(600)
+                .keyboardAccessible(true)
+                .colors(['#ccc', '#e2f2ff', '#c4e4ff', '#9ed2ff', '#81c5ff', '#6bbaff', '#51aeff', '#36a2ff', '#1e96ff', '#0089ff'])
+                .colorDomain([0, 155])
+                .overlayGeoJson(geoJson.features, 'state', d => d.properties.name)
+                .overlayGeoJson(geoJson2.features, 'county')
+                .transitionDuration(0)
+                .title(d => `${d.key} : ${d.value ? d.value : 0}`);
+        });
+
+        it('internal elements are focusable by keyboard', () => {
+            
+            chart.render();
+            chart.selectAll('path.dc-tabbable').each(function () {
+                const state = d3.select(this);
+                expect(state.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('internal elements are clickable by pressing enter', () => {
+
+            const clickHandlerSpy = jasmine.createSpy();
+            chart.onClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+                     
+            chart.selectAll('path.dc-tabbable').each(function () {
+                const state = d3.select(this).node();
+                state.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+
+    });
+
 });

--- a/spec/heatmap-spec.js
+++ b/spec/heatmap-spec.js
@@ -605,4 +605,36 @@ describe('dc.heatmap', () => {
             });
         });
     });
+
+    describe('accessibility heatmap', () => {
+
+        beforeEach(() => {
+            chart.keyboardAccessible(true);
+        })
+
+        it('internal elements are focusable by keyboard', () => {
+
+            chart.render();
+            chart.selectAll('rect.heat-box').each(function () {
+                const bar = d3.select(this);
+                expect(bar.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('internal elements are clickable by pressing enter', () => {
+
+            const clickHandlerSpy = jasmine.createSpy();
+            chart.boxOnClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+                     
+            chart.selectAll('rect.heat-box').each(function () {
+                const bar = d3.select(this).node();
+                bar.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+    });
 });

--- a/spec/heatmap-spec.js
+++ b/spec/heatmap-spec.js
@@ -630,10 +630,10 @@ describe('dc.heatmap', () => {
             const event = new Event('keydown');
             event.keyCode = 13;
                      
-            chart.selectAll('rect.heat-box').each(function () {
-                const bar = d3.select(this).node();
-                bar.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('rect.heat-box').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();
             });
         });
     });

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -273,6 +273,31 @@ describe('dc.legend', () => {
         });
     });
 
+    describe('accessible legends', () => {
+        beforeEach(() => {
+            chart.legend(new dc.Legend().keyboardAccessible(true)).render();
+        });
+
+        it('legend items should be focusable from keyboard', () => {
+
+            chart.select('g.dc-legend').selectAll('g.dc-legend-item text').each(function () {
+                const item = d3.select(this);
+                expect(item.attr('tabindex')).toEqual('0');
+            });
+           
+        });
+
+        it('keyboard focus on legend item should highlight chart item', () => {
+
+            chart
+            .select('g.dc-legend').select('g.dc-legend-item text')
+            .on('focus').call(legendItem(0).nodes()[0], legendItem(0).datum());
+
+            expect(d3.select(chart.selectAll('path.line').nodes()[0]).classed('highlight')).toBeTruthy();
+        });
+
+    });
+    
     function legendItem (n) {
         return d3.select(chart.selectAll('g.dc-legend g.dc-legend-item').nodes()[n]);
     }

--- a/spec/line-chart-spec.js
+++ b/spec/line-chart-spec.js
@@ -750,6 +750,22 @@ describe('dc.lineChart', () => {
         });
     });
 
+    describe('accessibility bar chart', () => {
+
+        beforeEach(() => {
+            chart.keyboardAccessible(true);
+            chart.brushOn(false);
+        })
+
+        it('internal elements are focusable by keyboard', () => {
+            chart.render();
+            chart.selectAll('circle.dot').each(function () {
+                const dot = d3.select(this);
+                expect(dot.attr('tabindex')).toEqual('0');
+            });
+        });
+    });
+
     function lineLabelCount () {
         expect(chart.selectAll('text.lineLabel').size()).toBe(chart.stack().length * chart.group().all().length);
     }

--- a/spec/number-display-spec.js
+++ b/spec/number-display-spec.js
@@ -221,4 +221,39 @@ describe('dc.numberDisplay', () => {
             });
         });
     });
+
+    describe('accessibility number display' , () => {
+        let chart;
+        beforeEach(() => {
+
+            const id = 'empty-div';
+            appendChartID(id);
+
+            chart = new dc.NumberDisplay(`#${id}`)
+            .transitionDuration(0)
+            .group(meanGroup)
+            .formatNumber(d3.format('.3s'))
+            .valueAccessor(average);
+        });
+
+        it('should have aria-live', () => {
+            chart.ariaLiveRegion(true);
+            chart.render();
+            d3.timerFlush();
+
+            expect(chart.select('span.number-display').attr('aria-live')).toEqual('polite');
+
+        });
+
+        it('should be focusable', () => {
+            chart.keyboardAccessible(true);
+            chart.render();
+            d3.timerFlush();
+
+            expect(chart.select('span.number-display').attr('tabindex')).toEqual('0');
+
+        });
+
+    });
+
 });

--- a/spec/pie-chart-spec.js
+++ b/spec/pie-chart-spec.js
@@ -845,10 +845,10 @@ describe('dc.pieChart', () => {
             const event = new Event('keydown');
             event.keyCode = 13;
                      
-            chart.selectAll('g.pie-slice').each(function () {
-                const pie = d3.select(this).node();
-                pie.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('g.pie-slice').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();
             });
         });
     });

--- a/spec/pie-chart-spec.js
+++ b/spec/pie-chart-spec.js
@@ -817,5 +817,45 @@ describe('dc.pieChart', () => {
             valueDimension.filterAll();
         });
     });
+
+    describe('accessibility pie chart', () => {
+
+        let chart;
+        beforeEach(() => {
+            chart = buildChart('pie-chart-legend');
+            chart.keyboardAccessible(true);
+ 
+        });
+
+        it('internal elements are focusable by keyboard', () => {
+
+            chart.render();
+            chart.selectAll('g.pie-slice').each(function () {
+                const pie = d3.select(this);
+                expect(pie.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('internal elements are clickable by pressing enter', () => {
+
+            const clickHandlerSpy = jasmine.createSpy();
+            chart._onClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+                     
+            chart.selectAll('g.pie-slice').each(function () {
+                const pie = d3.select(this).node();
+                pie.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+    });
+
+
+
+
+
 });
 

--- a/spec/row-chart-spec.js
+++ b/spec/row-chart-spec.js
@@ -163,6 +163,40 @@ describe('dc.rowChart', () => {
         });
     });
 
+    describe('accessibility row chart', () => {
+
+        beforeEach(() => {
+            chart.group(positiveGroupHolder.group);
+            chart.x(d3.scaleLinear());
+            chart.keyboardAccessible(true);
+        });
+
+        it('internal elements are focusable by keyboard', () => {
+
+            chart.render();
+            chart.selectAll('rect').each(function () {
+                const row = d3.select(this);
+                expect(row.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('internal elements are clickable by pressing enter', () => {
+
+            const clickHandlerSpy = jasmine.createSpy();
+            chart._onClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+                     
+            chart.selectAll('rect').each(function () {
+                const row = d3.select(this).node();
+                row.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+    });
+
     function itShouldBehaveLikeARowChartWithGroup (groupHolder, N, xAxisTicks) {
         describe(`for ${groupHolder.groupType} data`, () => {
             beforeEach(() => {

--- a/spec/row-chart-spec.js
+++ b/spec/row-chart-spec.js
@@ -189,10 +189,10 @@ describe('dc.rowChart', () => {
             const event = new Event('keydown');
             event.keyCode = 13;
                      
-            chart.selectAll('rect').each(function () {
-                const row = d3.select(this).node();
-                row.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('rect').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();
             });
         });
     });

--- a/spec/scatter-plot-spec.js
+++ b/spec/scatter-plot-spec.js
@@ -538,6 +538,21 @@ describe('dc.scatterPlot', () => {
         });
     });
 
+    describe('accessibility scatter plot', () => {
+
+        beforeEach(() => {
+            chart.keyboardAccessible(true);
+        })
+
+        it('internal elements are focusable by keyboard', () => {
+            chart.render();
+            chart.selectAll('path.symbol').each(function () {
+                const dot = d3.select(this);
+                expect(dot.attr('tabindex')).toEqual('0');
+            });
+        });
+    });
+
     function nthSymbol (i) {
         return d3.select(chart.selectAll('path.symbol').nodes()[i]);
     }

--- a/spec/sunburst-chart-spec.js
+++ b/spec/sunburst-chart-spec.js
@@ -477,4 +477,48 @@ describe('dc.sunburstChart', () => {
 
     });
 
+
+    describe('accessibility sunburst', () => {
+
+        let chart;
+        beforeEach(() => {
+            
+            const id = 'accessible-sunburst'
+            appendChartID(id);
+            chart = new dc.SunburstChart(`#${id}`);
+            chart
+                .dimension(countryRegionStateDimension)
+                .group(countryRegionStateGroup)
+                .width(width)
+                .height(height)
+                .transitionDuration(0)
+                .keyboardAccessible(true);
+        })
+
+        it('internal elements are focusable by keyboard', () => {
+
+            chart.render();
+            chart.selectAll('g.pie-slice path').each(function () {
+                const burst = d3.select(this);
+                expect(burst.attr('tabindex')).toEqual('0');
+            });
+        });
+
+        it('internal elements are clickable by pressing enter', () => {
+
+            const clickHandlerSpy = jasmine.createSpy();
+            chart.onClick = clickHandlerSpy;
+            chart.render();
+          
+            const event = new Event('keydown');
+            event.keyCode = 13;
+                     
+            chart.selectAll('g.pie-slice path').each(function () {
+                const burst = d3.select(this).node();
+                burst.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalled();            
+            });
+        });
+    });
+
 });

--- a/spec/sunburst-chart-spec.js
+++ b/spec/sunburst-chart-spec.js
@@ -513,10 +513,10 @@ describe('dc.sunburstChart', () => {
             const event = new Event('keydown');
             event.keyCode = 13;
                      
-            chart.selectAll('g.pie-slice path').each(function () {
-                const burst = d3.select(this).node();
-                burst.dispatchEvent(event);
-                expect(clickHandlerSpy).toHaveBeenCalled();            
+            chart.selectAll('g.pie-slice path').each(function (d) {
+                this.dispatchEvent(event);
+                expect(clickHandlerSpy).toHaveBeenCalledWith(d);
+                clickHandlerSpy.calls.reset();   
             });
         });
     });

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -719,14 +719,14 @@ export class BaseMixin {
         // called from each chart module's render and redraw methods
         this._svg.selectAll('.dc-tabbable')
                 .attr('tabindex', 0)
-                .on('keydown', d => {
+                .on('keydown', (d, i) => {
                     // trigger only if d is an object undestood by KeyAccessor()
                     if (d3Event.keyCode === 13 && typeof d === 'object') {
-                        onClickFunction.call(this, d, ...onClickArgs)
+                        onClickFunction.call(this, d, i, ...onClickArgs)
                     } 
                     // special case for space key press - prevent scrolling
                     if (d3Event.keyCode === 32 && typeof d === 'object') {
-                        onClickFunction.call(this, d, ...onClickArgs)
+                        onClickFunction.call(this, d, i,  ...onClickArgs)
                         d3Event.preventDefault();                
                     }
                 

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -72,7 +72,7 @@ const _defaultResetFilterHandler = filters => [];
 export class BaseMixin {
     constructor () {
         this.__dcFlag__ = utils.uniqueId();
-        this._svgDescription = ''
+        this._svgDescription = this.constructor.name || '';
 
         this._dimension = undefined;
         this._group = undefined;

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -72,6 +72,7 @@ const _defaultResetFilterHandler = filters => [];
 export class BaseMixin {
     constructor () {
         this.__dcFlag__ = utils.uniqueId();
+        this._svgDescription = ''
 
         this._dimension = undefined;
         this._group = undefined;
@@ -521,8 +522,30 @@ export class BaseMixin {
 
     generateSvg () {
         this._svg = this.root().append('svg');
+
+        this._svg.append('desc')
+            .attr('id', `desc-id-${this.__dcFlag__}`)
+            .html(`${this._svgDescription}`);
+
+        this._svg
+            .attr('tabindex', '0')
+            .attr('role', 'img')
+            .attr('aria-labelledby', `desc-id-${this.__dcFlag__}`);
         this.sizeSvg();
         return this._svg;
+    }
+
+    /**
+     * Set description text for the entire SVG graphic to be read out by assistive technologies.
+     * @param {String} [description='']
+     * @returns {String|BaseMixin}
+     */
+    svgDescription (description) {
+        if (!arguments.length) {
+            return this._svgDescription;
+        }
+        this._svgDescription = description;
+        return this;
     }
 
     /**

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -1,4 +1,4 @@
-import {select} from 'd3-selection';
+import {select, event as d3Event} from 'd3-selection';
 import {dispatch} from 'd3-dispatch';
 import {ascending} from 'd3-array';
 
@@ -73,6 +73,7 @@ export class BaseMixin {
     constructor () {
         this.__dcFlag__ = utils.uniqueId();
         this._svgDescription = this.constructor.name || '';
+        this._keyboardAccessible = false;
 
         this._dimension = undefined;
         this._group = undefined;
@@ -549,6 +550,19 @@ export class BaseMixin {
     }
 
     /**
+     * Whether interactive chart elements will be accessible by keyboard using tabindex.
+     * @param {Boolean} [keyboardAccessible=false]
+     * @returns {Boolean|BarChart}
+     */
+    keyboardAccessible (keyboardAccessible) {
+        if (!arguments.length) {
+            return this._keyboardAccessible;
+        }
+        this._keyboardAccessible = keyboardAccessible;
+        return this;
+    }
+
+    /**
      * Set or get the filter printer function. The filter printer function is used to generate human
      * friendly text for filter value(s) associated with the chart instance. The text will get shown
      * in the `.filter element; see {@link BaseMixin#turnOnControls turnOnControls}.
@@ -686,9 +700,32 @@ export class BaseMixin {
             this._legend.render();
         }
 
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible();
+        }
+
         this._activateRenderlets('postRender');
 
         return result;
+    }
+
+    _makeKeyboardAccessible () {
+        this._svg.selectAll('.dc-tabbable')
+                .attr('tabindex', 0)
+                .on('keydown', d => {
+
+                    if (d3Event.keyCode === 13) {
+                        console.log('clicked!');
+                        this.onClick(d);
+                    } 
+                    // special case for space key press - prevent scrolling
+                    if (d3Event.keyCode === 32) {
+                        console.log('clicked!');
+                        this.onClick(d);
+                        d3Event.preventDefault();
+                    }
+                
+                })
     }
 
     _activateRenderlets (event) {
@@ -727,6 +764,10 @@ export class BaseMixin {
 
         if (this._legend) {
             this._legend.render();
+        }
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible();
         }
 
         this._activateRenderlets('postRedraw');

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -537,7 +537,8 @@ export class BaseMixin {
     }
 
     /**
-     * Set description text for the entire SVG graphic to be read out by assistive technologies.
+     * Set description text for the entire SVG graphic to be read out by assistive technologies. By default
+     * will try to set the description to the parent chart's class constructor name: BarChart, HeatMap, etc.
      * @param {String} [description='']
      * @returns {String|BaseMixin}
      */
@@ -713,19 +714,17 @@ export class BaseMixin {
         this._svg.selectAll('.dc-tabbable')
                 .attr('tabindex', 0)
                 .on('keydown', d => {
-
-                    if (d3Event.keyCode === 13) {
-                        console.log('clicked!');
-                        this.onClick(d);
+                    // trigger only if d is an object undestood by KeyAccessor()
+                    if (d3Event.keyCode === 13 && typeof d === 'object') {
+                        this.onClick(d)
                     } 
                     // special case for space key press - prevent scrolling
-                    if (d3Event.keyCode === 32) {
-                        console.log('clicked!');
-                        this.onClick(d);
-                        d3Event.preventDefault();
+                    if (d3Event.keyCode === 32 && typeof d === 'object') {
+                        this.onClick(d)
+                        d3Event.preventDefault();                
                     }
                 
-                })
+                });
     }
 
     _activateRenderlets (event) {

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -72,7 +72,7 @@ const _defaultResetFilterHandler = filters => [];
 export class BaseMixin {
     constructor () {
         this.__dcFlag__ = utils.uniqueId();
-        this._svgDescription = this.constructor.name || '';
+        this._svgDescription = this.svgDescription()
         this._keyboardAccessible = false;
 
         this._dimension = undefined;
@@ -523,35 +523,48 @@ export class BaseMixin {
 
     generateSvg () {
         this._svg = this.root().append('svg');
+    
+        if (this.svgDescription.userSet || this._keyboardAccessible) {
 
-        this._svg.append('desc')
-            .attr('id', `desc-id-${this.__dcFlag__}`)
-            .html(`${this._svgDescription}`);
+            this._svg.append('desc')
+                .attr('id', `desc-id-${this.__dcFlag__}`)
+                .html(`${this._svgDescription}`);
 
-        this._svg
-            .attr('tabindex', '0')
-            .attr('role', 'img')
-            .attr('aria-labelledby', `desc-id-${this.__dcFlag__}`);
+            this._svg
+                .attr('tabindex', '0')
+                .attr('role', 'img')
+                .attr('aria-labelledby', `desc-id-${this.__dcFlag__}`);
+        }
+
         this.sizeSvg();
         return this._svg;
     }
 
     /**
-     * Set description text for the entire SVG graphic to be read out by assistive technologies. By default
-     * will try to set the description to the parent chart's class constructor name: BarChart, HeatMap, etc.
-     * @param {String} [description='']
+     * Set description text for the entire SVG graphic to be read out by assistive technologies and make
+     * the SVG focusable from keyboard.
+     * @param {String} [description]
      * @returns {String|BaseMixin}
      */
-    svgDescription (description) {
-        if (!arguments.length) {
-            return this._svgDescription;
-        }
-        this._svgDescription = description;
-        return this;
+    svgDescription () {
+
+        // overwrite for public API
+        this.svgDescription = description => {
+            this.svgDescription.userSet = true
+            this._svgDescription = description;
+            return this;
+        };
+        // pseudo-default that is exposed only if keyboardAccessible is called
+        return this.constructor.name;
+
     }
 
     /**
-     * Whether interactive chart elements will be accessible by keyboard using tabindex.
+     * If set, interactive chart elements like individual bars in a bar chart or symbols in a scatter plot
+     * will be focusable from keyboard and on pressing Enter or Space will behave as if clicked on.
+     * 
+     * If `svgDescription` has not been explicitly set, will also set SVG description text to the class
+     * constructor name, like BarChart or HeatMap, and make the entire SVG focusable.
      * @param {Boolean} [keyboardAccessible=false]
      * @returns {Boolean|BarChart}
      */

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -1,4 +1,4 @@
-import {select, event as d3Event} from 'd3-selection';
+import {select} from 'd3-selection';
 import {dispatch} from 'd3-dispatch';
 import {ascending} from 'd3-array';
 
@@ -11,6 +11,7 @@ import {logger} from '../core/logger';
 import {printers} from '../core/printers';
 import {InvalidStateException} from '../core/invalid-state-exception';
 import {BadArgumentException} from '../core/bad-argument-exception';
+import {adaptHandler} from '../core/d3compat';
 
 const _defaultFilterHandler = (dimension, filters) => {
     if (filters.length === 0) {
@@ -722,18 +723,18 @@ export class BaseMixin {
             .attr('tabindex', 0);
                 
         if (onClickFunction) {
-            tabElements.on('keydown', (d, i) => {
+            tabElements.on('keydown', adaptHandler((d, event) => {
                 // trigger only if d is an object undestood by KeyAccessor()
-                if (d3Event.keyCode === 13 && typeof d === 'object') {
-                    onClickFunction.call(this, d, i, ...onClickArgs)
+                if (event.keyCode === 13 && typeof d === 'object') {
+                    onClickFunction.call(this, d, ...onClickArgs)
                 } 
                 // special case for space key press - prevent scrolling
-                if (d3Event.keyCode === 32 && typeof d === 'object') {
-                    onClickFunction.call(this, d, i,  ...onClickArgs)
-                    d3Event.preventDefault();                
+                if (event.keyCode === 32 && typeof d === 'object') {
+                    onClickFunction.call(this, d, ...onClickArgs)
+                    event.preventDefault();                
                 }
             
-            });
+            }));
         }
     }
 

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -72,7 +72,7 @@ const _defaultResetFilterHandler = filters => [];
 export class BaseMixin {
     constructor () {
         this.__dcFlag__ = utils.uniqueId();
-        this._svgDescription = this.svgDescription()
+        this._svgDescription = null
         this._keyboardAccessible = false;
 
         this._dimension = undefined;
@@ -524,11 +524,11 @@ export class BaseMixin {
     generateSvg () {
         this._svg = this.root().append('svg');
     
-        if (this.svgDescription.userSet || this._keyboardAccessible) {
+        if (this._svgDescription || this._keyboardAccessible) {
 
             this._svg.append('desc')
                 .attr('id', `desc-id-${this.__dcFlag__}`)
-                .html(`${this._svgDescription}`);
+                .html(`${this.svgDescription()}`);
 
             this._svg
                 .attr('tabindex', '0')
@@ -541,22 +541,18 @@ export class BaseMixin {
     }
 
     /**
-     * Set description text for the entire SVG graphic to be read out by assistive technologies and make
-     * the SVG focusable from keyboard.
+     * Set or get description text for the entire SVG graphic. If set, will create a `<desc>` element as the first
+     * child of the SVG with the description text and also make the SVG focusable from keyboard.
      * @param {String} [description]
      * @returns {String|BaseMixin}
      */
-    svgDescription () {
+    svgDescription (description) {
+        if (!arguments.length) {
+            return this._svgDescription || this.constructor.name;
+        }
 
-        // overwrite for public API
-        this.svgDescription = description => {
-            this.svgDescription.userSet = true
-            this._svgDescription = description;
-            return this;
-        };
-        // pseudo-default that is exposed only if keyboardAccessible is called
-        return this.constructor.name;
-
+        this._svgDescription = description;
+        return this;
     }
 
     /**

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -717,20 +717,24 @@ export class BaseMixin {
 
     _makeKeyboardAccessible (onClickFunction, ...onClickArgs) {
         // called from each chart module's render and redraw methods
-        this._svg.selectAll('.dc-tabbable')
-                .attr('tabindex', 0)
-                .on('keydown', (d, i) => {
-                    // trigger only if d is an object undestood by KeyAccessor()
-                    if (d3Event.keyCode === 13 && typeof d === 'object') {
-                        onClickFunction.call(this, d, i, ...onClickArgs)
-                    } 
-                    // special case for space key press - prevent scrolling
-                    if (d3Event.keyCode === 32 && typeof d === 'object') {
-                        onClickFunction.call(this, d, i,  ...onClickArgs)
-                        d3Event.preventDefault();                
-                    }
+        const tabElements = this._svg
+            .selectAll('.dc-tabbable')
+            .attr('tabindex', 0);
                 
-                });
+        if (onClickFunction) {
+            tabElements.on('keydown', (d, i) => {
+                // trigger only if d is an object undestood by KeyAccessor()
+                if (d3Event.keyCode === 13 && typeof d === 'object') {
+                    onClickFunction.call(this, d, i, ...onClickArgs)
+                } 
+                // special case for space key press - prevent scrolling
+                if (d3Event.keyCode === 32 && typeof d === 'object') {
+                    onClickFunction.call(this, d, i,  ...onClickArgs)
+                    d3Event.preventDefault();                
+                }
+            
+            });
+        }
     }
 
     _activateRenderlets (event) {

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -710,26 +710,23 @@ export class BaseMixin {
             this._legend.render();
         }
 
-        if (this._keyboardAccessible) {
-            this._makeKeyboardAccessible();
-        }
-
         this._activateRenderlets('postRender');
 
         return result;
     }
 
-    _makeKeyboardAccessible () {
+    _makeKeyboardAccessible (onClickFunction, ...onClickArgs) {
+        // called from each chart module's render and redraw methods
         this._svg.selectAll('.dc-tabbable')
                 .attr('tabindex', 0)
                 .on('keydown', d => {
                     // trigger only if d is an object undestood by KeyAccessor()
                     if (d3Event.keyCode === 13 && typeof d === 'object') {
-                        this.onClick(d)
+                        onClickFunction.call(this, d, ...onClickArgs)
                     } 
                     // special case for space key press - prevent scrolling
                     if (d3Event.keyCode === 32 && typeof d === 'object') {
-                        this.onClick(d)
+                        onClickFunction.call(this, d, ...onClickArgs)
                         d3Event.preventDefault();                
                     }
                 
@@ -772,10 +769,6 @@ export class BaseMixin {
 
         if (this._legend) {
             this._legend.render();
-        }
-
-        if (this._keyboardAccessible) {
-            this._makeKeyboardAccessible();
         }
 
         this._activateRenderlets('postRedraw');

--- a/src/base/bubble-mixin.js
+++ b/src/base/bubble-mixin.js
@@ -1,4 +1,4 @@
-import { descending, min, max } from 'd3-array';
+import { ascending, descending, min, max } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
 
 import {ColorMixin} from './color-mixin';
@@ -32,6 +32,12 @@ export const BubbleMixin = Base => class extends ColorMixin(Base) {
 
         this.data(group => {
             const data = group.all();
+
+            if (this._keyboardAccessible) {
+                // sort based on the x value (key)
+                data.sort((a, b) => ascending(this.keyAccessor()(a), this.keyAccessor()(b)));
+            }
+
             if (this._sortBubbleSize) {
                 // sort descending so smaller bubbles are on top
                 const radiusAccessor = this.radiusValueAccessor();

--- a/src/charts/bar-chart.js
+++ b/src/charts/bar-chart.js
@@ -176,7 +176,8 @@ export class BarChart extends StackMixin {
 
         const enter = bars.enter()
             .append('rect')
-            .attr('class', `bar ${this._keyboardAccessible ? 'dc-tabbable' : ''}`)
+            .attr('class', 'bar')
+            .classed('dc-tabbable', this._keyboardAccessible)
             .attr('fill', pluck('data', this.getColor))
             .attr('x', d => this._barXPos(d))
             .attr('y', this.yAxisHeight())
@@ -190,6 +191,10 @@ export class BarChart extends StackMixin {
 
         if (this.isOrdinal()) {
             barsEnterUpdate.on('click', adaptHandler(d => this.onClick(d)));
+        }
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(this.onClick);
         }
 
         transition(barsEnterUpdate, this.transitionDuration(), this.transitionDelay())

--- a/src/charts/bar-chart.js
+++ b/src/charts/bar-chart.js
@@ -176,7 +176,7 @@ export class BarChart extends StackMixin {
 
         const enter = bars.enter()
             .append('rect')
-            .attr('class', 'bar')
+            .attr('class', `bar ${this._keyboardAccessible ? 'dc-tabbable' : ''}`)
             .attr('fill', pluck('data', this.getColor))
             .attr('x', d => this._barXPos(d))
             .attr('y', this.yAxisHeight())

--- a/src/charts/box-plot.js
+++ b/src/charts/box-plot.js
@@ -43,7 +43,7 @@ function defaultWhiskersIQR (k) {
  */
 export class BoxPlot extends CoordinateGridMixin {
     /**
-     * Create a BoxP lot.
+     * Create a Box Plot.
      *
      * @example
      * // create a box plot under #chart-container1 element using the default global chart group
@@ -194,13 +194,16 @@ export class BoxPlot extends CoordinateGridMixin {
         const boxesGEnter = boxesG.enter().append('g');
 
         boxesGEnter
-            .attr('class', 'box')
+            .attr('class', `box ${this._keyboardAccessible ? 'dc-tabbable' : ''}`)
             .attr('transform', (d, i) => this._boxTransform(d, i))
             .call(this._box)
             .on('click', adaptHandler(d => {
                 this.filter(this.keyAccessor()(d));
                 this.redrawGroup();
-            }));
+            }))
+            .selectAll('circle')
+            .classed('dc-tabbable', this._keyboardAccessible);
+
         return boxesGEnter.merge(boxesG);
     }
 

--- a/src/charts/box-plot.js
+++ b/src/charts/box-plot.js
@@ -194,7 +194,8 @@ export class BoxPlot extends CoordinateGridMixin {
         const boxesGEnter = boxesG.enter().append('g');
 
         boxesGEnter
-            .attr('class', `box ${this._keyboardAccessible ? 'dc-tabbable' : ''}`)
+            .attr('class', 'box')
+            .classed('dc-tabbable', this._keyboardAccessible)
             .attr('transform', (d, i) => this._boxTransform(d, i))
             .call(this._box)
             .on('click', adaptHandler(d => {
@@ -203,6 +204,10 @@ export class BoxPlot extends CoordinateGridMixin {
             }))
             .selectAll('circle')
             .classed('dc-tabbable', this._keyboardAccessible);
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(this.onClick);
+        }
 
         return boxesGEnter.merge(boxesG);
     }
@@ -233,6 +238,11 @@ export class BoxPlot extends CoordinateGridMixin {
 
     _yAxisRangeRatio () {
         return ((this._maxDataValue() - this._minDataValue()) / this.effectiveHeight());
+    }
+
+    onClick (d) {
+        this.filter(this.keyAccessor()(d));
+        this.redrawGroup();
     }
 
     fadeDeselectedArea (brushSelection) {

--- a/src/charts/bubble-chart.js
+++ b/src/charts/bubble-chart.js
@@ -75,6 +75,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
             .attr('transform', d => this._bubbleLocator(d))
             .append('circle').attr('class', (d, i) => `${this.BUBBLE_CLASS} _${i}`)
             .on('click', adaptHandler(d => this.onClick(d)))
+            .classed('dc-tabbable', this._keyboardAccessible)
             .attr('fill', this.getColor)
             .attr('r', 0);
 
@@ -84,6 +85,10 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
             .select(`circle.${this.BUBBLE_CLASS}`)
             .attr('r', d => this.bubbleR(d))
             .attr('opacity', d => (this.bubbleR(d) > 0) ? 1 : 0);
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(this.onClick);
+        }
 
         this._doRenderLabel(bubbleGEnter);
 

--- a/src/charts/bubble-chart.js
+++ b/src/charts/bubble-chart.js
@@ -53,7 +53,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
         const data = this.data();
         let bubbleG = this.chartBodyG().selectAll(`g.${this.BUBBLE_NODE_CLASS}`)
             .data(data, d => d.key);
-        if (this.sortBubbleSize()) {
+        if (this.sortBubbleSize() || this.keyboardAccessible()) {
             // update dom order based on sort
             bubbleG.order();
         }

--- a/src/charts/bubble-overlay.js
+++ b/src/charts/bubble-overlay.js
@@ -54,6 +54,7 @@ export class BubbleOverlay extends BubbleMixin(BaseMixin) {
          */
         this._g = undefined;
         this._points = [];
+        this._keyboardAccessible = false;
 
         this.transitionDuration(750);
 
@@ -113,9 +114,14 @@ export class BubbleOverlay extends BubbleMixin(BaseMixin) {
             if (circle.empty()) {
                 circle = nodeG.append('circle')
                     .attr('class', BUBBLE_CLASS)
+                    .classed('dc-tabbable', this._keyboardAccessible)
                     .attr('r', 0)
                     .attr('fill', this.getColor)
                     .on('click', adaptHandler(d => this.onClick(d)));
+            }
+
+            if (this._keyboardAccessible) {
+                this._makeKeyboardAccessible(this.onClick);
             }
 
             transition(circle, this.transitionDuration(), this.transitionDelay())

--- a/src/charts/geo-choropleth-chart.js
+++ b/src/charts/geo-choropleth-chart.js
@@ -63,6 +63,7 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
 
             regionG
                 .append('path')
+                .classed('dc-tabbable', this._keyboardAccessible)
                 .attr('fill', 'white')
                 .attr('d', this._getGeoPath());
 
@@ -149,6 +150,10 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
                 return 'none';
             })
             .on('click', adaptHandler(d => this.onClick(d, layerIndex)));
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(this.onClick, layerIndex);
+        }
 
         transition(paths, this.transitionDuration(),
                    this.transitionDelay()).attr('fill', (d, i) => this.getColor(data[this._geoJson(layerIndex).keyAccessor(d)], i));

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -236,7 +236,7 @@ export class HeatMap extends ColorMixin(MarginMixin) {
             .on('click', adaptHandler(this.boxOnClick()));
 
         if (this._keyboardAccessible) {
-            this._makeKeyboardAccessible(this.boxOnClick());
+            this._makeKeyboardAccessible(this.boxOnClick);
         }
 
         boxes = gEnter.merge(boxes);

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -229,10 +229,15 @@ export class HeatMap extends ColorMixin(MarginMixin) {
 
         gEnter.append('rect')
             .attr('class', 'heat-box')
+            .classed('dc-tabbable', this._keyboardAccessible)
             .attr('fill', 'white')
             .attr('x', (d, i) => cols(this.keyAccessor()(d, i)))
             .attr('y', (d, i) => rows(this.valueAccessor()(d, i)))
             .on('click', adaptHandler(this.boxOnClick()));
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(this.boxOnClick());
+        }
 
         boxes = gEnter.merge(boxes);
 

--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -1,7 +1,6 @@
 import {pluck, utils} from '../core/utils';
 import {adaptHandler} from '../core/d3compat';
 import {constants} from '../core/constants';
-import {event} from 'd3-selection';
 
 const LABEL_GAP = 2;
 
@@ -242,7 +241,7 @@ export class Legend {
             .attr('tabindex', 0);
 
         tabElements
-            .on('keydown', d => {
+            .on('keydown', adaptHandler((d, event) => {
                 // trigger only if d is an object
                 if (event.keyCode === 13 && typeof d === 'object') {
                     d.chart.legendToggle(d)
@@ -252,13 +251,13 @@ export class Legend {
                     d.chart.legendToggle(d)
                     event.preventDefault();            
                 }
-            })
-            .on('focus', d => {
+            }))
+            .on('focus', adaptHandler(d => {
                 this._parent.legendHighlight(d);
-            })
-            .on('blur', d => {
+            }))
+            .on('blur', adaptHandler(d => {
                 this._parent.legendReset(d);
-            });
+            }));
     }
 
     render () {

--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -1,6 +1,7 @@
 import {pluck, utils} from '../core/utils';
 import {adaptHandler} from '../core/d3compat';
 import {constants} from '../core/constants';
+import {event} from 'd3-selection';
 
 const LABEL_GAP = 2;
 
@@ -29,6 +30,7 @@ export class Legend {
         this._legendText = pluck('name');
         this._maxItems = undefined;
         this._highlightSelected = false;
+        this._keyboardAccessible = false;
 
         this._g = undefined;
     }
@@ -197,10 +199,66 @@ export class Legend {
         return this;
     }
 
+    /**
+     * If set, individual legend items will be focusable from keyboard and on pressing Enter or Space
+     * will behave as if clicked on.
+     * 
+     * If `svgDescription` on the parent chart has not been explicitly set, will also set the default 
+     * SVG description text to the class constructor name, like BarChart or HeatMap, and make the entire
+     * SVG focusable.
+     * @param {Boolean} [keyboardAccessible=false]
+     * @returns {Boolean|Legend}
+     */
+    keyboardAccessible (keyboardAccessible) {
+        if (!arguments.length) {
+            return this._keyboardAccessible;
+        }
+        this._keyboardAccessible = keyboardAccessible;
+        return this;
+    }
+
     // Implementation methods
 
     _legendItemHeight () {
         return this._gap + this._itemHeight;
+    }
+
+    _makeLegendKeyboardAccessible () {
+
+        if (!this._parent._svgDescription) {
+
+            this._parent.svg().append('desc')
+                .attr('id', `desc-id-${this._parent.__dcFlag__}`)
+                .html(`${this._parent.svgDescription()}`);
+
+            this._parent.svg()
+                .attr('tabindex', '0')
+                .attr('role', 'img')
+                .attr('aria-labelledby', `desc-id-${this._parent.__dcFlag__}`);
+        }
+
+        const tabElements = this._parent.svg()
+            .selectAll('.dc-legend .dc-tabbable')
+            .attr('tabindex', 0);
+
+        tabElements
+            .on('keydown', d => {
+                // trigger only if d is an object
+                if (event.keyCode === 13 && typeof d === 'object') {
+                    d.chart.legendToggle(d)
+                } 
+                // special case for space key press - prevent scrolling
+                if (event.keyCode === 32 && typeof d === 'object') {
+                    d.chart.legendToggle(d)
+                    event.preventDefault();            
+                }
+            })
+            .on('focus', d => {
+                this._parent.legendHighlight(d);
+            })
+            .on('blur', d => {
+                this._parent.legendReset(d);
+            });
     }
 
     render () {
@@ -262,10 +320,15 @@ export class Legend {
 
             itemEnter.append('text')
                 .text(self._legendText)
+                .classed('dc-tabbable', this._keyboardAccessible)
                 .attr('x', self._itemHeight + LABEL_GAP)
                 .attr('y', function () {
                     return self._itemHeight / 2 + (this.clientHeight ? this.clientHeight : 13) / 2 - 2;
                 });
+
+            if (this._keyboardAccessible) {
+                this._makeLegendKeyboardAccessible();
+            }
         }
 
         let cumulativeLegendTextWidth = 0;

--- a/src/charts/line-chart.js
+++ b/src/charts/line-chart.js
@@ -379,6 +379,7 @@ export class LineChart extends StackMixin {
                     .enter()
                     .append('circle')
                     .attr('class', DOT_CIRCLE_CLASS)
+                    .classed('dc-tabbable', this._keyboardAccessible)
                     .attr('cx', d => utils.safeNumber(this.x()(d.x)))
                     .attr('cy', d => utils.safeNumber(this.y()(d.y + d.y0)))
                     .attr('r', this._getDotRadius())
@@ -397,6 +398,23 @@ export class LineChart extends StackMixin {
                         chart._hideRefLines(g);
                     })
                     .merge(dots);
+
+                // special case for on-focus for line chart and its dots
+                if (this._keyboardAccessible) {
+
+                    this._svg.selectAll('.dc-tabbable')
+                        .attr('tabindex', 0)
+                        .on('focus', function () {
+                            const dot = select(this);
+                            chart._showDot(dot);
+                            chart._showRefLines(dot, g);
+                        })
+                        .on('blur', function () {
+                            const dot = select(this);
+                            chart._hideDot(dot);
+                            chart._hideRefLines(g);
+                        });
+                }
 
                 dotsEnterModify.call(dot => this._doRenderTitle(dot, data));
 

--- a/src/charts/number-display.js
+++ b/src/charts/number-display.js
@@ -124,6 +124,10 @@ export class NumberDisplay extends BaseMixin {
                 .attr('class', SPAN_CLASS)
                 .classed('dc-tabbable', this._keyboardAccessible)
                 .merge(span);
+
+            if (this._keyboardAccessible) {
+                span.attr('tabindex', '0');
+            }
         }
 
         {               

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -155,7 +155,8 @@ export class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
         return slices
             .enter()
             .append('g')
-            .attr('class', (d, i) => `${this._sliceCssClass} _${i}`);
+            .attr('class', (d, i) => `${this._sliceCssClass} _${i}`)
+            .classed('dc-tabbable', this._keyboardAccessible);
     }
 
     _createSlicePath (slicesEnter, arcs) {
@@ -163,6 +164,10 @@ export class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
             .attr('fill', (d, i) => this._fill(d, i))
             .on('click', adaptHandler(d => this._onClick(d)))
             .attr('d', (d, i) => this._safeArc(d, i, arcs));
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(this._onClick);
+        }
 
         const tranNodes = transition(slicePath, this.transitionDuration(), this.transitionDelay());
         if (tranNodes.attrTween) {

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -192,8 +192,13 @@ export class RowChart extends CapMixin(ColorMixin(MarginMixin)) {
             .attr('height', height)
             .attr('fill', this.getColor)
             .on('click', adaptHandler(d => this._onClick(d)))
+            .classed('dc-tabbable', this._keyboardAccessible)
             .classed('deselected', d => (this.hasFilter()) ? !this._isSelectedRow(d) : false)
             .classed('selected', d => (this.hasFilter()) ? this._isSelectedRow(d) : false);
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(adaptHandler(d => this._onClick(d)));
+        }
 
         transition(rect, this.transitionDuration(), this.transitionDelay())
             .attr('width', d => Math.abs(this._rootValue() - this._x(this.cappedValueAccessor(d))))

--- a/src/charts/sunburst-chart.js
+++ b/src/charts/sunburst-chart.js
@@ -173,7 +173,12 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
         const slicePath = slicesEnter.append('path')
             .attr('fill', (d, i) => this._fill(d, i))
             .on('click', adaptHandler(d => this.onClick(d)))
+            .classed('dc-tabbable', this._keyboardAccessible)
             .attr('d', d => this._safeArc(arcs, d));
+
+        if (this._keyboardAccessible) {
+            this._makeKeyboardAccessible(adaptHandler(d => this.onClick(d)));
+        }
 
         const tranNodes = transition(slicePath, this.transitionDuration());
         if (tranNodes.attrTween) {
@@ -608,7 +613,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
         const path = d.path || d.key;
         const filter = filters.HierarchyFilter(path);
 
-        // filters are equal to, parents or children of the path.
+        // filters are equal to parents or children of the path.
         const filtersList = this._filtersForPath(path);
         let exactMatch = false;
         // clear out any filters that cover the path filtered.

--- a/src/charts/sunburst-chart.js
+++ b/src/charts/sunburst-chart.js
@@ -177,7 +177,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
             .attr('d', d => this._safeArc(arcs, d));
 
         if (this._keyboardAccessible) {
-            this._makeKeyboardAccessible(adaptHandler(d => this.onClick(d)));
+            this._makeKeyboardAccessible(this.onClick);
         }
 
         const tranNodes = transition(slicePath, this.transitionDuration());

--- a/style/dc.scss
+++ b/style/dc.scss
@@ -50,7 +50,10 @@ $font_sans_serif: sans-serif;
         &.external {
             fill: $color_black;
         }
-        :hover,:focus &.highlight {
+        &:focus {
+            fill-opacity: .8;
+        }
+        :hover &.highlight {
             fill-opacity: .8;
         }
     }

--- a/style/dc.scss
+++ b/style/dc.scss
@@ -34,7 +34,7 @@ $font_sans_serif: sans-serif;
         &.bar {
             stroke: none;
             cursor: pointer;
-            &:hover {
+            &:hover,&:focus {
                 fill-opacity: .5;
             }
         }
@@ -50,7 +50,7 @@ $font_sans_serif: sans-serif;
         &.external {
             fill: $color_black;
         }
-        :hover, &.highlight {
+        :hover,:focus &.highlight {
             fill-opacity: .8;
         }
     }
@@ -123,7 +123,7 @@ $font_sans_serif: sans-serif;
     g {
         &.state {
             cursor: pointer;
-            :hover {
+            :hover,:focus {
                 fill-opacity: .8;
             }
             path {
@@ -142,7 +142,7 @@ $font_sans_serif: sans-serif;
             rect {
                 fill-opacity: 0.8;
                 cursor: pointer;
-                &:hover {
+                &:hover,&:focus {
                     fill-opacity: 0.6;
                 }
             }
@@ -173,7 +173,7 @@ $font_sans_serif: sans-serif;
     .node {
         font-size: 0.7em;
         cursor: pointer;
-        :hover {
+        :hover,:focus {
             fill-opacity: .8;
         }
     }

--- a/web-src/examples/filtering.html
+++ b/web-src/examples/filtering.html
@@ -64,12 +64,14 @@ var ndx = crossfilter(spendData),
 yearRingChart
     .dimension(yearDim)
     .group(spendPerYear)
+    .keyboardAccessible(true)
     .innerRadius(50)
     .controlsUseVisibility(true);
 
   spendHistChart
     .dimension(spendDim)
     .group(spendHist)
+    .svgDescription("Histogram")
     .x(d3.scaleLinear().domain([0,10]))
     .elasticY(true)
     .controlsUseVisibility(true);
@@ -80,6 +82,7 @@ spendHistChart.yAxis().ticks(2);
 spenderRowChart
     .dimension(nameDim)
     .group(spendPerName)
+    .keyboardAccessible(true)
     .elasticX(true)
     .controlsUseVisibility(true);
 

--- a/web-src/examples/filtering.html
+++ b/web-src/examples/filtering.html
@@ -11,6 +11,7 @@
 
 <div class="container">
 <script type="text/javascript" src="header.js"></script>
+  <p>This page demonstrates filtering and accessibility features. Charts can be labelled for screen readers using <code>svgDescription()</code> method and internal chart elements, like bars in a bar chart, can be made interactive as if clicked on by setting the <code>keyboardAccessible()</code> method to <code>true</code></p>
   <div id="chart-ring-year" style="width:300px; height:300px">
     <div class="reset" style="visibility: hidden;">selected: <span class="filter"></span>
       <a href="javascript:yearRingChart.filterAll();dc.redrawAll();">reset</a>
@@ -72,7 +73,9 @@ yearRingChart
     .dimension(spendDim)
     .group(spendHist)
     .svgDescription("Histogram")
-    .x(d3.scaleLinear().domain([0,10]))
+    .keyboardAccessible(true)
+    .x(d3.scaleBand().domain(d3.range(10)))
+    .xUnits(dc.units.ordinal)
     .elasticY(true)
     .controlsUseVisibility(true);
 


### PR DESCRIPTION
Currently, to add accessibility features to dc.js charts you need to do it as part of post-processing. It would be easier to simply specify what features you'd like to include together with other chart attributes, like width and height and labels. This idea has been brought up before (#1185) and after raising it again on the mailing list recently, @gordonwoodhull encouraged me to try to implement something.

I'm thinking of a series of commits / PRs to cover the basics:

- This one makes all SVG charts accessible by keyboard using tabindex. It also adds a description that screen readers can access. The configuration of a `<desc>` element and `aria-labelledby` attribute seems to have the best support according to [this](https://www.deque.com/blog/creating-accessible-svgs/). I tried adding `<title>`, but it fails a few tests looking at tooltips and besides, some screen readers will read it twice. It defaults to an empty string and ideally, I'd like it to reflect the default chart type - so a `dc.PieChart` will have "pie chart" in the description and so on. This will likely require modifying each chart file with some default attribute, however. Users can add a description for their charts by simply passing a string to `.svgDescription()`.

- Make internal chart elements, like `<circle>` in a bubble chart or `rect` in a bar chart keyboard-selectable. Also, make them "clickable" from keyboard.

- When I tested tooltips created using `<title>` in Narrator / NVDA, I got mixed results for a variety of browsers. In some, the tooltip text was read out, on others it wasn't. There is probably a way to make it a little bit more consistent.

- Optionally designating the `NumberDisplay` widget as `aria-live` [region](https://developer.paciellogroup.com/blog/2014/03/screen-reader-support-aria-live-regions/), meaning changes to it will be read out by screen readers.

Here's the summary of this PR as it currently stands:

- [x] root SVG can get focus and users can add custom description using `svgDescription` method

- [x] internal chart elements can get focus and filtering interactions will trigger on `Enter` or `Space` as if clicked

- [x] CSS will behave on focus in the same way as it behaves on hover

- [x] Individual chart types are accessible  

  - [x] Bar chart
  - [x] Box plot
  - [x] Bubble chart
    - [x] DOM order of bubbles can be changed based on x value
  - [x] Choropleth
  - [x] Heatmap
  - [x] Line chart
  - [x] Pie chart
  - [x] Row chart
  - [x] Scatter plot
    - [x] DOM order of bubbles can be changed based on x value
  - [x] Sunburst chart
 <html><br></html>

- [x] NumberDisplay can optionally be set as `aria-live` region

- [x] Legends can get focus and interactivity

- [x] Add example


