### PR TITLE
Gruntfile refactoring

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,10 @@
     "ecmaVersion": 6,
     "sourceType": "module"
   },
-  "extends": "eslint:recommended",
+  "extends": [
+    "eslint:recommended",
+    "prettier"
+  ],
   "rules": {
     "no-useless-escape": "off",
     "no-console": "off",
@@ -16,34 +19,19 @@
     "curly": "error",
     "eqeqeq": "error",
     "no-extend-native": "error",
-    "wrap-iife": ["error", "any"],
-    "indent": ["error", 4, {
-        "SwitchCase": 1,
-        "MemberExpression": "off",
-        "CallExpression": {"arguments": "first"},
-        "ArrayExpression": "first",
-        "flatTernaryExpressions": true
-      }
-    ],
     "no-caller": "error",
     "no-new": "error",
     "no-unused-vars": ["error", {"args": "none"}],
     "max-params": ["error", 5],
     "max-depth": ["error", 4],
     "complexity": ["error", 10],
-    "max-len": ["error", 140],
-    "quotes": ["error", "single"],
     "no-var": "error",
     "prefer-const": "error",
     "no-shadow": "error",
     "prefer-arrow-callback": "error",
     "arrow-body-style": "error",
-    "implicit-arrow-linebreak": "error",
-    "arrow-parens": ["error", "as-needed"],
-    "space-before-function-paren": ["error", "always"],
     "no-useless-concat": "error",
     "prefer-template": "error",
-    "template-curly-spacing": "error",
     "valid-jsdoc": ["error", {"requireParamDescription": false, "requireReturnDescription": false}]
   },
   "overrides": [

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           node-version: '12.x'
       - run: npm ci
-      - run: npx grunt ci-pull
+      - run: npx grunt ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - '12'
 
 script:
-  - npx grunt ci-pull
+  - npx grunt ci

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,8 @@ module.exports = function (grunt) {
                     'src/**/*.js',
                     'spec/*.js',
                     'spec/helpers/*.js',
+                    'tsconfig.json',
+                    'rollup.config.js',
                 ],
                 tasks: ['test'],
                 options: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
             },
             sass: {
                 files: ['style/dc.scss'],
-                tasks: ['sass', 'cssmin:main', 'copy:dc-to-gh'],
+                tasks: ['sass', 'cssmin:main', 'copy:web'],
             },
             tests: {
                 files: [
@@ -63,10 +63,11 @@ module.exports = function (grunt) {
                     'src/**/*.js',
                     'spec/*.js',
                     'spec/helpers/*.js',
-                    'web-src/**/*',
-                    'docs/**/*',
                 ],
                 tasks: ['test'],
+                options: {
+                    atBegin: true,
+                },
             },
             reload: {
                 files: [
@@ -414,7 +415,7 @@ module.exports = function (grunt) {
     ]);
     grunt.registerTask('server', ['server-only', 'watch:scripts-sass-docs']);
     // This task will activate server, test when initiated, and then keep a watch for changes, and rebuild and test as needed
-    grunt.registerTask('test-n-serve', ['connect:server', 'test', 'watch:tests']);
+    grunt.registerTask('test-n-serve', ['connect:server', 'watch:tests']);
 
     grunt.registerTask('ci', ['pre-test', 'karma:ci']);
     grunt.registerTask('ci-windows', ['pre-test', 'karma:ci-windows']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function (grunt) {
     'use strict';
 
     require('load-grunt-tasks')(grunt, {
-        pattern: ['grunt-*']
+        pattern: ['grunt-*'],
     });
     require('time-grunt')(grunt);
 
@@ -13,48 +13,49 @@ module.exports = function (grunt) {
 
     const pkg = require('./package.json');
     // in d3v4 and d3v5 pre-built d3.js are in different sub folders
-    const d3pkgSubDir = pkg.dependencies.d3.split('.')[0].replace(/[^\d]/g, '') === '4' ? 'build' : 'dist';
+    const d3pkgSubDir =
+        pkg.dependencies.d3.split('.')[0].replace(/[^\d]/g, '') === '4' ? 'build' : 'dist';
 
     const sass = require('node-sass');
 
     grunt.initConfig({
         sass: {
             options: {
-                implementation: sass
+                implementation: sass,
             },
             dist: {
                 files: {
-                    'dist/style/dc.css': 'style/dc.scss'
-                }
-            }
+                    'dist/style/dc.css': 'style/dc.scss',
+                },
+            },
         },
         cssmin: {
             options: {
                 shorthandCompacting: false,
-                roundingPrecision: -1
+                roundingPrecision: -1,
             },
             main: {
                 files: {
-                    'dist/style/dc.min.css': ['dist/style/dc.css']
-                }
-            }
+                    'dist/style/dc.min.css': ['dist/style/dc.css'],
+                },
+            },
         },
         watch: {
             typedoc: {
                 files: ['docs/**/*', 'src/**/*.ts', 'src/**/*.js'],
-                tasks: ['shell:typedoc']
+                tasks: ['shell:typedoc'],
             },
             scripts: {
                 files: ['src/**/*.ts', 'src/**/*.js', 'web/stock.js'],
-                tasks: ['docs']
+                tasks: ['docs'],
             },
             websrc: {
                 files: ['web-src/**/*.html', 'web-src/**/*.js'],
-                tasks: ['docs']
+                tasks: ['docs'],
             },
             sass: {
                 files: ['style/dc.scss'],
-                tasks: ['sass', 'cssmin:main', 'copy:dc-to-gh']
+                tasks: ['sass', 'cssmin:main', 'copy:dc-to-gh'],
             },
             tests: {
                 files: [
@@ -63,27 +64,30 @@ module.exports = function (grunt) {
                     'spec/*.js',
                     'spec/helpers/*.js',
                     'web-src/**/*',
-                    'docs/**/*'],
-                tasks: ['test']
+                    'docs/**/*',
+                ],
+                tasks: ['test'],
             },
             reload: {
-                files: ['dist/dc.js',
-                        'dist/style/dc.css',
-                        'web/js/dc.js',
-                        'web/css/dc.css',
-                        'dist/dc.min.js'],
+                files: [
+                    'dist/dc.js',
+                    'dist/style/dc.css',
+                    'web/js/dc.js',
+                    'web/css/dc.css',
+                    'dist/dc.min.js',
+                ],
                 options: {
-                    livereload: true
-                }
-            }
+                    livereload: true,
+                },
+            },
         },
         connect: {
             server: {
                 options: {
                     port: process.env.PORT || 8888,
-                    base: '.'
-                }
-            }
+                    base: '.',
+                },
+            },
         },
         jasmine: {
             specs: {
@@ -91,24 +95,17 @@ module.exports = function (grunt) {
                     display: 'short',
                     summary: true,
                     specs: 'spec/*-spec.js',
-                    helpers: [
-                        'spec/helpers/*.js',
-                        'spec/3rd-party/*.js'
-                    ],
-                    styles: [
-                        'dist/style/dc.css'
-                    ],
+                    helpers: ['spec/helpers/*.js', 'spec/3rd-party/*.js'],
+                    styles: ['dist/style/dc.css'],
                     outfile: 'spec/index.html',
-                    keepRunner: true
+                    keepRunner: true,
                 },
-                src: [
-                    'dist/dc.js'
-                ]
-            }
+                src: ['dist/dc.js'],
+            },
         },
         karma: {
             options: {
-                configFile: 'karma.conf.js'
+                configFile: 'karma.conf.js',
             },
             unit: {},
             coverage: {
@@ -118,44 +115,44 @@ module.exports = function (grunt) {
                     // source files, that you wanna generate coverage for
                     // do not include tests or libraries
                     // (these files will be instrumented by Istanbul)
-                    'dist/dc.js': ['coverage']
+                    'dist/dc.js': ['coverage'],
                 },
 
                 // optionally, configure the reporter
                 coverageReporter: {
                     type: 'html',
-                    dir: 'coverage/'
-                }
+                    dir: 'coverage/',
+                },
             },
             ci: {
                 browsers: ['ChromeNoSandboxHeadless', 'FirefoxHeadless'],
                 concurrency: 1,
-                reporters: ['dots', 'summary']
+                reporters: ['dots', 'summary'],
             },
             'ci-windows': {
                 browsers: ['EdgeHeadless', 'ChromeNoSandboxHeadless', 'FirefoxHeadless'],
                 concurrency: 1,
-                reporters: ['dots', 'summary']
+                reporters: ['dots', 'summary'],
             },
             'ci-macos': {
                 browsers: ['Safari', 'ChromeNoSandboxHeadless', 'FirefoxHeadless'],
                 concurrency: 1,
-                reporters: ['dots', 'summary']
+                reporters: ['dots', 'summary'],
             },
         },
         docco: {
             options: {
-                dst: 'web/docs'
+                dst: 'web/docs',
             },
             howto: {
                 files: [
                     {
                         expand: true,
                         cwd: 'web',
-                        src: ['stock.js']
-                    }
-                ]
-            }
+                        src: ['stock.js'],
+                    },
+                ],
+            },
         },
         copy: {
             web: {
@@ -165,20 +162,20 @@ module.exports = function (grunt) {
                         nonull: true,
                         cwd: 'web-src',
                         src: '**',
-                        dest: 'web/'
+                        dest: 'web/',
                     },
                     {
                         expand: true,
                         cwd: 'docs/old-api-docs',
                         src: '**',
-                        dest: 'web/docs/'
+                        dest: 'web/docs/',
                     },
                     {
                         expand: true,
                         flatten: true,
                         nonull: true,
                         src: ['dist/style/dc.css', 'dist/style/dc.min.css'],
-                        dest: 'web/css/'
+                        dest: 'web/css/',
                     },
                     {
                         expand: true,
@@ -191,13 +188,13 @@ module.exports = function (grunt) {
                             'node_modules/crossfilter2/crossfilter.js',
                             'node_modules/file-saver/FileSaver.js',
                             'node_modules/reductio/reductio.js',
-                            'node_modules/regression/dist/regression.js'
+                            'node_modules/regression/dist/regression.js',
                         ],
-                        dest: 'web/js/'
-                    }
-                ]
+                        dest: 'web/js/',
+                    },
+                ],
             },
