### PR TITLE
Mixins take3

### DIFF
--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -5,10 +5,9 @@ import { ColorMixin } from './color-mixin';
 import { transition } from '../core/core';
 import { events } from '../core/events';
 import { Constructor, MinimalRadiusScale, SVGGElementSelection } from '../core/types';
-import { BaseMixin } from './base-mixin';
 import { IBubbleMixinConf } from './i-bubble-mixin-conf';
 import { adaptHandler } from '../core/d3compat';
-import { IBaseMixinConf } from "./i-base-mixin-conf";
+import { IBaseMixinConf } from './i-base-mixin-conf';
 
 interface MinimalBase {
     configure(conf: IBaseMixinConf);

--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -8,6 +8,21 @@ import { Constructor, MinimalRadiusScale, SVGGElementSelection } from '../core/t
 import { BaseMixin } from './base-mixin';
 import { IBubbleMixinConf } from './i-bubble-mixin-conf';
 import { adaptHandler } from '../core/d3compat';
+import { IBaseMixinConf } from "./i-base-mixin-conf";
+
+interface MinimalBase {
+    configure(conf: IBaseMixinConf);
+    data();
+    data(callback): this;
+    redrawGroup();
+    title();
+    filter(filter: any);
+    selectAll(arg0: string);
+    hasFilter(f?);
+    highlightSelected(e): void;
+    fadeDeselected(e): void;
+    resetHighlight(e): void;
+}
 
 /**
  * This Mixin provides reusable functionalities for any chart that needs to visualize data using bubbles.
@@ -17,7 +32,7 @@ import { adaptHandler } from '../core/d3compat';
  * @returns {BubbleMixin}
  */
 // tslint:disable-next-line:variable-name
-export function BubbleMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
+export function BubbleMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
         protected _conf: IBubbleMixinConf;

--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -35,12 +35,12 @@ interface MinimalBase {
 export function BubbleMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
-        protected _conf: IBubbleMixinConf;
+        public _conf: IBubbleMixinConf;
 
-        protected BUBBLE_NODE_CLASS: string;
-        protected BUBBLE_CLASS: string;
-        protected MIN_RADIUS: number;
-        private _r: MinimalRadiusScale;
+        public BUBBLE_NODE_CLASS: string;
+        public BUBBLE_CLASS: string;
+        public MIN_RADIUS: number;
+        public _r: MinimalRadiusScale;
 
         constructor(...args: any[]) {
             super();

--- a/src/base/cap-mixin.ts
+++ b/src/base/cap-mixin.ts
@@ -30,7 +30,7 @@ interface MinimalBase {
 export function CapMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
-        protected _conf: ICapMixinConf;
+        public _conf: ICapMixinConf;
 
         constructor(...args: any[]) {
             super();

--- a/src/base/cap-mixin.ts
+++ b/src/base/cap-mixin.ts
@@ -1,8 +1,7 @@
 import { sum } from 'd3-array';
 import { Constructor } from '../core/types';
-import { BaseMixin } from './base-mixin';
 import { ICapMixinConf } from './i-cap-mixin-conf';
-import { IBaseMixinConf } from "./i-base-mixin-conf";
+import { IBaseMixinConf } from './i-base-mixin-conf';
 
 interface MinimalBase {
     configure(conf: IBaseMixinConf);
@@ -12,7 +11,6 @@ interface MinimalBase {
     onClick(d: any);
     filter(arg0: any[]);
 }
-
 
 /**
  * Cap is a mixin that groups small data elements below a _cap_ into an *others* grouping for both the

--- a/src/base/cap-mixin.ts
+++ b/src/base/cap-mixin.ts
@@ -2,6 +2,17 @@ import { sum } from 'd3-array';
 import { Constructor } from '../core/types';
 import { BaseMixin } from './base-mixin';
 import { ICapMixinConf } from './i-cap-mixin-conf';
+import { IBaseMixinConf } from "./i-base-mixin-conf";
+
+interface MinimalBase {
+    configure(conf: IBaseMixinConf);
+    data();
+    data(callback): this;
+    _computeOrderedGroups(arg0: any);
+    onClick(d: any);
+    filter(arg0: any[]);
+}
+
 
 /**
  * Cap is a mixin that groups small data elements below a _cap_ into an *others* grouping for both the
@@ -16,7 +27,7 @@ import { ICapMixinConf } from './i-cap-mixin-conf';
  * @returns {CapMixin}
  */
 // tslint:disable-next-line:variable-name
-export function CapMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
+export function CapMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
         protected _conf: ICapMixinConf;

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -25,9 +25,9 @@ interface MinimalBase {
 // tslint:disable-next-line:variable-name
 export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     return class extends Base {
-        protected _conf: IColorMixinConf;
+        public _conf: IColorMixinConf;
 
-        private _colorHelper: IColorHelper;
+        public _colorHelper: IColorHelper;
 
         constructor(...args: any[]) {
             super();

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -7,6 +7,13 @@ import { IColorMixinConf } from './i-color-mixin-conf';
 import { IColorHelper } from './colors/i-color-helper';
 import { ColorScaleHelper } from './colors/color-scale-helper';
 import { OrdinalColors } from './colors/ordinal-colors';
+import { IBaseMixinConf } from "./i-base-mixin-conf";
+
+interface MinimalBase {
+    configure(conf: IBaseMixinConf);
+    data();
+    data(callback): this;
+}
 
 /**
  * The Color Mixin is an abstract chart functional class providing universal coloring support
@@ -16,7 +23,7 @@ import { OrdinalColors } from './colors/ordinal-colors';
  * @returns {ColorMixin}
  */
 // tslint:disable-next-line:variable-name
-export function ColorMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
+export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     return class extends Base {
         protected _conf: IColorMixinConf;
 

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -1,13 +1,12 @@
 import { extent } from 'd3-array';
 
 import { config } from '../core/config';
-import { BaseMixin } from './base-mixin';
 import { Constructor, MinimalColorScale } from '../core/types';
 import { IColorMixinConf } from './i-color-mixin-conf';
 import { IColorHelper } from './colors/i-color-helper';
 import { ColorScaleHelper } from './colors/color-scale-helper';
 import { OrdinalColors } from './colors/ordinal-colors';
-import { IBaseMixinConf } from "./i-base-mixin-conf";
+import { IBaseMixinConf } from './i-base-mixin-conf';
 
 interface MinimalBase {
     configure(conf: IBaseMixinConf);

--- a/src/base/coordinate-grid-mixin.ts
+++ b/src/base/coordinate-grid-mixin.ts
@@ -37,7 +37,7 @@ const DEFAULT_AXIS_LABEL_PADDING = 12;
  * @mixes MarginMixin
  */
 export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
-    protected _conf: ICoordinateGridMixinConf;
+    public _conf: ICoordinateGridMixinConf;
 
     private _parent: Selection<SVGElement, any, any, any>;
     private _g: SVGGElementSelection;

--- a/src/base/i-color-mixin-conf.ts
+++ b/src/base/i-color-mixin-conf.ts
@@ -1,5 +1,5 @@
 import { IBaseMixinConf } from './i-base-mixin-conf';
-import { BaseAccessor, ColorAccessor } from '../core/types';
+import { ColorAccessor } from '../core/types';
 
 export interface IColorMixinConf extends IBaseMixinConf {
     readonly colorAccessor?: ColorAccessor;

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -12,7 +12,7 @@ import { IStackMixinConf } from './i-stack-mixin-conf';
  * @mixes CoordinateGridMixin
  */
 export class StackMixin extends CoordinateGridMixin {
-    protected _conf: IStackMixinConf;
+    public _conf: IStackMixinConf;
 
     private _stackLayout: Stack<any, { [p: string]: number }, string>;
     private _stack;

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -27,7 +27,7 @@ const LABEL_PADDING = 3;
  * @mixes StackMixin
  */
 export class BarChart extends StackMixin {
-    protected _conf: IBarChartConf;
+    public _conf: IBarChartConf;
 
     private _gap: number;
     private _barWidth: number;

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -50,7 +50,7 @@ function defaultWhiskersIQR(k: number): (d) => [number, number] {
  * @mixes CoordinateGridMixin
  */
 export class BoxPlot extends CoordinateGridMixin {
-    protected _conf: IBoxPlotConf;
+    public _conf: IBoxPlotConf;
 
     private readonly _whiskers: (d) => [number, number];
     private readonly _box;

--- a/src/charts/bubble-overlay.ts
+++ b/src/charts/bubble-overlay.ts
@@ -26,7 +26,7 @@ const BUBBLE_CLASS = 'bubble';
  * @mixes BaseMixin
  */
 export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
-    protected _conf: IBubbleOverlayConf;
+    public _conf: IBubbleOverlayConf;
 
     private _g: Selection<SVGGElement, any, any, any>;
 

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -23,7 +23,7 @@ const DEFAULT_RIGHT_Y_AXIS_LABEL_PADDING = 12;
  * @mixes CoordinateGridMixin
  */
 export class CompositeChart extends CoordinateGridMixin {
-    protected _conf: ICompositeChartConf;
+    public _conf: ICompositeChartConf;
 
     private _children: CoordinateGridMixin[];
     private _childOptions; // TODO: it is conf for children, revisit after creating concept of conf

--- a/src/charts/geo-choropleth-chart.ts
+++ b/src/charts/geo-choropleth-chart.ts
@@ -22,7 +22,7 @@ import { adaptHandler } from '../core/d3compat';
  * @mixes BaseMixin
  */
 export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
-    protected _conf: IGeoChoroplethChartConf;
+    public _conf: IGeoChoroplethChartConf;
 
     private _geoPath: GeoPath;
     private _projectionFlag: boolean;

--- a/src/charts/heat-map.ts
+++ b/src/charts/heat-map.ts
@@ -21,7 +21,7 @@ const DEFAULT_BORDER_RADIUS = 6.75;
  * @mixes BaseMixin
  */
 export class HeatMap extends ColorMixin(MarginMixin) {
-    protected _conf: IHeatMapConf;
+    public _conf: IHeatMapConf;
 
     private _chartBody: Selection<SVGGElement, any, SVGElement, any>;
 

--- a/src/charts/pie-chart.ts
+++ b/src/charts/pie-chart.ts
@@ -27,7 +27,7 @@ const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
  */
 
 export class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
-    protected _conf: IPieChartConf;
+    public _conf: IPieChartConf;
 
     private _sliceCssClass: string;
     private _labelCssClass: string;

--- a/src/charts/row-chart.ts
+++ b/src/charts/row-chart.ts
@@ -28,7 +28,7 @@ import { adaptHandler } from '../core/d3compat';
  */
 
 export class RowChart extends CapMixin(ColorMixin(MarginMixin)) {
-    protected _conf: IRowChartConf;
+    public _conf: IRowChartConf;
 
     private _g: Selection<SVGGElement, any, any, any>;
     private _labelOffsetY: number;

--- a/src/charts/scatter-plot.ts
+++ b/src/charts/scatter-plot.ts
@@ -21,7 +21,7 @@ export type SymbolTypeGenerator = (d: any, ...args: any[]) => SymbolType;
  * @mixes CoordinateGridMixin
  */
 export class ScatterPlot extends CoordinateGridMixin {
-    protected _conf: IScatterPlotConf;
+    public _conf: IScatterPlotConf;
 
     private _symbol: Symbol<any, any>;
     private _filtered;

--- a/src/charts/series-chart.ts
+++ b/src/charts/series-chart.ts
@@ -16,7 +16,7 @@ import { compatNestHelper } from '../core/d3compat';
  * @mixes CompositeChart
  */
 export class SeriesChart extends CompositeChart {
-    protected _conf: ISeriesChartConf;
+    public _conf: ISeriesChartConf;
 
     private _charts: { [key: string]: LineChart };
 

--- a/src/charts/sunburst-chart.ts
+++ b/src/charts/sunburst-chart.ts
@@ -33,7 +33,7 @@ const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
  * @mixes BaseMixin
  */
 export class SunburstChart extends ColorMixin(BaseMixin) {
-    protected _conf: ISunburstChartConf;
+    public _conf: ISunburstChartConf;
 
     private _sliceCssClass: string;
     private _emptyCssClass: string;

--- a/src/compat/charts/bubble-chart.ts
+++ b/src/compat/charts/bubble-chart.ts
@@ -7,6 +7,7 @@ import { CoordinateGridMixinExt } from '../base/coordinate-grid-mixin';
 import { BubbleMixinExt } from '../base/bubble-mixin';
 
 export class BubbleChart extends BubbleMixinExt(
+// @ts-ignore
     CoordinateGridMixinExt(ColorMixinExt(MarginMixinExt(BaseMixinExt(BubbleChartNeo))))
 ) {
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     /* TODO: come back after redoing Mixins. Typescript compiler can not generate declarations for anonymous classes. */
-    "declaration": false,                     /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                     /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
Ref #1703, type definitions are now generated.

After considering multiple approaches, settling to this one. It involved one interface each that describes what each of the three Mixins expects. In addition, all members of the mixin themselves need to be public.

We will need to exclude the private members during typdoc configuration.