### PR TITLE
Typedoc - initial config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,9 +52,9 @@ module.exports = function (grunt) {
             }
         },
         watch: {
-            jsdoc2md: {
-                files: ['docs/welcome.base.md', '<%= conf.src %>/**/*.ts', '<%= conf.src %>/**/*.js'],
-                tasks: ['build', 'jsdoc', 'jsdoc2md']
+            typedoc: {
+                files: ['docs/**/*', '<%= conf.src %>/**/*.ts', '<%= conf.src %>/**/*.js'],
+                tasks: ['shell:typedoc']
             },
             scripts: {
                 files: ['<%= conf.src %>/**/*.ts', '<%= conf.src %>/**/*.js', '<%= conf.web %>/stock.js'],
@@ -154,22 +154,6 @@ module.exports = function (grunt) {
                 concurrency: 1,
                 reporters: ['dots', 'summary']
             },
-        },
-        jsdoc: {
-            dist: {
-                src: ['docs/welcome.base.md', '<%= conf.src %>/**/*.js', '!<%= conf.src %>/{banner,footer}.js'],
-                options: {
-                    destination: '<%= conf.web %>/docs/html',
-                    template: 'node_modules/ink-docstrap/template',
-                    configure: 'jsdoc.conf.json'
-                }
-            }
-        },
-        jsdoc2md: {
-            dist: {
-                src: '<%= conf.dist %>/<%= conf.pkg.name %>.js',
-                dest: 'docs/api-latest.md'
-            }
         },
         docco: {
             options: {
@@ -362,6 +346,9 @@ module.exports = function (grunt) {
             rollup: {
                 command: 'rollup --config'
             },
+            typedoc: {
+                command: 'typedoc src/index.ts'
+            },
             eslint: {
                 command: `eslint ${lintableFiles}`
             },
@@ -410,7 +397,7 @@ module.exports = function (grunt) {
 
     // task aliases
     grunt.registerTask('build', ['shell:dist-clean', 'shell:tsc', 'shell:rollup', 'sass', 'cssmin']);
-    grunt.registerTask('docs', ['build', 'copy', 'jsdoc', 'jsdoc2md', 'docco', 'fileindex']);
+    grunt.registerTask('docs', ['build', 'copy', 'shell:typedoc', 'docco', 'fileindex']);
     grunt.registerTask('web', ['docs', 'gh-pages']);
     grunt.registerTask('server-only', ['docs', 'fileindex', 'jasmine:specs:build', 'connect:server']);
     grunt.registerTask('server', ['server-only', 'watch:scripts-sass-docs']);
@@ -424,5 +411,5 @@ module.exports = function (grunt) {
     grunt.registerTask('lint', ['shell:tslint', 'shell:eslint', 'shell:prettier-check']);
     grunt.registerTask('lint-fix', ['shell:tslint-fix', 'shell:eslint-fix', 'shell:prettier']);
     grunt.registerTask('default', ['build', 'shell:hooks']);
-    grunt.registerTask('doc-debug', ['build', 'jsdoc', 'jsdoc2md', 'watch:jsdoc2md']);
+    grunt.registerTask('doc-debug', ['build', 'shell:typedoc', 'watch:typedoc']);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -631,6 +631,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "13.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz",
@@ -1027,6 +1033,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
+      }
     },
     "backo2": {
       "version": "1.0.2",
@@ -5350,6 +5365,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+      "dev": true
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -6156,6 +6177,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.7",
@@ -8506,6 +8533,17 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9691,6 +9729,36 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedoc": {
+      "version": "0.17.0-3",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.0-3.tgz",
+      "integrity": "sha512-DO2djkR4NHgzAWfNbJb2eQKsFMs+gOuYBXlQ8dOSCjkAK5DRI7ZywDufBGPUw7Ue9Qwi2Cw1DxLd3reDq8wFuQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "3.0.3",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.2",
+        "highlight.js": "^9.18.0",
+        "lodash": "^4.17.15",
+        "marked": "^0.8.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.3",
+        "typedoc-default-themes": "0.8.0-0"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.8.0-0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0-0.tgz",
+      "integrity": "sha512-blFWppm5aKnaPOa1tpGO9MLu+njxq7P3rtkXK4QxJBNszA+Jg7x0b+Qx0liXU1acErur6r/iZdrwxp5DUFdSXw==",
+      "dev": true,
+      "requires": {
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.8",
+        "underscore": "^1.9.1"
+      }
     },
     "typescript": {
       "version": "3.9.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -723,23 +723,6 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
-    "ansi-escape-sequences": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-      "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-          "dev": true
-        }
-      }
-    },
     "ansi-escapes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
@@ -870,12 +853,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
-    },
-    "array-back": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
       "dev": true
     },
     "array-differ": {
@@ -1427,17 +1404,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "cache-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-1.0.0.tgz",
-      "integrity": "sha512-ZqrZp9Hi5Uq7vfSGmNP2bUT/9DzZC2Y/GXjHB8rUJN1a+KLmbV05+vxHipNsg8+CSVgjcVVzLV8VZms6w8ZeRw==",
-      "dev": true,
-      "requires": {
-        "array-back": "^4.0.0",
-        "fs-then-native": "^2.0.0",
-        "mkdirp2": "^1.0.4"
-      }
-    },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -1471,15 +1437,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
-    },
-    "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -1652,16 +1609,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "collect-all": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-      "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
-      "dev": true,
-      "requires": {
-        "stream-connect": "^1.0.2",
-        "stream-via": "^1.0.4"
-      }
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1702,79 +1649,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-          "dev": true
-        },
-        "typical": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-          "dev": true
-        }
-      }
-    },
-    "command-line-tool": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
-      "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "command-line-args": "^5.0.0",
-        "command-line-usage": "^4.1.0",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        }
-      }
-    },
-    "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "table-layout": "^0.4.2",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        }
-      }
-    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1784,12 +1658,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/commenting/-/commenting-1.1.0.tgz",
       "integrity": "sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==",