-            'specs': {
+            specs: {
                 files: [
                     {
                         expand: true,
@@ -207,22 +204,20 @@ module.exports = function (grunt) {
                             `node_modules/d3/${d3pkgSubDir}/d3.js`,
                             'node_modules/crossfilter2/crossfilter.js',
                         ],
-                        dest: 'spec/3rd-party/'
+                        dest: 'spec/3rd-party/',
                     },
                     {
                         expand: true,
                         flatten: true,
                         nonull: true,
-                        src: [
-                            'node_modules/compare-versions/index.js'
-                        ],
+                        src: ['node_modules/compare-versions/index.js'],
                         dest: 'spec/3rd-party/',
                         rename: function (dest, src) {
                             return `${dest}compare-versions.js`;
-                        }
-                    }
-                ]
-            }
+                        },
+                    },
+                ],
+            },
         },
         fileindex: {
             'examples-listing': {
@@ -233,11 +228,9 @@ module.exports = function (grunt) {
                     heading: 'Examples of using dc.js',
                     description: 'An attempt to present a simple example of each chart type.',
                     also: ['transitions', 'resizing', 'zoom'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/examples'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/examples',
                 },
-                files: [
-                    {dest: 'web/examples/index.html', src: ['web-src/examples/*.html']}
-                ]
+                files: [{ dest: 'web/examples/index.html', src: ['web-src/examples/*.html'] }],
             },
             'transitions-listing': {
                 options: {
@@ -245,14 +238,15 @@ module.exports = function (grunt) {
                     absolute: true,
                     title: 'Index of dc.js transition tests',
                     heading: 'Eyeball tests for dc.js transitions',
-                    description: 'Transitions can only be tested by eye. ' +
+                    description:
+                        'Transitions can only be tested by eye. ' +
                         'These pages automate the transitions so they can be visually verified.',
                     also: ['examples', 'resizing', 'zoom'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/transitions'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/transitions',
                 },
                 files: [
-                    {dest: 'web/transitions/index.html', src: ['web-src/transitions/*.html']}
-                ]
+                    { dest: 'web/transitions/index.html', src: ['web-src/transitions/*.html'] },
+                ],
             },
             'resizing-listing': {
                 options: {
@@ -260,18 +254,17 @@ module.exports = function (grunt) {
                     absolute: true,
                     title: 'Index of dc.js resizing tests',
                     heading: 'Eyeball tests for resizing dc.js charts',
-                    description: 'It\'s a lot easier to test resizing behavior by eye. ' +
-                        'These pages fit the charts to the browser dynamically so it\'s easier to test. ' +
+                    description:
+                        "It's a lot easier to test resizing behavior by eye. " +
+                        "These pages fit the charts to the browser dynamically so it's easier to test. " +
                         'For the examples with a single chart taking up the entire window, you can add <code>?resize=viewbox</code> ' +
                         'to the URL to test resizing the chart using the ' +
                         '<a href="http://dc-js.github.io/dc.js/docs/html/dc.baseMixin.html#useViewBoxResizing__anchor">' +
                         'useViewBoxResizing</a> strategy.',
                     also: ['examples', 'transitions', 'zoom'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/resizing'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/resizing',
                 },
-                files: [
-                    {dest: 'web/resizing/index.html', src: ['web-src/resizing/*.html']}
-                ]
+                files: [{ dest: 'web/resizing/index.html', src: ['web-src/resizing/*.html'] }],
             },
             'zoom-listing': {
                 options: {
@@ -279,22 +272,21 @@ module.exports = function (grunt) {
                     absolute: true,
                     title: 'Index of dc.js zoom tests',
                     heading: 'Interactive test for dc.js chart zoom',
-                    description: 'It\'s hard to conceive of a way to test zoom except by trying it. ' +
+                    description:
+                        "It's hard to conceive of a way to test zoom except by trying it. " +
                         'So this is a substitute for automated tests in this area',
                     also: ['examples', 'transitions', 'resizing'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/zoom'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/zoom',
                 },
-                files: [
-                    {dest: 'web/zoom/index.html', src: ['web-src/zoom/*.html']}
-                ]
-            }
+                files: [{ dest: 'web/zoom/index.html', src: ['web-src/zoom/*.html'] }],
+            },
         },
         'gh-pages': {
             options: {
                 base: 'web',
-                message: 'Synced from from master branch.'
+                message: 'Synced from from master branch.',
             },
-            src: ['**']
+            src: ['**'],
         },
         shell: {
             merge: {
@@ -304,62 +296,63 @@ module.exports = function (grunt) {
                         'git checkout master',
                         'git reset --hard origin/master',
                         'git fetch origin',
-                        `git merge --no-ff origin/pr/${pr} -m 'Merge pull request #${pr}'`
+                        `git merge --no-ff origin/pr/${pr} -m 'Merge pull request #${pr}'`,
                     ].join('&&');
                 },
                 options: {
                     stdout: true,
-                    failOnError: true
-                }
+                    failOnError: true,
+                },
             },
             amend: {
                 command: 'git commit -a --amend --no-edit',
                 options: {
                     stdout: true,
-                    failOnError: true
-                }
+                    failOnError: true,
+                },
             },
             hooks: {
-                command: 'cp -n scripts/pre-commit.sh .git/hooks/pre-commit' +
-                    ' || echo \'Cowardly refusing to overwrite your existing git pre-commit hook.\''
+                command:
+                    'cp -n scripts/pre-commit.sh .git/hooks/pre-commit' +
+                    " || echo 'Cowardly refusing to overwrite your existing git pre-commit hook.'",
             },
             hierarchy: {
-                command: 'dot -Tsvg -o web-src/img/class-hierarchy.svg class-hierarchy.dot'
+                command: 'dot -Tsvg -o web-src/img/class-hierarchy.svg class-hierarchy.dot',
             },
             'dist-clean': {
-                command: 'rm -rf dist/'
+                command: 'rm -rf dist/',
             },
-            'web-specs-clean' :{
-                command: 'rm -rf web/ spec/3rd-part'
+            'web-specs-clean': {
+                command: 'rm -rf web/ spec/3rd-part',
             },
             rollup: {
-                command: 'rollup --config'
+                command: 'rollup --config',
             },
             typedoc: {
-                command: 'typedoc src/index.ts'
+                command: 'typedoc src/index.ts',
             },
             eslint: {
-                command: `eslint ${lintableFiles}`
+                command: `eslint ${lintableFiles}`,
             },
             'eslint-fix': {
-                command: `eslint ${lintableFiles} --fix`
+                command: `eslint ${lintableFiles} --fix`,
             },
             tslint: {
-                command: 'tslint src/**/*.ts'
+                command: 'tslint src/**/*.ts',
             },
             'tslint-fix': {
-                command: 'tslint src/**/*.ts --fix'
+                command: 'tslint src/**/*.ts --fix',
             },
             tsc: {
-                command: 'tsc'
+                command: 'tsc',
             },
             'prettier-check': {
-                command: 'prettier --check src'
+                command: 'prettier --check src',
             },
             prettier: {
-                command: 'prettier --write src'
-            }
-        }
+                command: 'prettier --write src',
+            },
+        },
     });
 
     grunt.registerTask('merge', 'Merge a github pull request.', pr => {
@@ -370,22 +363,36 @@ module.exports = function (grunt) {
         'test-stock-example',
         'Test a new rendering of the stock example web page against a baseline rendering',
         function (option) {
-            require('./regression/stock-regression-test.js').testStockExample(this.async(), option === 'diff');
-        });
-    grunt.registerTask('update-stock-example', 'Update the baseline stock example web page.', function () {
-        require('./regression/stock-regression-test.js').updateStockExample(this.async());
-    });
+            require('./regression/stock-regression-test.js').testStockExample(
+                this.async(),
+                option === 'diff'
+            );
+        }
+    );
+    grunt.registerTask(
+        'update-stock-example',
+        'Update the baseline stock example web page.',
+        function () {
+            require('./regression/stock-regression-test.js').updateStockExample(this.async());
+        }
+    );
     grunt.registerTask('watch:scripts-sass-docs', () => {
         grunt.config('watch', {
             scripts: grunt.config('watch').scripts,
             websrc: grunt.config('watch').websrc,
-            sass: grunt.config('watch').sass
+            sass: grunt.config('watch').sass,
         });
         grunt.task.run('watch');
     });
 
     // task aliases
