### PR TITLE
Experiment with Prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "singleQuote": true,
+  "tabWidth": 4
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -406,6 +406,12 @@ module.exports = function (grunt) {
             },
             tsc: {
                 command: 'tsc'
+            },
+            'prettier-check': {
+                command: 'prettier --check src'
+            },
+            prettier: {
+                command: 'prettier --write src'
             }
         }
     });
@@ -451,8 +457,8 @@ module.exports = function (grunt) {
     grunt.registerTask('coverage', ['build', 'copy', 'karma:coverage']);
     grunt.registerTask('ci', ['ci-pull', 'safe-sauce-labs']);
     grunt.registerTask('ci-pull', ['build', 'copy', 'karma:ci']);
-    grunt.registerTask('lint', ['shell:tslint', 'shell:eslint']);
-    grunt.registerTask('lint-fix', ['shell:tslint-fix', 'shell:eslint-fix']);
+    grunt.registerTask('lint', ['shell:tslint', 'shell:eslint', 'shell:prettier-check']);
+    grunt.registerTask('lint-fix', ['shell:tslint-fix', 'shell:eslint-fix', 'shell:prettier']);
     grunt.registerTask('default', ['build', 'shell:hooks']);
     grunt.registerTask('doc-debug', ['build', 'jsdoc', 'jsdoc2md', 'watch:jsdoc2md']);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9665,6 +9665,12 @@
         }
       }
     },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7490,6 +7490,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-license": "^2.0.0",
     "rollup-plugin-terser": "^5.3.0",
-    "time-grunt": "~1.4"
+    "time-grunt": "~1.4",
+    "tslint-config-prettier": "^1.18.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "karma-summary-reporter": "^1.7.2",
     "load-grunt-tasks": "~4",
     "node-sass": "^4.13.1",
+    "prettier": "2.0.5",
     "reductio": "0.6.x",
     "regression": "^2.0.1",
     "rollup": "^1.32.1",

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,8 @@
 {
   "defaultSeverity": "error",
   "extends": [
-    "tslint:recommended"
+    "tslint:recommended",
+    "tslint-config-prettier"
   ],
   "jsdoc-format": false,
   "jsRules": {},
@@ -17,11 +18,6 @@
     "object-literal-sort-keys": false,
     "only-arrow-functions": false, // TODO: switch and manual fix
     "prefer-for-of": false,
-    "quotemark": [
-      true,
-      "single"
-    ],
-    "space-before-function-paren": [true, "always"],
     "trailing-comma": false,
     "variable-name": [
       true,


### PR DESCRIPTION
I have been trying to use `tslint` to help maintain consistent code formatting. However, after going through all options, it still leaves formatting inconsistencies.

We have started using Prettier (https://prettier.io/) in some of our projects. On new projects, it seems quite natural. I wanted to experiment and see how does it look on this codebase.

The default settings cause too many changes. As a philosophy, Prettier supports very few options. I found the following goes inline with current code conventions:

```JSON
{
  "arrowParens": "avoid",
  "printWidth": 100,
  "singleQuote": true,
  "tabWidth": 4
}
```

It does bring consistent formatting. One departure from current code conventions (no space before `()` in function declarations):

```typescript
 public calculateRadiusDomain (): void {
```
to
```typescript
 public calculateRadiusDomain(): void {
```

I have put two commits here, first one is the setup and the second has some sample conversions. I will also add some comments against specific code lines to highlight some issues.

If we decide to go this route we can pass our tests and samples as well.