-      "dev": true
-    },
-    "common-sequence": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.0.tgz",
-      "integrity": "sha512-f0QqPLpRTgMQn/pQIynf+SdE73Lw5Q1jn4hjirHLgH/NJ71TiHjXusV16BmOyuK5rRQ1W2f++II+TFZbQOh4hA==",
       "dev": true
     },
     "commondir": {
@@ -1850,23 +1718,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "config-master": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
-      "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
-      "dev": true,
-      "requires": {
-        "walk-back": "^2.0.1"
-      },
-      "dependencies": {
-        "walk-back": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
-          "dev": true
-        }
       }
     },
     "connect": {
@@ -2399,12 +2250,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2507,40 +2352,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
-    },
-    "dmd": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.6.tgz",
-      "integrity": "sha512-7ZYAnFQ6jGm4SICArwqNPylJ83PaOdPTAkds3Z/s1ueFqSc5ilJ2F0b7uP+35W1PUbemH++gn5/VlC3KwEgiHQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^4.0.1",
-        "cache-point": "^1.0.0",
-        "common-sequence": "^2.0.0",
-        "file-set": "^3.0.0",
-        "handlebars": "^4.5.3",
-        "marked": "^0.7.0",
-        "object-get": "^2.1.0",
-        "reduce-flatten": "^3.0.0",
-        "reduce-unique": "^2.0.1",
-        "reduce-without": "^1.0.1",
-        "test-value": "^3.0.0",
-        "walk-back": "^4.0.0"
-      },
-      "dependencies": {
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
-          "dev": true
-        },
-        "reduce-flatten": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.0.tgz",
-          "integrity": "sha512-eczl8wAYBxJ6Egl6I1ECIF+8z6sHu+KE7BzaEDZTpPXKXfy9SUDQlVYwkRcNTjJLC3Iakxbhss50KuT/R6SYfg==",
-          "dev": true
-        }
-      }
     },
     "docco": {
       "version": "0.6.3",
@@ -3420,16 +3231,6 @@
       "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==",
       "dev": true
     },
