### PR TITLE
Refactoring colors

### DIFF
--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -80,15 +80,12 @@ export function ColorMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
          * @returns {ColorMixin}
          */
         public calculateColorDomain(): this {
-            // TODO: use extent from d3-array which does exactly this
-            const newDomain = [
-                min(this.data(), this._conf.colorAccessor),
-                max(this.data(), this._conf.colorAccessor),
-            ];
+            const scale: MinimalColorScale = (this._colorHelper as ColorScaleHelper)
+                .scale as MinimalColorScale;
 
-            // @ts-ignore
-            const scale: MinimalColorScale = (this._colorHelper as ColorScaleHelper).scale;
-            scale && scale.domain && scale.domain(newDomain);
+            if (scale && scale.domain) {
+                scale.domain(extent(this.data(), this._conf.colorAccessor));
+            }
 
             return this;
         }

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -1,71 +1,14 @@
-import { scaleLinear, scaleOrdinal, scaleQuantize } from 'd3-scale';
-import { interpolateHcl } from 'd3-interpolate';
-import { max, min } from 'd3-array';
+import { scaleQuantize } from 'd3-scale';
+import { extent } from 'd3-array';
 
 import { config } from '../core/config';
 import { BaseMixin } from './base-mixin';
 import { BaseAccessor, Constructor, MinimalColorScale } from '../core/types';
 import { IColorMixinConf } from './i-color-mixin-conf';
