### PR TITLE
Replace data callbacks with overrides

### DIFF
--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -13,6 +13,7 @@ import { InvalidStateException } from '../core/invalid-state-exception';
 import { BadArgumentException } from '../core/bad-argument-exception';
 import {
     BaseAccessor,
+    CFGrouping,
     ChartGroupType,
     ChartParentType,
     LegendItem,
@@ -101,8 +102,6 @@ export class BaseMixin {
     private _chartGroup: IChartGroup;
     private _listeners: Dispatch<BaseMixin>;
     private _legend; // TODO: figure out actual type
-    private _defaultData: (group) => any; // TODO: find correct type
-    private _data: (group) => any;
     private _filters: any[]; // TODO: find better types
     protected _groupName: string; // StackMixin needs it
 
@@ -172,9 +171,6 @@ export class BaseMixin {
         );
 
         this._legend = undefined;
-
-        this._defaultData = group => group.all();
-        this._data = this._defaultData;
 
         this._filters = [];
     }
@@ -265,27 +261,11 @@ export class BaseMixin {
     }
 
     /**
-     * Set the data callback or retrieve the chart's data set. The data callback is passed the chart's
-     * group and by default will return
-     * {@link https://github.com/crossfilter/crossfilter/wiki/API-Reference#group_all group.all}.
-     * This behavior may be modified to, for instance, return only the top 5 groups.
-     * @example
-     * // Default data function
-     * chart.data(function (group) { return group.all(); });
-     *
-     * chart.data(function (group) { return group.top(5); });
-     * @param {Function} [callback]
-     * @returns {*|BaseMixin}
+     * Return charts data, typically `group.all()`. Some charts override this method.
+     * The derived classes may even use different return type.
      */
-    public data();
-    public data(callback): this;
-    public data(callback?) {
-        if (!arguments.length) {
-            return this._data(this._group);
-        }
-        this._data = typeof callback === 'function' ? callback : () => callback;
-        this.expireCache();
-        return this;
+    public data(): CFGrouping[] {
+        return this._group.all();
     }
 
     /**

--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -12,7 +12,6 @@ import { IBaseMixinConf } from './i-base-mixin-conf';
 interface MinimalBase {
     configure(conf: IBaseMixinConf);
     data();
-    data(callback): this;
     redrawGroup();
     title();
     filter(filter: any);
@@ -59,16 +58,6 @@ export function BubbleMixin<TBase extends Constructor<MinimalBase>>(Base: TBase)
             this.BUBBLE_CLASS = 'bubble';
             this.MIN_RADIUS = 10;
 
-            this.data(group => {
-                const data = group.all();
-                if (this._conf.sortBubbleSize) {
-                    // sort descending so smaller bubbles are on top
-                    const radiusAccessor = this._conf.radiusValueAccessor;
-                    data.sort((a, b) => descending(radiusAccessor(a), radiusAccessor(b)));
-                }
-                return data;
-            });
-
             this._r = scaleLinear().domain([0, 100]);
         }
 
@@ -79,6 +68,16 @@ export function BubbleMixin<TBase extends Constructor<MinimalBase>>(Base: TBase)
 
         public conf(): IBubbleMixinConf {
             return this._conf;
+        }
+
+        public data() {
+            const data = super.data();
+            if (this._conf.sortBubbleSize) {
+                // sort descending so smaller bubbles are on top
+                const radiusAccessor = this._conf.radiusValueAccessor;
+                data.sort((a, b) => descending(radiusAccessor(a), radiusAccessor(b)));
+            }
+            return data;
         }
 
         /**

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -11,7 +11,6 @@ import { IBaseMixinConf } from './i-base-mixin-conf';
 interface MinimalBase {
     configure(conf: IBaseMixinConf);
     data();
-    data(callback): this;
 }
 
 /**

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -34,30 +34,6 @@ export class StackMixin extends CoordinateGridMixin {
         this._titles = {};
 
         this._hiddenStacks = {};
-
-        this.data(() => {
-            const layers = this._stack.filter(l => this._visibility(l));
-            if (!layers.length) {
-                return [];
-            }
-            layers.forEach((l, i) => this._prepareValues(l, i));
-            const v4data = layers[0].values.map((v, i) => {
-                const col = { x: v.x };
-                layers.forEach(layer => {
-                    col[layer.name] = layer.values[i].y;
-                });
-                return col;
-            });
-            const keys = layers.map(layer => layer.name);
-            const v4result = this.stackLayout().keys(keys)(v4data);
-            v4result.forEach((series, i) => {
-                series.forEach((ys, j) => {
-                    layers[i].values[j].y0 = ys[0];
-                    layers[i].values[j].y1 = ys[1];
-                });
-            });
-            return layers;
-        });
     }
 
     public configure(conf: IStackMixinConf): this {
@@ -67,6 +43,30 @@ export class StackMixin extends CoordinateGridMixin {
 
     public conf(): IStackMixinConf {
         return this._conf;
+    }
+
+    public data() {
+        const layers = this._stack.filter(l => this._visibility(l));
+        if (!layers.length) {
+            return [];
+        }
+        layers.forEach((l, i) => this._prepareValues(l, i));
+        const v4data = layers[0].values.map((v, i) => {
+            const col = { x: v.x };
+            layers.forEach(layer => {
+                col[layer.name] = layer.values[i].y;
+            });
+            return col;
+        });
+        const keys = layers.map(layer => layer.name);
+        const v4result = this.stackLayout().keys(keys)(v4data);
+        v4result.forEach((series, i) => {
+            series.forEach((ys, j) => {
+                layers[i].values[j].y0 = ys[0];
+                layers[i].values[j].y1 = ys[1];
+            });
+        });
+        return layers;
     }
 
     public _prepareValues(layer, layerIdx) {

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -102,22 +102,6 @@ export class BoxPlot extends CoordinateGridMixin {
         // default to ordinal
         this.x(scaleBand());
 
-        // valueAccessor should return an array of values that can be coerced into numbers
-        // or if data is overloaded for a static array of arrays, it should be `Number`.
-        // Empty arrays are not included.
-        this.data(group =>
-            group
-                .all()
-                .map(d => {
-                    d.map = accessor => accessor.call(d, d);
-                    return d;
-                })
-                .filter(d => {
-                    const values = this._conf.valueAccessor(d);
-                    return values.length !== 0;
-                })
-        );
-
         this.boxPadding(0.8);
         this.outerPadding(0.5);
 
@@ -133,6 +117,21 @@ export class BoxPlot extends CoordinateGridMixin {
         return this._conf;
     }
 
+    public data() {
+        // valueAccessor should return an array of values that can be coerced into numbers
+        // or if data is overloaded for a static array of arrays, it should be `Number`.
+        // Empty arrays are not included.
+        return super
+            .data()
+            .map(d => {
+                d.map = accessor => accessor.call(d, d);
+                return d;
+            })
+            .filter(d => {
+                const values = this._conf.valueAccessor(d);
+                return values.length !== 0;
+            });
+    }
     /**
      * Get or set the spacing between boxes as a fraction of box size. Valid values are within 0-1.
      * See the {@link https://github.com/d3/d3-scale/blob/master/README.md#scaleBand d3 docs}

--- a/src/charts/cbox-menu.ts
+++ b/src/charts/cbox-menu.ts
@@ -57,8 +57,6 @@ export class CboxMenu extends BaseMixin {
 
         this._uniqueId = uniqueId();
 
-        this.data(group => group.all().filter(this._conf.filterDisplayed));
-
         this.anchor(parent, chartGroup);
     }
 
@@ -69,6 +67,10 @@ export class CboxMenu extends BaseMixin {
 
     public conf(): ICboxMenuConf {
         return this._conf;
+    }
+
+    public data() {
+        return super.data().filter(this._conf.filterDisplayed);
     }
 
     public _doRender(): this {

--- a/src/charts/number-display.ts
+++ b/src/charts/number-display.ts
@@ -3,7 +3,7 @@ import { easeQuad } from 'd3-ease';
 import { interpolateNumber } from 'd3-interpolate';
 
 import { BaseMixin } from '../base/base-mixin';
-import { ChartGroupType, ChartParentType } from '../core/types';
+import { ChartGroupType, ChartParentType, MinimalCFGroup } from '../core/types';
 import { INumberDisplayConf } from './i-number-display-conf';
 
 const SPAN_CLASS = 'number-display';
@@ -59,11 +59,6 @@ export class NumberDisplay extends BaseMixin {
         // dimension not required
         this._mandatoryAttributes(['group']);
 
-        this.data(group => {
-            const valObj = group.value ? group.value() : this._maxBin(group.all());
-            return this._conf.valueAccessor(valObj);
-        });
-
         this.anchor(parent, chartGroup);
     }
 
@@ -74,6 +69,14 @@ export class NumberDisplay extends BaseMixin {
 
     public conf(): INumberDisplayConf {
         return this._conf;
+    }
+
+    public data() {
+        const group: MinimalCFGroup & { value? } = this.group();
+
+        const valObj = group.value ? group.value() : this._maxBin(group.all());
+
+        return this._conf.valueAccessor(valObj);
     }
 
     /**

--- a/src/charts/select-menu.ts
+++ b/src/charts/select-menu.ts
@@ -52,8 +52,6 @@ export class SelectMenu extends BaseMixin {
 
         this._select = undefined;
 
-        this.data(group => group.all().filter(this._conf.filterDisplayed));
-
         this.anchor(parent, chartGroup);
     }
 
@@ -64,6 +62,10 @@ export class SelectMenu extends BaseMixin {
 
     public conf(): ISelectMenuConf {
         return this._conf;
+    }
+
+    public data() {
+        return super.data().filter(this._conf.filterDisplayed);
     }
 
     public _doRender() {

--- a/src/compat/charts/bubble-chart.ts
+++ b/src/compat/charts/bubble-chart.ts
@@ -7,7 +7,7 @@ import { CoordinateGridMixinExt } from '../base/coordinate-grid-mixin';
 import { BubbleMixinExt } from '../base/bubble-mixin';
 
 export class BubbleChart extends BubbleMixinExt(
-// @ts-ignore
+    // @ts-ignore
     CoordinateGridMixinExt(ColorMixinExt(MarginMixinExt(BaseMixinExt(BubbleChartNeo))))
 ) {
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,13 +18,13 @@ export interface MinimalCFDimension {
     bottom(k: number): any[];
 }
 
-interface CFGrouping {
+export interface CFGrouping {
     key: any;
     value: any;
 }
 
 export interface MinimalCFGroup {
-    all: CFGrouping[];
+    all(): CFGrouping[];
 }
 
 // Used for mix-ins


### PR DESCRIPTION
Moving towards #1747 

It makes data call a method which gets overridden by a chart if they wish to change it. This will allow group and dimension to move out of BaseMixin.