-    "file-set": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-3.0.0.tgz",
-      "integrity": "sha512-B/SdeSIeRv7VlOgIjtH3dkxMI+tEy5m+OeCXfAUsirBoVoY+bGtsmvmmTFPm/G23TBY4RiTtjpcgePCfwXRjqA==",
-      "dev": true,
-      "requires": {
-        "array-back": "^4.0.0",
-        "glob": "^7.1.5"
-      }
-    },
     "file-sync-cmp": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
@@ -3559,23 +3360,6 @@
           "requires": {
             "find-up": "^4.0.0"
           }
-        }
-      }
-    },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-          "dev": true
         }
       }
     },
@@ -3755,12 +3539,6 @@
       "requires": {
         "minipass": "^2.6.0"
       }
-    },
-    "fs-then-native": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
-      "dev": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -4255,68 +4033,6 @@
           "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
           "dev": true
         }
-      }
-    },
-    "grunt-jsdoc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/grunt-jsdoc/-/grunt-jsdoc-2.4.1.tgz",
-      "integrity": "sha512-S0zxU0wDewRu7z+vijEItOWe/UttxWVmvz0qz2ZVcAYR2GpXjsiski2CAVN0b18t2qeVLdmxZkJaEWCOsKzcAw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.1",
-        "jsdoc": "^3.6.3"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
-    "grunt-jsdoc-to-markdown": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-jsdoc-to-markdown/-/grunt-jsdoc-to-markdown-5.0.0.tgz",
-      "integrity": "sha512-3mCIeYZF7h1mug5N7+mqn+D0Cqc4PQ6b8fHqzME0pLXgFoQZMAZP67ELwrwy7CEKXCo5fWzezyiBYs3Tt0QM4A==",
-      "dev": true,
-      "requires": {
-        "jsdoc-to-markdown": "^5.0.2"
       }
     },
     "grunt-karma": {
@@ -5393,164 +5109,11 @@
         "esprima": "^4.0.0"
       }
     },
-    "js2xmlparser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
-      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
-      "dev": true,
-      "requires": {
-        "xmlcreate": "^2.0.3"
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
-    },
-    "jsdoc": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.4.tgz",
-      "integrity": "sha512-3G9d37VHv7MFdheviDCjUfQoIjdv4TC5zTTf5G9VODLtOnVS6La1eoYBDlbWfsRT3/Xo+j2MIqki2EV12BZfwA==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.9.4",
-        "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
-        "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.1",
-        "klaw": "^3.0.0",
-        "markdown-it": "^10.0.0",
-        "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
-        "mkdirp": "^1.0.4",
-        "requizzle": "^0.2.3",
-        "strip-json-comments": "^3.1.0",
-        "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.9.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
-        },
-        "klaw": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-          "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.9"
-          }
-        },
-        "marked": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
-          "dev": true
-        },
-        "underscore": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-          "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
-          "dev": true
-        }
-      }
-    },
-    "jsdoc-api": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.4.tgz",
-      "integrity": "sha512-1KMwLnfo0FyhF06TQKzqIm8BiY1yoMIGICxRdJHUjzskaHMzHMmpLlmNFgzoa4pAC8t1CDPK5jWuQTvv1pBsEQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^4.0.0",
-        "cache-point": "^1.0.0",
-        "collect-all": "^1.0.3",
-        "file-set": "^2.0.1",
-        "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.3",
-        "object-to-spawn-args": "^1.1.1",
-        "temp-path": "^1.0.0",
-        "walk-back": "^3.0.1"
-      },
-      "dependencies": {
-        "file-set": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz",
-          "integrity": "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "glob": "^7.1.3"
-          },
-          "dependencies": {
-            "array-back": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-              "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-              "dev": true,
-              "requires": {
-                "typical": "^2.6.1"
-              }
-            }
-          }
-        },
-        "walk-back": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.1.tgz",
-          "integrity": "sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ==",
-          "dev": true
-        }
-      }
-    },
-    "jsdoc-parse": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-4.0.1.tgz",
-      "integrity": "sha512-qIObw8yqYZjrP2qxWROB5eLQFLTUX2jRGLhW9hjo2CC2fQVlskidCIzjCoctwsDvauBp2a/lR31jkSleczSo8Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "^4.0.0",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
-        "reduce-extract": "^1.0.0",
-        "sort-array": "^2.0.0",
-        "test-value": "^3.0.0"
-      }
-    },
-    "jsdoc-to-markdown": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.3.tgz",
-      "integrity": "sha512-tQv5tBV0fTYidRQtE60lJKxE98mmuLcYuITFDKQiDPE9hGccpeEGUNFcVkInq1vigyuPnZmt79bQ8wv2GKjY0Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "^4.0.1",
-        "command-line-tool": "^0.8.0",
-        "config-master": "^3.1.0",
-        "dmd": "^4.0.5",
-        "jsdoc-api": "^5.0.4",
-        "jsdoc-parse": "^4.0.1",
-        "walk-back": "^4.0.0"
-      }
     },
     "jsesc": {
       "version": "2.5.2",
@@ -6007,15 +5570,6 @@
         }
       }
     },