-
-export interface IColorHelper {
-    getColor(d, i?: number): string;
-    colorAccessor: BaseAccessor<string>;
-}
-
-export class ColorCalculator implements IColorHelper {
-    public colorAccessor: BaseAccessor<string>;
-    public getColor: BaseAccessor<string>;
-
-    constructor(colorCalculator: BaseAccessor<string>) {
-        this.getColor = colorCalculator;
-    }
-}
-
-export class ColorScaleHelper implements IColorHelper {
-    public colorAccessor: BaseAccessor<string>;
-    public scale: BaseAccessor<string>;
-
-    constructor({
-        scale,
-        colorAccessor,
-    }: {
-        scale: BaseAccessor<string>;
-        colorAccessor?: BaseAccessor<string>;
-    }) {
-        this.colorAccessor = colorAccessor;
-        this.scale = scale;
-    }
-
-    getColor(d, i?: number): string {
-        return this.scale(this.colorAccessor(d, i));
-    }
-}
-
-export class OrdinalColors extends ColorScaleHelper {
-    constructor({
-        colors,
-        colorAccessor,
-    }: {
-        colors: string[];
-        colorAccessor?: BaseAccessor<string>;
-    }) {
-        const scale = scaleOrdinal<any, string>().range(colors);
-        super({ scale, colorAccessor });
-    }
-}
-
-export class LinearColors extends ColorScaleHelper {
-    constructor({
-        range,
-        colorAccessor,
-    }: {
-        range: [string, string];
-        colorAccessor?: BaseAccessor<string>;
-    }) {
-        const scale = scaleLinear<any, string>().range(range).interpolate(interpolateHcl);
-        super({ scale, colorAccessor });
-    }
-}
+import { IColorHelper } from './colors/i-color-helper';
+import { ColorScaleHelper } from './colors/color-scale-helper';
+import { OrdinalColors } from './colors/ordinal-colors';
+import { LinearColors } from './colors/linear-colors';
 
 /**
  * The Color Mixin is an abstract chart functional class providing universal coloring support

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -1,14 +1,12 @@
-import { scaleQuantize } from 'd3-scale';
 import { extent } from 'd3-array';
 
 import { config } from '../core/config';
 import { BaseMixin } from './base-mixin';
-import { BaseAccessor, Constructor, MinimalColorScale } from '../core/types';
+import { Constructor, MinimalColorScale } from '../core/types';
 import { IColorMixinConf } from './i-color-mixin-conf';
 import { IColorHelper } from './colors/i-color-helper';
 import { ColorScaleHelper } from './colors/color-scale-helper';
 import { OrdinalColors } from './colors/ordinal-colors';
-import { LinearColors } from './colors/linear-colors';
 
 /**
  * The Color Mixin is an abstract chart functional class providing universal coloring support
@@ -87,98 +85,6 @@ export function ColorMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
                 scale.domain(extent(this.data(), this._conf.colorAccessor));
             }
 
-            return this;
-        }
-
-        /**
-         * Retrieve current color scale or set a new color scale. This methods accepts any function that
-         * operates like a d3 scale.
-         * @memberof ColorMixin
-         * @instance
-         * @see {@link https://github.com/d3/d3-scale/blob/master/README.md d3.scale}
-         * @example
-         * // alternate categorical scale
-         * chart.colors(d3.scale.category20b());
-         * // ordinal scale
-         * chart.colors(d3.scaleOrdinal().range(['red','green','blue']));
-         * // convenience method, the same as above
-         * chart.ordinalColors(['red','green','blue']);
-         * // set a linear scale
-         * chart.linearColors(["#4575b4", "#ffffbf", "#a50026"]);
-         * @param {d3.scale} [colorScale=d3.scaleOrdinal(d3.schemeCategory20c)]
-         * @returns {d3.scale|ColorMixin}
-         */
-        public colors(): BaseAccessor<string>;
-        public colors(colorScale: BaseAccessor<string>): this;
-        public colors(colorScale?) {
-            if (!arguments.length) {
-                return (this._colorHelper as ColorScaleHelper).scale;
-            }
-            let newScale;
-            if (colorScale instanceof Array) {
-                newScale = scaleQuantize<string>().range(colorScale); // deprecated legacy support, note: this fails for ordinal domains
-            } else {
-                newScale = typeof colorScale === 'function' ? colorScale : () => colorScale;
-            }
-
-            this._colorHelper = new ColorScaleHelper({
-                scale: newScale,
-                colorAccessor: this._conf.colorAccessor,
-            });
-            return this;
-        }
-
-        /**
-         * Convenience method to set the color scale to
-         * {@link https://github.com/d3/d3-scale/blob/master/README.md#ordinal-scales d3.scaleOrdinal} with
-         * range `r`.
-         * @memberof ColorMixin
-         * @instance
-         * @param {Array<String>} r
-         * @returns {ColorMixin}
-         */
-        public ordinalColors(r: string[]): this {
-            this._colorHelper = new OrdinalColors({
-                colors: r,
-                colorAccessor: this._conf.colorAccessor,
-            });
-            return this;
-        }
-
-        /**
-         * Convenience method to set the color scale to an Hcl interpolated linear scale with range `r`.
-         * @memberof ColorMixin
-         * @instance
-         * @param {Array<Number>} r
-         * @returns {ColorMixin}
-         */
-        public linearColors(r: [string, string]): this {
-            this._colorHelper = new LinearColors({
-                range: r,
-                colorAccessor: this._conf.colorAccessor,
-            });
-            return this;
-        }
-
-        /**
-         * Set or get the current domain for the color mapping function. The domain must be supplied as an
-         * array.
-         *
-         * Note: previously this method accepted a callback function. Instead you may use a custom scale
-         * set by {@link ColorMixin#colors .colors}.
-         * @memberof ColorMixin
-         * @instance
-         * @param {Array<String>} [domain]
-         * @returns {Array<String>|ColorMixin}
-         */
-        public colorDomain(): string[];
-        public colorDomain(domain: string[]): this;
-        public colorDomain(domain?) {
-            const scale = (this._colorHelper as ColorScaleHelper).scale as MinimalColorScale;
-            if (!arguments.length) {
-                return scale.domain();
-            }
-            scale.domain(domain);
             return this;
         }
     };

--- a/src/base/colors/color-calculator.ts
+++ b/src/base/colors/color-calculator.ts
@@ -8,4 +8,8 @@ export class ColorCalculator implements IColorHelper {
     constructor(colorCalculator: BaseAccessor<string>) {
         this.getColor = colorCalculator;
     }
+
+    public share(colorAccessor: BaseAccessor<string>): IColorHelper {
+        return this;
+    }
 }

--- a/src/base/colors/color-calculator.ts
+++ b/src/base/colors/color-calculator.ts
@@ -1,0 +1,11 @@
+import { IColorHelper } from './i-color-helper';
+import { BaseAccessor } from '../../core/types';
+
+export class ColorCalculator implements IColorHelper {
+    public colorAccessor: BaseAccessor<string>;
+    public getColor: BaseAccessor<string>;
+
+    constructor(colorCalculator: BaseAccessor<string>) {
+        this.getColor = colorCalculator;
+    }
+}

--- a/src/base/colors/color-scale-helper.ts
+++ b/src/base/colors/color-scale-helper.ts
@@ -19,4 +19,8 @@ export class ColorScaleHelper implements IColorHelper {
     getColor(d, i?: number): string {
         return this.scale(this.colorAccessor(d, i));
     }
+
+    share(colorAccessor: BaseAccessor<string>): IColorHelper {
+        return new ColorScaleHelper({ scale: this.scale, colorAccessor });
+    }
 }