-    grunt.registerTask('build', ['shell:dist-clean', 'shell:tsc', 'shell:rollup', 'sass', 'cssmin']);
+    grunt.registerTask('build', [
+        'shell:dist-clean',
+        'shell:tsc',
+        'shell:rollup',
+        'sass',
+        'cssmin',
+    ]);
     grunt.registerTask('pre-test', ['build', 'shell:web-specs-clean', 'copy']);
     grunt.registerTask('build-copy', ['build', 'copy']);
 
@@ -398,7 +405,13 @@ module.exports = function (grunt) {
     grunt.registerTask('web', ['build-copy', 'docs', 'gh-pages']);
     grunt.registerTask('doc-debug', ['shell:typedoc', 'watch:typedoc']);
 
-    grunt.registerTask('server-only', ['build-copy', 'docs', 'fileindex', 'jasmine:specs:build', 'connect:server']);
+    grunt.registerTask('server-only', [
+        'build-copy',
+        'docs',
+        'fileindex',
+        'jasmine:specs:build',
+        'connect:server',
+    ]);
     grunt.registerTask('server', ['server-only', 'watch:scripts-sass-docs']);
     // This task will activate server, test when initiated, and then keep a watch for changes, and rebuild and test as needed
     grunt.registerTask('test-n-serve', ['connect:server', 'test', 'watch:tests']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -415,7 +415,7 @@ module.exports = function (grunt) {
     // This task will activate server, test when initiated, and then keep a watch for changes, and rebuild and test as needed
     grunt.registerTask('test-n-serve', ['connect:server', 'test', 'watch:tests']);
 
-    grunt.registerTask('ci-pull', ['pre-test', 'karma:ci']);
+    grunt.registerTask('ci', ['pre-test', 'karma:ci']);
     grunt.registerTask('ci-windows', ['pre-test', 'karma:ci-windows']);
     grunt.registerTask('ci-macos', ['pre-test', 'karma:ci-macos']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,7 +170,7 @@ module.exports = function (grunt) {
             }
         },
         copy: {
-            'dc-to-gh': {
+            web: {
                 files: [
                     {
                         expand: true,
@@ -341,6 +341,9 @@ module.exports = function (grunt) {
             'dist-clean': {
                 command: 'rm -rf dist/'
             },
+            'web-specs-clean' :{
+                command: 'rm -rf web/ spec/3rd-part'
+            },
             rollup: {
                 command: 'rollup --config'
             },
@@ -395,19 +398,26 @@ module.exports = function (grunt) {
 
     // task aliases
     grunt.registerTask('build', ['shell:dist-clean', 'shell:tsc', 'shell:rollup', 'sass', 'cssmin']);
-    grunt.registerTask('docs', ['build', 'copy', 'shell:typedoc', 'docco', 'fileindex']);
-    grunt.registerTask('web', ['docs', 'gh-pages']);
-    grunt.registerTask('server-only', ['docs', 'fileindex', 'jasmine:specs:build', 'connect:server']);
-    grunt.registerTask('server', ['server-only', 'watch:scripts-sass-docs']);
-    // This task will active server, test when initiated, and then keep a watch for changes, and rebuild and test as needed
-    grunt.registerTask('test-n-serve', ['server-only', 'test', 'watch:tests']);
-    grunt.registerTask('test', ['build', 'copy', 'karma:unit']);
-    grunt.registerTask('coverage', ['build', 'copy', 'karma:coverage']);
-    grunt.registerTask('ci-pull', ['build', 'copy', 'karma:ci']);
-    grunt.registerTask('ci-windows', ['build', 'copy', 'karma:ci-windows']);
-    grunt.registerTask('ci-macos', ['build', 'copy', 'karma:ci-macos']);
+    grunt.registerTask('pre-test', ['build', 'shell:web-specs-clean', 'copy']);
+    grunt.registerTask('build-copy', ['build', 'copy']);
+
+    grunt.registerTask('test', ['pre-test', 'karma:unit']);
+    grunt.registerTask('coverage', ['pre-test', 'karma:coverage']);
     grunt.registerTask('lint', ['shell:tslint', 'shell:eslint', 'shell:prettier-check']);
     grunt.registerTask('lint-fix', ['shell:tslint-fix', 'shell:eslint-fix', 'shell:prettier']);
+
+    grunt.registerTask('docs', ['shell:typedoc', 'docco']);
+    grunt.registerTask('web', ['build-copy', 'docs', 'gh-pages']);
+    grunt.registerTask('doc-debug', ['shell:typedoc', 'watch:typedoc']);
+
+    grunt.registerTask('server-only', ['build-copy', 'docs', 'fileindex', 'jasmine:specs:build', 'connect:server']);
+    grunt.registerTask('server', ['server-only', 'watch:scripts-sass-docs']);
+    // This task will activate server, test when initiated, and then keep a watch for changes, and rebuild and test as needed
+    grunt.registerTask('test-n-serve', ['connect:server', 'test', 'watch:tests']);
+
+    grunt.registerTask('ci-pull', ['pre-test', 'karma:ci']);
+    grunt.registerTask('ci-windows', ['pre-test', 'karma:ci-windows']);
+    grunt.registerTask('ci-macos', ['pre-test', 'karma:ci-macos']);
+
     grunt.registerTask('default', ['build', 'shell:hooks']);
-    grunt.registerTask('doc-debug', ['build', 'shell:typedoc', 'watch:typedoc']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,34 +9,22 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-karma');
 
     const formatFileList = require('./grunt/format-file-list')(grunt);
+    const lintableFiles = "'spec/**/*.js' '*.js' 'grunt/*.js' 'web-src/stock.js'";
 
-    const config = {
-        src: 'src',
-        spec: 'spec',
-        web: 'web',
-        websrc: 'web-src',
-        dist: 'dist',
-        pkg: require('./package.json'),
-        banner: grunt.file.read('./LICENSE_BANNER')
-    };
-
+    const pkg = require('./package.json');
     // in d3v4 and d3v5 pre-built d3.js are in different sub folders
-    const d3pkgSubDir = config.pkg.dependencies.d3.split('.')[0].replace(/[^\d]/g, '') === '4' ? 'build' : 'dist';
-
-    const lintableFiles = `'${config.spec}/**/*.js' '*.js' 'grunt/*.js' '<%= conf.websrc %>/stock.js'`;
+    const d3pkgSubDir = pkg.dependencies.d3.split('.')[0].replace(/[^\d]/g, '') === '4' ? 'build' : 'dist';
 
     const sass = require('node-sass');
 
     grunt.initConfig({
-        conf: config,
-
         sass: {
             options: {
                 implementation: sass
             },
             dist: {
                 files: {
-                    '<%= conf.dist %>/style/<%= conf.pkg.name %>.css': 'style/<%= conf.pkg.name %>.scss'
+                    'dist/style/dc.css': 'style/dc.scss'
                 }
             }
         },
@@ -47,43 +35,43 @@ module.exports = function (grunt) {
             },
             main: {
                 files: {
-                    '<%= conf.dist %>/style/<%= conf.pkg.name %>.min.css': ['<%= conf.dist %>/style/<%= conf.pkg.name %>.css']
+                    'dist/style/dc.min.css': ['dist/style/dc.css']
                 }
             }
         },
         watch: {
             typedoc: {
-                files: ['docs/**/*', '<%= conf.src %>/**/*.ts', '<%= conf.src %>/**/*.js'],
+                files: ['docs/**/*', 'src/**/*.ts', 'src/**/*.js'],
                 tasks: ['shell:typedoc']
             },
             scripts: {
-                files: ['<%= conf.src %>/**/*.ts', '<%= conf.src %>/**/*.js', '<%= conf.web %>/stock.js'],
+                files: ['src/**/*.ts', 'src/**/*.js', 'web/stock.js'],
                 tasks: ['docs']
             },
             websrc: {
-                files: ['<%= conf.websrc %>/**/*.html', '<%= conf.websrc %>/**/*.js'],
+                files: ['web-src/**/*.html', 'web-src/**/*.js'],
                 tasks: ['docs']
             },
             sass: {
-                files: ['style/<%= conf.pkg.name %>.scss'],
+                files: ['style/dc.scss'],
                 tasks: ['sass', 'cssmin:main', 'copy:dc-to-gh']
             },
             tests: {
                 files: [
-                    '<%= conf.src %>/**/*.ts',
-                    '<%= conf.src %>/**/*.js',
-                    '<%= conf.spec %>/*.js',
-                    '<%= conf.spec %>/helpers/*.js',
-                    '<%= conf.websrc %>/**/*',
+                    'src/**/*.ts',
+                    'src/**/*.js',
+                    'spec/*.js',
+                    'spec/helpers/*.js',
+                    'web-src/**/*',
                     'docs/**/*'],
                 tasks: ['test']
             },
             reload: {
-                files: ['<%= conf.dist %>/<%= conf.pkg.name %>.js',
-                        '<%= conf.dist %>/style/<%= conf.pkg.name %>.css',
-                        '<%= conf.web %>/js/<%= conf.pkg.name %>.js',
-                        '<%= conf.web %>/css/<%= conf.pkg.name %>.css',
-                        '<%= conf.dist %>/<%= conf.pkg.name %>.min.js'],
+                files: ['dist/dc.js',
+                        'dist/style/dc.css',
+                        'web/js/dc.js',
+                        'web/css/dc.css',
+                        'dist/dc.min.js'],
                 options: {
                     livereload: true
                 }
@@ -102,19 +90,19 @@ module.exports = function (grunt) {
                 options: {
                     display: 'short',
                     summary: true,
-                    specs: '<%= conf.spec %>/*-spec.js',
+                    specs: 'spec/*-spec.js',
                     helpers: [
-                        '<%= conf.spec %>/helpers/*.js',
-                        '<%= conf.spec %>/3rd-party/*.js'
+                        'spec/helpers/*.js',
+                        'spec/3rd-party/*.js'
                     ],
                     styles: [
-                        '<%= conf.dist %>/style/dc.css'
+                        'dist/style/dc.css'
                     ],
-                    outfile: '<%= conf.spec %>/index.html',
+                    outfile: 'spec/index.html',
                     keepRunner: true
                 },
                 src: [
-                    '<%= conf.dist %>/<%= conf.pkg.name %>.js'
+                    'dist/dc.js'
                 ]
             }
         },
@@ -130,7 +118,7 @@ module.exports = function (grunt) {
                     // source files, that you wanna generate coverage for
                     // do not include tests or libraries
                     // (these files will be instrumented by Istanbul)
-                    '<%= conf.dist %>/<%= conf.pkg.name %>.js': ['coverage']
+                    'dist/dc.js': ['coverage']
                 },
 
                 // optionally, configure the reporter
@@ -157,13 +145,13 @@ module.exports = function (grunt) {
         },
         docco: {
             options: {
-                dst: '<%= conf.web %>/docs'
+                dst: 'web/docs'
             },
             howto: {
                 files: [
                     {
                         expand: true,
-                        cwd: '<%= conf.web %>',
+                        cwd: 'web',
                         src: ['stock.js']
                     }
                 ]
@@ -175,37 +163,37 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         nonull: true,
-                        cwd: '<%= conf.websrc %>',
+                        cwd: 'web-src',
                         src: '**',
-                        dest: '<%= conf.web %>/'
+                        dest: 'web/'
                     },
                     {
                         expand: true,
                         cwd: 'docs/old-api-docs',
                         src: '**',
-                        dest: '<%= conf.web %>/docs/'
+                        dest: 'web/docs/'
                     },
                     {
                         expand: true,
                         flatten: true,
                         nonull: true,
-                        src: ['<%= conf.dist %>/style/<%= conf.pkg.name %>.css', '<%= conf.dist %>/style/<%= conf.pkg.name %>.min.css'],
-                        dest: '<%= conf.web %>/css/'
+                        src: ['dist/style/dc.css', 'dist/style/dc.min.css'],
+                        dest: 'web/css/'
                     },
                     {
                         expand: true,
                         flatten: true,
                         nonull: true,
                         src: [
-                            '<%= conf.dist %>/*.js',
-                            '<%= conf.dist %>/*.js.map',
+                            'dist/*.js',
+                            'dist/*.js.map',
                             `node_modules/d3/${d3pkgSubDir}/d3.js`,
                             'node_modules/crossfilter2/crossfilter.js',
                             'node_modules/file-saver/FileSaver.js',
                             'node_modules/reductio/reductio.js',
                             'node_modules/regression/dist/regression.js'
                         ],
-                        dest: '<%= conf.web %>/js/'
+                        dest: 'web/js/'
                     }
                 ]
             },
@@ -219,7 +207,7 @@ module.exports = function (grunt) {
                             `node_modules/d3/${d3pkgSubDir}/d3.js`,
                             'node_modules/crossfilter2/crossfilter.js',
                         ],
-                        dest: '<%= conf.spec %>/3rd-party/'
+                        dest: 'spec/3rd-party/'
                     },
                     {
                         expand: true,
@@ -228,7 +216,7 @@ module.exports = function (grunt) {
                         src: [
                             'node_modules/compare-versions/index.js'
                         ],
-                        dest: '<%= conf.spec %>/3rd-party/',
+                        dest: 'spec/3rd-party/',
                         rename: function (dest, src) {
                             return `${dest}compare-versions.js`;
                         }
@@ -245,10 +233,10 @@ module.exports = function (grunt) {
                     heading: 'Examples of using dc.js',
                     description: 'An attempt to present a simple example of each chart type.',
                     also: ['transitions', 'resizing', 'zoom'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/<%= conf.websrc %>/examples'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/examples'
                 },
                 files: [
-                    {dest: '<%= conf.web %>/examples/index.html', src: ['<%= conf.websrc %>/examples/*.html']}
+                    {dest: 'web/examples/index.html', src: ['web-src/examples/*.html']}
                 ]
             },
             'transitions-listing': {
@@ -260,10 +248,10 @@ module.exports = function (grunt) {
                     description: 'Transitions can only be tested by eye. ' +
                         'These pages automate the transitions so they can be visually verified.',
                     also: ['examples', 'resizing', 'zoom'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/<%= conf.websrc %>/transitions'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/transitions'
                 },
                 files: [
-                    {dest: '<%= conf.web %>/transitions/index.html', src: ['<%= conf.websrc %>/transitions/*.html']}
+                    {dest: 'web/transitions/index.html', src: ['web-src/transitions/*.html']}
                 ]
             },
             'resizing-listing': {
@@ -279,10 +267,10 @@ module.exports = function (grunt) {
                         '<a href="http://dc-js.github.io/dc.js/docs/html/dc.baseMixin.html#useViewBoxResizing__anchor">' +
                         'useViewBoxResizing</a> strategy.',
                     also: ['examples', 'transitions', 'zoom'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/<%= conf.websrc %>/resizing'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/resizing'
                 },
                 files: [
-                    {dest: '<%= conf.web %>/resizing/index.html', src: ['<%= conf.websrc %>/resizing/*.html']}
+                    {dest: 'web/resizing/index.html', src: ['web-src/resizing/*.html']}
                 ]
             },
             'zoom-listing': {
@@ -294,16 +282,16 @@ module.exports = function (grunt) {
                     description: 'It\'s hard to conceive of a way to test zoom except by trying it. ' +
                         'So this is a substitute for automated tests in this area',
                     also: ['examples', 'transitions', 'resizing'],
-                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/<%= conf.websrc %>/zoom'
+                    sourceLink: 'https://github.com/dc-js/dc.js/tree/develop/web-src/zoom'
                 },
                 files: [
-                    {dest: '<%= conf.web %>/zoom/index.html', src: ['<%= conf.websrc %>/zoom/*.html']}
+                    {dest: 'web/zoom/index.html', src: ['web-src/zoom/*.html']}
                 ]
             }
         },
         'gh-pages': {
             options: {
-                base: '<%= conf.web %>',
+                base: 'web',
                 message: 'Synced from from master branch.'
             },
             src: ['**']
@@ -336,7 +324,7 @@ module.exports = function (grunt) {
                     ' || echo \'Cowardly refusing to overwrite your existing git pre-commit hook.\''
             },
             hierarchy: {
-                command: 'dot -Tsvg -o <%= conf.websrc %>/img/class-hierarchy.svg class-hierarchy.dot'
+                command: 'dot -Tsvg -o web-src/img/class-hierarchy.svg class-hierarchy.dot'
             },
             'dist-clean': {
                 command: 'rm -rf dist/'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,11 +11,6 @@ module.exports = function (grunt) {
     const formatFileList = require('./grunt/format-file-list')(grunt);
     const lintableFiles = "'spec/**/*.js' '*.js' 'grunt/*.js' 'web-src/stock.js'";
 
-    const pkg = require('./package.json');
-    // in d3v4 and d3v5 pre-built d3.js are in different sub folders
-    const d3pkgSubDir =
-        pkg.dependencies.d3.split('.')[0].replace(/[^\d]/g, '') === '4' ? 'build' : 'dist';
-
     const sass = require('node-sass');
 
     grunt.initConfig({
@@ -186,7 +181,7 @@ module.exports = function (grunt) {
                         src: [
                             'dist/*.js',
                             'dist/*.js.map',
-                            `node_modules/d3/${d3pkgSubDir}/d3.js`,
+                            `node_modules/d3/dist/d3.js`,
                             'node_modules/crossfilter2/crossfilter.js',
                             'node_modules/file-saver/FileSaver.js',
                             'node_modules/reductio/reductio.js',
@@ -203,7 +198,7 @@ module.exports = function (grunt) {
                         flatten: true,
                         nonull: true,
                         src: [
-                            `node_modules/d3/${d3pkgSubDir}/d3.js`,
+                            `node_modules/d3/dist/d3.js`,
                             'node_modules/crossfilter2/crossfilter.js',
                         ],
                         dest: 'spec/3rd-party/',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,11 +42,11 @@ module.exports = function (grunt) {
         },
         watch: {
             typedoc: {
-                files: ['docs/**/*', 'src/**/*.ts', 'src/**/*.js'],
+                files: ['docs/**/*', 'src/**/*.ts'],
                 tasks: ['shell:typedoc'],
             },
             scripts: {
-                files: ['src/**/*.ts', 'src/**/*.js', 'web/stock.js'],
+                files: ['src/**/*.ts', 'web/stock.js'],
                 tasks: ['docs'],
             },
             websrc: {
@@ -60,7 +60,6 @@ module.exports = function (grunt) {
             tests: {
                 files: [
                     'src/**/*.ts',
-                    'src/**/*.js',
                     'spec/*.js',
                     'spec/helpers/*.js',
                     'tsconfig.json',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,7 @@ module.exports = function (grunt) {
                 tasks: ['test'],
                 options: {
                     atBegin: true,
+                    interrupt: true,
                 },
             },
             reload: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2703,6 +2703,23 @@
         "v8-compile-cache": "^2.0.3"
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "crossfilter2": "^1.5.2",
     "d3-collection": "^1.0.7",
     "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",


### PR DESCRIPTION
Well, after procrastinating for a few years, finally took the plunge. :smile: 

The main purpose is to remove portions that are unused and to make it readable. Removed most of the string interpolations where the target string is well known by now (like `src`, `dest`, etc.).

I have also refactored grouped tasks to minimize duplicate/redundant subtasks.

The watch type of tasks needs further work. Over the years tooling has changed and so has dependencies. I will put more details in subsequent comments.