-    "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "dev": true,
-      "requires": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "livereload-js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
@@ -6060,12 +5614,6 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -6120,24 +5668,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
     },
     "lodash.union": {
@@ -6251,33 +5781,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
-          "dev": true
-        }
-      }
-    },
-    "markdown-it-anchor": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.7.tgz",
-      "integrity": "sha512-REFmIaSS6szaD1bye80DMbp7ePwsPNvLTR5HunsUcZ0SG0rWJQ+Pz24R4UlTKtjKBPhxo0v0tOBDYjZQQknW8Q==",
-      "dev": true
-    },
     "marked": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
@@ -6347,12 +5850,6 @@
           "dev": true
         }
       }
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -6602,12 +6099,6 @@
           "dev": true
         }
       }
-    },
-    "mkdirp2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
-      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
-      "dev": true
     },
     "moment": {
       "version": "2.24.0",
@@ -7096,12 +6587,6 @@
         }
       }
     },
-    "object-get": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
-      "dev": true
-    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -7112,12 +6597,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object-to-spawn-args": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
       "dev": true
     },
     "object-visit": {
@@ -7860,78 +7339,6 @@
         "strip-indent": "^1.0.1"
       }
     },
-    "reduce-extract": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
-      "dev": true,
-      "requires": {
-        "test-value": "^1.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        },
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "^1.0.2",
-            "typical": "^2.4.2"
-          }
-        }
-      }
-    },
-    "reduce-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
-      "dev": true
-    },
-    "reduce-unique": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz",
-      "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==",
-      "dev": true
-    },
-    "reduce-without": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
-      "dev": true,
-      "requires": {
-        "test-value": "^2.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        },
-        "test-value": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-          "dev": true,
-          "requires": {
-            "array-back": "^1.0.3",
-            "typical": "^2.6.0"
-          }
-        }
-      }
-    },
     "reductio": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/reductio/-/reductio-0.6.3.tgz",
@@ -8037,15 +7444,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
-    },
-    "requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "resolve": {
       "version": "1.14.1",
@@ -8837,28 +8235,6 @@
         }
       }
     },
-    "sort-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
-      "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
-      "dev": true,
-      "requires": {
-        "array-back": "^1.0.4",
-        "object-get": "^2.1.0",
-        "typical": "^2.6.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        }
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9074,26 +8450,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "stream-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
-      "dev": true,
-      "requires": {
-        "array-back": "^1.0.2"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        }
-      }
-    },
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -9108,12 +8464,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
-    },
-    "stream-via": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
       "dev": true
     },
     "streamroller": {
@@ -9276,36 +8626,6 @@
         }
       }
     },
-    "table-layout": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-      "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
-      "dev": true,
-      "requires": {
-        "array-back": "^2.0.0",
-        "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        }
-      }
-    },
-    "taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-      "dev": true
-    },
     "tar": {
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
@@ -9347,12 +8667,6 @@
         }
       }
     },