--- a/src/base/colors/color-scale-helper.ts
+++ b/src/base/colors/color-scale-helper.ts
@@ -1,0 +1,22 @@
+import { IColorHelper } from './i-color-helper';
+import { BaseAccessor } from '../../core/types';
+
+export class ColorScaleHelper implements IColorHelper {
+    public colorAccessor: BaseAccessor<string>;
+    public scale: BaseAccessor<string>;
+
+    constructor({
+        scale,
+        colorAccessor,
+    }: {
+        scale: BaseAccessor<string>;
+        colorAccessor?: BaseAccessor<string>;
+    }) {
+        this.colorAccessor = colorAccessor;
+        this.scale = scale;
+    }
+
+    getColor(d, i?: number): string {
+        return this.scale(this.colorAccessor(d, i));
+    }
+}

--- a/src/base/colors/i-color-helper.ts
+++ b/src/base/colors/i-color-helper.ts
@@ -3,4 +3,5 @@ import { BaseAccessor } from '../../core/types';
 export interface IColorHelper {
     getColor(d, i?: number): string;
     colorAccessor: BaseAccessor<string>;
+    share(colorAccessor: BaseAccessor<string>): IColorHelper;
 }

--- a/src/base/colors/i-color-helper.ts
+++ b/src/base/colors/i-color-helper.ts
@@ -1,0 +1,6 @@
+import { BaseAccessor } from '../../core/types';
+
+export interface IColorHelper {
+    getColor(d, i?: number): string;
+    colorAccessor: BaseAccessor<string>;
+}

--- a/src/base/colors/linear-colors.ts
+++ b/src/base/colors/linear-colors.ts
@@ -1,0 +1,17 @@
+import { ColorScaleHelper } from './color-scale-helper';
+import { BaseAccessor } from '../../core/types';
+import { scaleLinear } from 'd3-scale';
+import { interpolateHcl } from 'd3-interpolate';
+
+export class LinearColors extends ColorScaleHelper {
+    constructor({
+        range,
+        colorAccessor,
+    }: {
+        range: [string, string];
+        colorAccessor?: BaseAccessor<string>;
+    }) {
+        const scale = scaleLinear<any, string>().range(range).interpolate(interpolateHcl);
+        super({ scale, colorAccessor });
+    }
+}

--- a/src/base/colors/ordinal-colors.ts
+++ b/src/base/colors/ordinal-colors.ts
@@ -1,0 +1,16 @@
+import { ColorScaleHelper } from './color-scale-helper';
+import { BaseAccessor } from '../../core/types';
+import { scaleOrdinal } from 'd3-scale';
+
+export class OrdinalColors extends ColorScaleHelper {
+    constructor({
+        colors,
+        colorAccessor,
+    }: {
+        colors: string[];
+        colorAccessor?: BaseAccessor<string>;
+    }) {
+        const scale = scaleOrdinal<any, string>().range(colors);
+        super({ scale, colorAccessor });
+    }
+}

