### PR TITLE
Update crossfilter repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Install without npm
 --------------------
 Download
 * [d3.js](https://github.com/mbostock/d3)
-* [crossfilter.js](https://github.com/square/crossfilter)
+* [crossfilter.js](https://github.com/crossfilter/crossfilter)
 * [dc.js - stable](https://github.com/dc-js/dc.js/releases)
 * [dc.js - bleeding edge (develop)](https://github.com/dc-js/dc.js)
 


### PR DESCRIPTION
The repo is crossfilter/crossfilter since 2015
See https://github.com/square/crossfilter/commit/0227e0e443d6426b35a3ccf4839c4456a98c6e0d