-    "temp-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
-      "dev": true
-    },
     "terser": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.2.1.tgz",
@@ -9369,27 +8683,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        }
-      }
-    },
-    "test-value": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
         }
       }
     },
@@ -9766,22 +9059,10 @@
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
-    "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-      "dev": true
-    },
     "ua-parser-js": {
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
-      "dev": true
-    },
-    "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "uglify-js": {
@@ -10041,12 +9322,6 @@
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
-    "walk-back": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
-      "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
-      "dev": true
-    },
     "wd": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/wd/-/wd-1.13.0.tgz",
@@ -10223,16 +9498,6 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
-    "wordwrapjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-      "dev": true,
-      "requires": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
-      }
-    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -10294,12 +9559,6 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
-    },
-    "xmlcreate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
-      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
-      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "grunt-docco2": "^0.2.1",
     "grunt-fileindex": "~0.1",
     "grunt-gh-pages": "^4.0.0",
-    "grunt-jsdoc": "^2.4.1",
-    "grunt-jsdoc-to-markdown": "^5.0.0",
     "grunt-karma": "^3.0.2",
     "grunt-sass": "^3.1.0",
     "grunt-shell": "~2.1",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "devDependencies": {
     "@chiragrupani/karma-chromium-edge-launcher": "^2.0.0",
-    "@types/d3": "^5.7.2",
     "@rollup/plugin-json": "^4.1.0",
+    "@types/d3": "^5.7.2",
     "compare-versions": "^3.6.0",
     "crossfilter2": "^1.5.2",
     "d3-collection": "^1.0.7",
@@ -75,6 +75,7 @@
     "time-grunt": "~1.4",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
+    "typedoc": "^0.17.0-3",
     "typescript": "^3.9.5"
   },
   "scripts": {

--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -5,10 +5,9 @@ import { ColorMixin } from './color-mixin';
 import { transition } from '../core/core';
 import { events } from '../core/events';
 import { Constructor, MinimalRadiusScale, SVGGElementSelection } from '../core/types';
-import { BaseMixin } from './base-mixin';
 import { IBubbleMixinConf } from './i-bubble-mixin-conf';
 import { adaptHandler } from '../core/d3compat';
-import { IBaseMixinConf } from "./i-base-mixin-conf";
+import { IBaseMixinConf } from './i-base-mixin-conf';
 
 interface MinimalBase {
     configure(conf: IBaseMixinConf);

--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -8,6 +8,21 @@ import { Constructor, MinimalRadiusScale, SVGGElementSelection } from '../core/t
 import { BaseMixin } from './base-mixin';
 import { IBubbleMixinConf } from './i-bubble-mixin-conf';
 import { adaptHandler } from '../core/d3compat';
+import { IBaseMixinConf } from "./i-base-mixin-conf";
+
+interface MinimalBase {
+    configure(conf: IBaseMixinConf);
+    data();
+    data(callback): this;
+    redrawGroup();
+    title();
+    filter(filter: any);
+    selectAll(arg0: string);
+    hasFilter(f?);
+    highlightSelected(e): void;
+    fadeDeselected(e): void;
+    resetHighlight(e): void;
+}
 
 /**
  * This Mixin provides reusable functionalities for any chart that needs to visualize data using bubbles.
@@ -17,7 +32,7 @@ import { adaptHandler } from '../core/d3compat';
  * @returns {BubbleMixin}
  */
 // tslint:disable-next-line:variable-name
-export function BubbleMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
+export function BubbleMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
         protected _conf: IBubbleMixinConf;

--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -35,12 +35,12 @@ interface MinimalBase {
 export function BubbleMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
-        protected _conf: IBubbleMixinConf;
+        public _conf: IBubbleMixinConf;
 
-        protected BUBBLE_NODE_CLASS: string;
-        protected BUBBLE_CLASS: string;
-        protected MIN_RADIUS: number;
-        private _r: MinimalRadiusScale;
+        public BUBBLE_NODE_CLASS: string;
+        public BUBBLE_CLASS: string;
+        public MIN_RADIUS: number;
+        public _r: MinimalRadiusScale;
 
         constructor(...args: any[]) {
             super();

--- a/src/base/cap-mixin.ts
+++ b/src/base/cap-mixin.ts
@@ -30,7 +30,7 @@ interface MinimalBase {
 export function CapMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
-        protected _conf: ICapMixinConf;
+        public _conf: ICapMixinConf;
 
         constructor(...args: any[]) {
             super();

--- a/src/base/cap-mixin.ts
+++ b/src/base/cap-mixin.ts
@@ -1,8 +1,7 @@
 import { sum } from 'd3-array';
 import { Constructor } from '../core/types';
-import { BaseMixin } from './base-mixin';
 import { ICapMixinConf } from './i-cap-mixin-conf';
-import { IBaseMixinConf } from "./i-base-mixin-conf";
+import { IBaseMixinConf } from './i-base-mixin-conf';
 
 interface MinimalBase {
     configure(conf: IBaseMixinConf);
@@ -12,7 +11,6 @@ interface MinimalBase {
     onClick(d: any);
     filter(arg0: any[]);
 }
-
 
 /**
  * Cap is a mixin that groups small data elements below a _cap_ into an *others* grouping for both the

--- a/src/base/cap-mixin.ts
+++ b/src/base/cap-mixin.ts
@@ -2,6 +2,17 @@ import { sum } from 'd3-array';
 import { Constructor } from '../core/types';
 import { BaseMixin } from './base-mixin';
 import { ICapMixinConf } from './i-cap-mixin-conf';
+import { IBaseMixinConf } from "./i-base-mixin-conf";
+
+interface MinimalBase {
+    configure(conf: IBaseMixinConf);
+    data();
+    data(callback): this;
+    _computeOrderedGroups(arg0: any);
+    onClick(d: any);
+    filter(arg0: any[]);
+}
+
 
 /**
  * Cap is a mixin that groups small data elements below a _cap_ into an *others* grouping for both the
@@ -16,7 +27,7 @@ import { ICapMixinConf } from './i-cap-mixin-conf';
  * @returns {CapMixin}
  */
 // tslint:disable-next-line:variable-name
-export function CapMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
+export function CapMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     // @ts-ignore
     return class extends Base {
         protected _conf: ICapMixinConf;

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -25,9 +25,9 @@ interface MinimalBase {
 // tslint:disable-next-line:variable-name
 export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     return class extends Base {
-        protected _conf: IColorMixinConf;
+        public _conf: IColorMixinConf;
 
-        private _colorHelper: IColorHelper;
+        public _colorHelper: IColorHelper;
 
         constructor(...args: any[]) {
             super();

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -7,6 +7,13 @@ import { IColorMixinConf } from './i-color-mixin-conf';
 import { IColorHelper } from './colors/i-color-helper';
 import { ColorScaleHelper } from './colors/color-scale-helper';
 import { OrdinalColors } from './colors/ordinal-colors';
+import { IBaseMixinConf } from "./i-base-mixin-conf";
+
+interface MinimalBase {
+    configure(conf: IBaseMixinConf);
+    data();
+    data(callback): this;
+}
 
 /**
  * The Color Mixin is an abstract chart functional class providing universal coloring support
@@ -16,7 +23,7 @@ import { OrdinalColors } from './colors/ordinal-colors';
  * @returns {ColorMixin}
  */
 // tslint:disable-next-line:variable-name
-export function ColorMixin<TBase extends Constructor<BaseMixin>>(Base: TBase) {
+export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) {
     return class extends Base {
         protected _conf: IColorMixinConf;
 

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -1,13 +1,12 @@
 import { extent } from 'd3-array';
 
 import { config } from '../core/config';
-import { BaseMixin } from './base-mixin';
 import { Constructor, MinimalColorScale } from '../core/types';
 import { IColorMixinConf } from './i-color-mixin-conf';
 import { IColorHelper } from './colors/i-color-helper';
 import { ColorScaleHelper } from './colors/color-scale-helper';
 import { OrdinalColors } from './colors/ordinal-colors';
-import { IBaseMixinConf } from "./i-base-mixin-conf";
+import { IBaseMixinConf } from './i-base-mixin-conf';
 
 interface MinimalBase {
     configure(conf: IBaseMixinConf);

--- a/src/base/coordinate-grid-mixin.ts
+++ b/src/base/coordinate-grid-mixin.ts
@@ -37,7 +37,7 @@ const DEFAULT_AXIS_LABEL_PADDING = 12;
  * @mixes MarginMixin
  */
 export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
-    protected _conf: ICoordinateGridMixinConf;
+    public _conf: ICoordinateGridMixinConf;
 
     private _parent: Selection<SVGElement, any, any, any>;
     private _g: SVGGElementSelection;

--- a/src/base/i-color-mixin-conf.ts
+++ b/src/base/i-color-mixin-conf.ts
@@ -1,5 +1,5 @@
 import { IBaseMixinConf } from './i-base-mixin-conf';
-import { BaseAccessor, ColorAccessor } from '../core/types';
+import { ColorAccessor } from '../core/types';
 
 export interface IColorMixinConf extends IBaseMixinConf {
     readonly colorAccessor?: ColorAccessor;

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -12,7 +12,7 @@ import { IStackMixinConf } from './i-stack-mixin-conf';
  * @mixes CoordinateGridMixin
  */
 export class StackMixin extends CoordinateGridMixin {
-    protected _conf: IStackMixinConf;
+    public _conf: IStackMixinConf;
 
     private _stackLayout: Stack<any, { [p: string]: number }, string>;
     private _stack;

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -27,7 +27,7 @@ const LABEL_PADDING = 3;
  * @mixes StackMixin
  */
 export class BarChart extends StackMixin {
-    protected _conf: IBarChartConf;
+    public _conf: IBarChartConf;
 
     private _gap: number;
     private _barWidth: number;

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -50,7 +50,7 @@ function defaultWhiskersIQR(k: number): (d) => [number, number] {
  * @mixes CoordinateGridMixin
  */
 export class BoxPlot extends CoordinateGridMixin {
-    protected _conf: IBoxPlotConf;
+    public _conf: IBoxPlotConf;
 
     private readonly _whiskers: (d) => [number, number];
     private readonly _box;

--- a/src/charts/bubble-overlay.ts
+++ b/src/charts/bubble-overlay.ts
@@ -26,7 +26,7 @@ const BUBBLE_CLASS = 'bubble';
  * @mixes BaseMixin
  */
 export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
-    protected _conf: IBubbleOverlayConf;
+    public _conf: IBubbleOverlayConf;
 
     private _g: Selection<SVGGElement, any, any, any>;
 

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -23,7 +23,7 @@ const DEFAULT_RIGHT_Y_AXIS_LABEL_PADDING = 12;
  * @mixes CoordinateGridMixin
  */
 export class CompositeChart extends CoordinateGridMixin {
-    protected _conf: ICompositeChartConf;
+    public _conf: ICompositeChartConf;
 
     private _children: CoordinateGridMixin[];
     private _childOptions; // TODO: it is conf for children, revisit after creating concept of conf

--- a/src/charts/geo-choropleth-chart.ts
+++ b/src/charts/geo-choropleth-chart.ts
@@ -22,7 +22,7 @@ import { adaptHandler } from '../core/d3compat';
  * @mixes BaseMixin
  */
 export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
-    protected _conf: IGeoChoroplethChartConf;
+    public _conf: IGeoChoroplethChartConf;
 
     private _geoPath: GeoPath;
     private _projectionFlag: boolean;

--- a/src/charts/heat-map.ts
+++ b/src/charts/heat-map.ts
@@ -21,7 +21,7 @@ const DEFAULT_BORDER_RADIUS = 6.75;
  * @mixes BaseMixin
  */
 export class HeatMap extends ColorMixin(MarginMixin) {
-    protected _conf: IHeatMapConf;
+    public _conf: IHeatMapConf;
 
     private _chartBody: Selection<SVGGElement, any, SVGElement, any>;
 

--- a/src/charts/pie-chart.ts
+++ b/src/charts/pie-chart.ts
@@ -27,7 +27,7 @@ const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
  */
 
 export class PieChart extends CapMixin(ColorMixin(BaseMixin)) {
-    protected _conf: IPieChartConf;
+    public _conf: IPieChartConf;
 
     private _sliceCssClass: string;
     private _labelCssClass: string;

--- a/src/charts/row-chart.ts
+++ b/src/charts/row-chart.ts
@@ -28,7 +28,7 @@ import { adaptHandler } from '../core/d3compat';
  */
 
 export class RowChart extends CapMixin(ColorMixin(MarginMixin)) {
-    protected _conf: IRowChartConf;
+    public _conf: IRowChartConf;
 
     private _g: Selection<SVGGElement, any, any, any>;
     private _labelOffsetY: number;

--- a/src/charts/scatter-plot.ts
+++ b/src/charts/scatter-plot.ts
@@ -21,7 +21,7 @@ export type SymbolTypeGenerator = (d: any, ...args: any[]) => SymbolType;
  * @mixes CoordinateGridMixin
  */
 export class ScatterPlot extends CoordinateGridMixin {
-    protected _conf: IScatterPlotConf;
+    public _conf: IScatterPlotConf;
 
     private _symbol: Symbol<any, any>;
     private _filtered;

--- a/src/charts/series-chart.ts
+++ b/src/charts/series-chart.ts
@@ -16,7 +16,7 @@ import { compatNestHelper } from '../core/d3compat';
  * @mixes CompositeChart
  */
 export class SeriesChart extends CompositeChart {
-    protected _conf: ISeriesChartConf;
+    public _conf: ISeriesChartConf;
 
     private _charts: { [key: string]: LineChart };
 

--- a/src/charts/sunburst-chart.ts
+++ b/src/charts/sunburst-chart.ts
@@ -33,7 +33,7 @@ const DEFAULT_MIN_ANGLE_FOR_LABEL = 0.5;
  * @mixes BaseMixin
  */
 export class SunburstChart extends ColorMixin(BaseMixin) {
-    protected _conf: ISunburstChartConf;
+    public _conf: ISunburstChartConf;
 
     private _sliceCssClass: string;
     private _emptyCssClass: string;

--- a/src/compat/charts/bubble-chart.ts
+++ b/src/compat/charts/bubble-chart.ts
@@ -7,6 +7,7 @@ import { CoordinateGridMixinExt } from '../base/coordinate-grid-mixin';
 import { BubbleMixinExt } from '../base/bubble-mixin';
 
 export class BubbleChart extends BubbleMixinExt(
+// @ts-ignore
     CoordinateGridMixinExt(ColorMixinExt(MarginMixinExt(BaseMixinExt(BubbleChartNeo))))
 ) {
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     /* TODO: come back after redoing Mixins. Typescript compiler can not generate declarations for anonymous classes. */
-    "declaration": false,                     /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                     /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,9 @@
+{
+  "out": "web/html2",
+  "mode": "library",
+  "includes": "./docs",
+  "exclude": ["src/index-with-version.ts", "src/compat/**/*"],
+  "excludeExternals": true,
+  "excludePrivate": true,
+  "stripInternal": true
+}


### PR DESCRIPTION
This attempt seems to have better than my previous attempts:

- Used library mode of `typedoc`, which is a work in progress, but suits us - https://github.com/TypeStrong/typedoc/pull/1184 (installed `typedoc@next`).
- All items that need not be exposed in documentation would be marked `@internal`.
- In the future we will add the following to `tslint` rules:
      - https://palantir.github.io/tslint/rules/completed-docs/ to enforce documentation completeness
      - https://palantir.github.io/tslint/rules/no-redundant-jsdoc/ to cleanup jsdoc tags which are no longer needed