--- a/src/base/colors/ordinal-colors.ts
+++ b/src/base/colors/ordinal-colors.ts
@@ -7,7 +7,7 @@ export class OrdinalColors extends ColorScaleHelper {
         colors,
         colorAccessor,
     }: {
-        colors: string[];
+        colors: readonly string[];
         colorAccessor?: BaseAccessor<string>;
     }) {
         const scale = scaleOrdinal<any, string>().range(colors);

--- a/src/base/coordinate-grid-mixin.ts
+++ b/src/base/coordinate-grid-mixin.ts
@@ -1,7 +1,7 @@
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { timeDay } from 'd3-time';
 import { max, min } from 'd3-array';
-import { scaleBand, scaleLinear, scaleOrdinal } from 'd3-scale';
+import { scaleBand, scaleLinear } from 'd3-scale';
 import { Axis, axisBottom, axisLeft, axisRight } from 'd3-axis';
 import { zoom, ZoomBehavior, zoomIdentity, ZoomTransform } from 'd3-zoom';
 import { BrushBehavior, brushX } from 'd3-brush';
@@ -18,6 +18,7 @@ import { filters } from '../core/filters';
 import { events } from '../core/events';
 import { DCBrushSelection, MinimalXYScale, SVGGElementSelection } from '../core/types';
 import { ICoordinateGridMixinConf } from './i-coordinate-grid-mixin-conf';
+import { OrdinalColors } from './colors/ordinal-colors';
 import { adaptHandler } from '../core/d3compat';
 
 const GRID_LINE_CLASS = 'grid-line';
@@ -71,7 +72,9 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
     constructor() {
         super();
 
-        this.colors(scaleOrdinal(schemeCategory10));
+        this.colorHelper(
+            new OrdinalColors({ colors: schemeCategory10, colorAccessor: this._conf.colorAccessor })
+        );
         this._mandatoryAttributes().push('x');
         this._parent = undefined;
         this._g = undefined;

--- a/src/base/i-color-mixin-conf.ts
+++ b/src/base/i-color-mixin-conf.ts
@@ -3,5 +3,4 @@ import { BaseAccessor, ColorAccessor } from '../core/types';
 
 export interface IColorMixinConf extends IBaseMixinConf {
     readonly colorAccessor?: ColorAccessor;
-    readonly colorCalculator?: BaseAccessor<string>;
 }

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -284,7 +284,7 @@ export class CompositeChart extends CoordinateGridMixin {
             }
 
             if (this._conf.shareColors) {
-                child.colors(this.colors());
+                child.colorHelper(this.colorHelper().share(child.conf().colorAccessor));
             }
 
             child.x(this.x());
@@ -555,7 +555,7 @@ export class CompositeChart extends CoordinateGridMixin {
     public legendables() {
         return this._children.reduce((items, child) => {
             if (this._conf.shareColors) {
-                child.colors(this.colors());
+                child.colorHelper(this.colorHelper().share(child.conf().colorAccessor));
             }
             items.push.apply(items, child.legendables());
             return items;

--- a/src/compat/base/color-mixin.ts
+++ b/src/compat/base/color-mixin.ts
@@ -1,7 +1,8 @@
 import { ColorAccessor, Constructor } from '../../core/types';
 import { BaseMixinExt } from './base-mixin';
-import { ColorCalculator, ColorMixin as ColorMixinNeo } from '../../base/color-mixin';
+import { ColorMixin as ColorMixinNeo } from '../../base/color-mixin';
 import { BaseMixin as BaseMixinNeo } from '../../base/base-mixin';
+import { ColorCalculator } from '../../base/colors/color-calculator';
 
 class Intermediate extends BaseMixinExt(ColorMixinNeo(BaseMixinNeo)) {}
 

--- a/src/compat/base/color-mixin.ts
+++ b/src/compat/base/color-mixin.ts
@@ -1,8 +1,12 @@
-import { ColorAccessor, Constructor } from '../../core/types';
+import { BaseAccessor, ColorAccessor, Constructor, MinimalColorScale } from '../../core/types';
 import { BaseMixinExt } from './base-mixin';
 import { ColorMixin as ColorMixinNeo } from '../../base/color-mixin';
 import { BaseMixin as BaseMixinNeo } from '../../base/base-mixin';
 import { ColorCalculator } from '../../base/colors/color-calculator';
+import { ColorScaleHelper } from '../../base/colors/color-scale-helper';
+import { scaleQuantize } from 'd3-scale';
+import { OrdinalColors } from '../../base/colors/ordinal-colors';
+import { LinearColors } from '../../base/colors/linear-colors';
 
 class Intermediate extends BaseMixinExt(ColorMixinNeo(BaseMixinNeo)) {}
 
@@ -56,6 +60,104 @@ export function ColorMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
                 return this.colorHelper().getColor;
             }
             this.colorHelper(new ColorCalculator(colorCalculator));
+            return this;
+        }
+
+        /**
+         * Retrieve current color scale or set a new color scale. This methods accepts any function that
+         * operates like a d3 scale.
+         * @memberof ColorMixin
+         * @instance
+         * @see {@link https://github.com/d3/d3-scale/blob/master/README.md d3.scale}
+         * @example
+         * // alternate categorical scale
+         * chart.colors(d3.scale.category20b());
+         * // ordinal scale
+         * chart.colors(d3.scaleOrdinal().range(['red','green','blue']));
+         * // convenience method, the same as above
+         * chart.ordinalColors(['red','green','blue']);
+         * // set a linear scale
+         * chart.linearColors(["#4575b4", "#ffffbf", "#a50026"]);
+         * @param {d3.scale} [colorScale=d3.scaleOrdinal(d3.schemeCategory20c)]
+         * @returns {d3.scale|ColorMixin}
+         */
+        public colors(): BaseAccessor<string>;
+        public colors(colorScale: BaseAccessor<string>): this;
+        public colors(colorScale?) {
+            if (!arguments.length) {
+                return (this.colorHelper() as ColorScaleHelper).scale;
+            }
+            let newScale;
+            if (colorScale instanceof Array) {
+                newScale = scaleQuantize<string>().range(colorScale); // deprecated legacy support, note: this fails for ordinal domains
+            } else {
+                newScale = typeof colorScale === 'function' ? colorScale : () => colorScale;
+            }
+
+            this.colorHelper(
+                new ColorScaleHelper({
+                    scale: newScale,
+                    colorAccessor: this._conf.colorAccessor,
+                })
+            );
+            return this;
+        }
+
+        /**
+         * Convenience method to set the color scale to
+         * {@link https://github.com/d3/d3-scale/blob/master/README.md#ordinal-scales d3.scaleOrdinal} with
+         * range `r`.
+         * @memberof ColorMixin
+         * @instance
+         * @param {Array<String>} r
+         * @returns {ColorMixin}
+         */
+        public ordinalColors(r: string[]): this {
+            this.colorHelper(
+                new OrdinalColors({
+                    colors: r,
+                    colorAccessor: this._conf.colorAccessor,
+                })
+            );
+            return this;
+        }
+
+        /**
+         * Convenience method to set the color scale to an Hcl interpolated linear scale with range `r`.
+         * @memberof ColorMixin
+         * @instance
+         * @param {Array<Number>} r
+         * @returns {ColorMixin}
+         */
+        public linearColors(r: [string, string]): this {
+            this.colorHelper(
+                new LinearColors({
+                    range: r,
+                    colorAccessor: this._conf.colorAccessor,
+                })
+            );
+            return this;
+        }
+
+        /**
+         * Set or get the current domain for the color mapping function. The domain must be supplied as an
+         * array.
+         *
+         * Note: previously this method accepted a callback function. Instead you may use a custom scale
+         * set by {@link ColorMixin#colors .colors}.
+         * @memberof ColorMixin
+         * @instance
+         * @param {Array<String>} [domain]
+         * @returns {Array<String>|ColorMixin}
+         */
+        public colorDomain(): string[];
+        public colorDomain(domain: string[]): this;
+        public colorDomain(domain?) {
+            const scale = (this.colorHelper() as ColorScaleHelper).scale as MinimalColorScale;
+            if (!arguments.length) {
+                return scale.domain();
+            }
+            scale.domain(domain);
             return this;
         }
     };

--- a/src/compat/base/color-mixin.ts
+++ b/src/compat/base/color-mixin.ts
@@ -1,6 +1,6 @@
 import { ColorAccessor, Constructor } from '../../core/types';
 import { BaseMixinExt } from './base-mixin';
-import { ColorMixin as ColorMixinNeo } from '../../base/color-mixin';
+import { ColorCalculator, ColorMixin as ColorMixinNeo } from '../../base/color-mixin';
 import { BaseMixin as BaseMixinNeo } from '../../base/base-mixin';
 
 class Intermediate extends BaseMixinExt(ColorMixinNeo(BaseMixinNeo)) {}
@@ -52,9 +52,9 @@ export function ColorMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
         public colorCalculator(colorCalculator: ColorAccessor): this;
         public colorCalculator(colorCalculator?) {
             if (!arguments.length) {
-                return this._conf.colorCalculator || this.getColor;
+                return this.colorHelper().getColor;
             }
-            this.configure({ colorCalculator: colorCalculator });
+            this.colorHelper(new ColorCalculator(colorCalculator));
             return this;
         }
     };


### PR DESCRIPTION
Colors in dc have always stumped me. I wanted to disambiguate both the API and the documentation. This is an attempt in this direction.

I have figured out the following so far:

- Ordinal colors work with an ordinal type of usage. In this case, setting a domain is not required, setting a domain may actually be counterproductive.
- Linear Scales will work well where interpolation is needed. In all likelihood, the domain needs to be explicitly set (as the default is [0,1]) for it to work.
- The backward compatibility mode creates a `scaleQuantize` when an array is passed. This also needs a domain to be explicitly specified.
- LinearScales need the same number of points in domain and range (otherwise it discards), so, in case of dc, these are likely to be used with two values.
- `scaleQuantize` supports any number of points in range, however, they do not support additional interpolation.
- Apart from these, there is mode `colorCalculator` which bypasses the `colorAccessor`. (there are no test cases to cover this).
- In some cases, like bar charts, the color may actually come from the CSS.

I can see that all of the above have possible use cases. I am making an attempt to restructure the API to clearly indicate that these modes are different with different semantics and use cases.

This is WIP.