### PR TITLE
Housekeeping tasks

### DIFF
--- a/spec/base-mixin-spec.js
+++ b/spec/base-mixin-spec.js
@@ -7,16 +7,14 @@ describe('dc.baseMixin', () => {
         dimension = data.dimension(d => d3.utcDay(d.dd));
         group = dimension.group().reduceSum(d => d.value);
 
-        chart = dc.baseMixin({})
-            .options({
-                dimension: dimension,
-                group: group,
-                transitionDuration: 100
-            });
         id = 'base-chart';
         appendChartID(id);
-        chart.anchor(`#${id}`)
-            .resetSvg(); // so that renderlets can fire
+        chart = dc.baseMixin(`#${id}`).options({
+            dimension: dimension,
+            group: group,
+            transitionDuration: 100,
+        });
+        chart.resetSvg(); // so that renderlets can fire
     });
 
     describe('renderlets', () => {
@@ -123,7 +121,7 @@ describe('dc.baseMixin', () => {
                 expect(thirdRenderlet).not.toHaveBeenCalled();
                 done();
             });
-            chart.on('renderlet.third' , secondRenderlet);
+            chart.on('renderlet.third', secondRenderlet);
             chart.renderlet(secondRenderlet);
             chart.on('renderlet.third');
             chart.redraw();
@@ -137,7 +135,7 @@ describe('dc.baseMixin', () => {
                 expect(thirdRenderlet).not.toHaveBeenCalled();
                 done();
             });
-            chart.on('renderlet.third' , secondRenderlet);
+            chart.on('renderlet.third', secondRenderlet);
             chart.renderlet(secondRenderlet);
             chart.on('renderlet.third');
             chart.render();
@@ -261,11 +259,12 @@ describe('dc.baseMixin', () => {
     });
 
     describe('validations', () => {
-
         it('should require dimension', () => {
             try {
-                dc.baseMixin({}).group(group).render();
-                throw new Error('That should\'ve thrown');
+                id = 'base-chart';
+                appendChartID(id);
+                dc.baseMixin(`#${id}`).group(group).render();
+                throw new Error("That should've thrown");
             } catch (e) {
                 expect(e instanceof dc.InvalidStateException).toBeTruthy();
             }
@@ -273,8 +272,10 @@ describe('dc.baseMixin', () => {
 
         it('should require group', () => {
             try {
-                dc.baseMixin({}).dimension(dimension).render();
-                throw new Error('That should\'ve thrown');
+                id = 'base-chart';
+                appendChartID(id);
+                dc.baseMixin(`#${id}`).dimension(dimension).render();
+                throw new Error("That should've thrown");
             } catch (e) {
                 expect(e instanceof dc.InvalidStateException).toBeTruthy();
             }
@@ -321,7 +322,6 @@ describe('dc.baseMixin', () => {
                     // see http://stackoverflow.com/questions/70579/what-are-valid-values-for-the-id-attribute-in-html
                     expect(chart.anchorName()).toMatch(/^[a-zA-Z][a-zA-Z0-9_:.-]*$/);
                 });
-
             });
         });
 
@@ -360,7 +360,6 @@ describe('dc.baseMixin', () => {
                     // see http://stackoverflow.com/questions/70579/what-are-valid-values-for-the-id-attribute-in-html
                     expect(chart.anchorName()).toMatch(/^[a-zA-Z][a-zA-Z0-9_:.-]*$/);
                 });
-
             });
         });
 
@@ -394,9 +393,7 @@ describe('dc.baseMixin', () => {
         describe('when set to a falsy on a sized div', () => {
             let h0, w0;
             beforeEach(() => {
-                dimdiv
-                    .style('height', '220px')
-                    .style('width', '230px');
+                dimdiv.style('height', '220px').style('width', '230px');
                 chart.width(null).height(null).render();
                 w0 = chart.width();
                 h0 = chart.height();
@@ -423,8 +420,7 @@ describe('dc.baseMixin', () => {
 
             describe('and minimums set', () => {
                 beforeEach(() => {
-                    chart.minHeight(234).minWidth(976)
-                        .render();
+                    chart.minHeight(234).minWidth(976).render();
                 });
 
                 it('should set the height to the minimum', () => {
@@ -441,9 +437,7 @@ describe('dc.baseMixin', () => {
             let h0, w0;
             beforeEach(() => {
                 dimdiv.append('h1').text('helL0');
-                chart.width(null).height(null)
-                    .render()
-                    .resetSvg(); // because all real charts generate svg
+                chart.width(null).height(null).render().resetSvg(); // because all real charts generate svg
                 w0 = chart.width();
                 h0 = chart.height();
             });
@@ -502,10 +496,7 @@ describe('dc.baseMixin', () => {
 
     describe('viewbox resizing strategy', () => {
         beforeEach(() => {
-            chart
-                .width(600)
-                .height(400)
-                .resetSvg();
+            chart.width(600).height(400).resetSvg();
         });
         it('useViewBoxResizing defaults false', () => {
             expect(chart.useViewBoxResizing()).toBeFalsy();

--- a/spec/cap-mixin-spec.js
+++ b/spec/cap-mixin-spec.js
@@ -1,4 +1,4 @@
-/* global loadDateFixture */
+/* global appendChartID, loadDateFixture */
 describe('dc.capMixin', () => {
     let data, dimension, group;
     let mixin, total;
@@ -10,7 +10,9 @@ describe('dc.capMixin', () => {
         total = d3.sum(group.all().map(dc.pluck('value')));
 
         const CapMixinTester = dc.CapMixin(dc.BaseMixin);
-        mixin = new CapMixinTester();
+        const id = 'cap-mixin-tester';
+        appendChartID(id);
+        mixin = new CapMixinTester(`#${id}`);
 
         mixin.dimension(dimension)
             .group(group);

--- a/spec/color-spec.js
+++ b/spec/color-spec.js
@@ -1,19 +1,24 @@
-/* global loadDateFixture, compareVersions */
+/* global appendChartID, loadDateFixture, compareVersions */
 describe('dc.colorMixin', () => {
-    function colorTest (chart, domain, test) {
+    function colorTest(chart, domain, test) {
         chart.colorDomain(domain);
         return (test || domain).map((d, i) => chart.getColor(d, i));
     }
 
     function identity (d) { return d; }
 
-    const ColorMixinTester = dc.ColorMixin(dc.BaseMixin);
+    function instantiateColorMixin() {
+        const ColorMixinTester = dc.ColorMixin(dc.BaseMixin);
+        const id = 'cap-mixin-tester';
+        appendChartID(id);
+        return new ColorMixinTester(`#${id}`);
+    }
 
     describe('deprecation', () => {
         it('issues a one time warning when using default color scheme', () => {
             spyOn(dc.logger, 'warnOnce');
 
-            new ColorMixinTester(); // eslint-disable-line no-new
+            instantiateColorMixin();
 
             expect(dc.logger.warnOnce).toHaveBeenCalled();
         });
@@ -24,7 +29,7 @@ describe('dc.colorMixin', () => {
             spyOn(dc.logger, 'warnOnce');
 
             dc.config.defaultColors(d3.schemeSet1);
-            new ColorMixinTester(); // eslint-disable-line no-new
+            instantiateColorMixin();
 
             expect(dc.logger.warnOnce).not.toHaveBeenCalled();
 
@@ -33,11 +38,11 @@ describe('dc.colorMixin', () => {
         });
     });
 
-    describe('with ordinal domain' , () => {
+    describe('with ordinal domain', () => {
         let chart, domain;
 
         beforeEach(() => {
-            chart = new ColorMixinTester();
+            chart = instantiateColorMixin();
             chart.colorAccessor(identity);
             domain = ['a','b','c','d','e'];
         });
@@ -76,7 +81,7 @@ describe('dc.colorMixin', () => {
         let chart, domain, test, expectedColorIndices;
 
         beforeEach(() => {
-            chart = new ColorMixinTester();
+            chart = instantiateColorMixin();
             chart.colorAccessor(identity);
             domain = [1, 100];
             // It has items that are not part of the domain.
@@ -131,7 +136,7 @@ describe('dc.colorMixin', () => {
             const data = crossfilter(loadDateFixture());
             const valueDimension = data.dimension(d => d.value);
             const valueGroup = valueDimension.group();
-            chart = new ColorMixinTester()
+            chart = instantiateColorMixin()
                 .colorAccessor(d => d.value)
                 .group(valueGroup);
         });

--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -250,7 +250,9 @@ describe('dc.coordinateGridChart', () => {
         describe('when an x function is not provided', () => {
             it('should trigger a descriptive exception', () => {
                 try {
-                    new dc.CoordinateGridMixin().group({}).dimension({}).render();
+                    id = 'coordinate-chart';
+                    appendChartID(id);
+                    new dc.CoordinateGridMixin(`#${id}`).group({}).dimension({}).render();
                     expect('exception').toBe('thrown');
                 } catch (e) {
                     expect(e instanceof dc.InvalidStateException).toBeTruthy();

--- a/spec/heatmap-spec.js
+++ b/spec/heatmap-spec.js
@@ -317,7 +317,9 @@ describe('dc.heatmap', () => {
 
         it('should keep all data points for that cell', () => {
             const otherGroup = otherDimension.group().reduceSum(d => +d.colorData);
-            const otherChart = dc.baseMixin().dimension(otherDimension).group(otherGroup);
+            id = 'other-chart';
+            appendChartID(id);
+            const otherChart = dc.baseMixin(`#${id}`).dimension(otherDimension).group(otherGroup);
 
             otherChart.render();
             const clickedCell = clickCellOnChart(chart, filterX, filterY);

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -42,8 +42,9 @@ export class BaseMixin {
     private _legend; // TODO: figure out actual type
     protected _dataProvider: CFSimpleAdapter;
 
-    constructor() {
+    constructor(chartGroup: ChartGroupType) {
         this.__dcFlag__ = uniqueId().toString();
+        this._chartGroup = this._getChartGroup(chartGroup);
 
         this.configure({
             minWidth: 200,
@@ -260,12 +261,11 @@ export class BaseMixin {
      * @returns {String|node|d3.selection|BaseMixin}
      */
     public anchor(): string | Element;
-    public anchor(parent: ChartParentType, chartGroup: ChartGroupType): this;
-    public anchor(parent?, chartGroup?) {
+    public anchor(parent: ChartParentType): this;
+    public anchor(parent?) {
         if (!arguments.length) {
             return this._anchor;
         }
-        this._chartGroup = this._getChartGroup(chartGroup);
         if (instanceOfChart(parent)) {
             this._anchor = parent.anchor();
             if ((this._anchor as any).children) {

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -657,7 +657,7 @@ export class BaseMixin {
      * @returns {Array<*>}
      */
     public filters() {
-        return this._dataProvider.filters();
+        return this._dataProvider.filters;
     }
 
     public highlightSelected(e): void {

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -42,9 +42,15 @@ export class BaseMixin {
     private _legend; // TODO: figure out actual type
     protected _dataProvider: CFSimpleAdapter;
 
-    constructor(chartGroup: ChartGroupType) {
+    constructor(parent, chartGroup: ChartGroupType) {
+        this._anchor = undefined;
+        this._root = undefined;
+        this._svg = undefined;
+        this._isChild = undefined;
+
         this.__dcFlag__ = uniqueId().toString();
         this._chartGroup = this._getChartGroup(chartGroup);
+        this.anchor(parent);
 
         this.configure({
             minWidth: 200,
@@ -63,11 +69,6 @@ export class BaseMixin {
         });
 
         this._dataProvider = new CFSimpleAdapter();
-
-        this._anchor = undefined;
-        this._root = undefined;
-        this._svg = undefined;
-        this._isChild = undefined;
 
         this._defaultWidthCalc = element => {
             const width =
@@ -257,7 +258,6 @@ export class BaseMixin {
      * within the chartGroup. This class is called internally on chart initialization, but be called
      * again to relocate the chart. However, it will orphan any previously created SVGElements.
      * @param {anchorChart|anchorSelector|anchorNode} [parent]
-     * @param {String} [chartGroup]
      * @returns {String|node|d3.selection|BaseMixin}
      */
     public anchor(): string | Element;

--- a/src/base/bubble-mixin.ts
+++ b/src/base/bubble-mixin.ts
@@ -40,7 +40,7 @@ export function BubbleMixin<TBase extends Constructor<MinimalBase>>(Base: TBase)
         public _r: MinimalRadiusScale;
 
         constructor(...args: any[]) {
-            super();
+            super(...args);
 
             this.configure({
                 renderLabel: true,

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -28,7 +28,7 @@ export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) 
         public _colorHelper: IColorHelper;
 
         constructor(...args: any[]) {
-            super();
+            super(...args);
 
             this.configure({
                 colorAccessor: (d, i?) => this._conf.keyAccessor(d),

--- a/src/base/coordinate-grid-mixin.ts
+++ b/src/base/coordinate-grid-mixin.ts
@@ -15,7 +15,7 @@ import { constants } from '../core/constants';
 import { add, appendOrSelect, arraysEqual, subtract } from '../core/utils';
 import { logger } from '../core/logger';
 import { events } from '../core/events';
-import { ChartGroupType, DCBrushSelection, MinimalXYScale, SVGGElementSelection } from '../core/types';
+import { ChartGroupType, ChartParentType, DCBrushSelection, MinimalXYScale, SVGGElementSelection } from '../core/types';
 import { ICoordinateGridMixinConf } from './i-coordinate-grid-mixin-conf';
 import { OrdinalColors } from './colors/ordinal-colors';
 import { adaptHandler } from '../core/d3compat';
@@ -69,8 +69,8 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
     private _fOuterRangeBandPadding: number;
     private _fRangeBandPadding: number;
 
-    constructor(chartGroup: ChartGroupType) {
-        super(chartGroup);
+    constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
+        super(parent, chartGroup);
 
         this.colorHelper(
             new OrdinalColors({ colors: schemeCategory10, colorAccessor: this._conf.colorAccessor })

--- a/src/base/coordinate-grid-mixin.ts
+++ b/src/base/coordinate-grid-mixin.ts
@@ -15,7 +15,7 @@ import { constants } from '../core/constants';
 import { add, appendOrSelect, arraysEqual, subtract } from '../core/utils';
 import { logger } from '../core/logger';
 import { events } from '../core/events';
-import { DCBrushSelection, MinimalXYScale, SVGGElementSelection } from '../core/types';
+import { ChartGroupType, DCBrushSelection, MinimalXYScale, SVGGElementSelection } from '../core/types';
 import { ICoordinateGridMixinConf } from './i-coordinate-grid-mixin-conf';
 import { OrdinalColors } from './colors/ordinal-colors';
 import { adaptHandler } from '../core/d3compat';
@@ -69,8 +69,8 @@ export class CoordinateGridMixin extends ColorMixin(MarginMixin) {
     private _fOuterRangeBandPadding: number;
     private _fRangeBandPadding: number;
 
-    constructor() {
-        super();
+    constructor(chartGroup: ChartGroupType) {
+        super(chartGroup);
 
         this.colorHelper(
             new OrdinalColors({ colors: schemeCategory10, colorAccessor: this._conf.colorAccessor })

--- a/src/base/coordinate-grid-mixin.ts
+++ b/src/base/coordinate-grid-mixin.ts
@@ -15,7 +15,13 @@ import { constants } from '../core/constants';
 import { add, appendOrSelect, arraysEqual, subtract } from '../core/utils';
 import { logger } from '../core/logger';
 import { events } from '../core/events';
-import { ChartGroupType, ChartParentType, DCBrushSelection, MinimalXYScale, SVGGElementSelection } from '../core/types';
+import {
+    ChartGroupType,
+    ChartParentType,
+    DCBrushSelection,
+    MinimalXYScale,
+    SVGGElementSelection,
+} from '../core/types';
 import { ICoordinateGridMixinConf } from './i-coordinate-grid-mixin-conf';
 import { OrdinalColors } from './colors/ordinal-colors';
 import { adaptHandler } from '../core/d3compat';

--- a/src/base/margin-mixin.ts
+++ b/src/base/margin-mixin.ts
@@ -1,5 +1,5 @@
 import { BaseMixin } from './base-mixin';
-import { Margins } from '../core/types';
+import { ChartGroupType, Margins } from '../core/types';
 import { IMarginMixinConf } from './i-margin-mixin-conf';
 
 /**
@@ -14,8 +14,8 @@ export class MarginMixin extends BaseMixin {
 
     private _margins: Margins;
 
-    constructor() {
-        super();
+    constructor(chartGroup: ChartGroupType) {
+        super(chartGroup);
 
         this._margins = { top: 10, right: 50, bottom: 30, left: 30 };
     }

--- a/src/base/margin-mixin.ts
+++ b/src/base/margin-mixin.ts
@@ -1,5 +1,5 @@
 import { BaseMixin } from './base-mixin';
-import { ChartGroupType, Margins } from '../core/types';
+import { ChartGroupType, ChartParentType, Margins } from '../core/types';
 import { IMarginMixinConf } from './i-margin-mixin-conf';
 
 /**
@@ -14,8 +14,8 @@ export class MarginMixin extends BaseMixin {
 
     private _margins: Margins;
 
-    constructor(chartGroup: ChartGroupType) {
-        super(chartGroup);
+    constructor(parent: ChartParentType,  chartGroup: ChartGroupType) {
+        super(parent, chartGroup);
 
         this._margins = { top: 10, right: 50, bottom: 30, left: 30 };
     }

--- a/src/base/margin-mixin.ts
+++ b/src/base/margin-mixin.ts
@@ -14,7 +14,7 @@ export class MarginMixin extends BaseMixin {
 
     private _margins: Margins;
 
-    constructor(parent: ChartParentType,  chartGroup: ChartGroupType) {
+    constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
         super(parent, chartGroup);
 
         this._margins = { top: 10, right: 50, bottom: 30, left: 30 };

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -62,7 +62,7 @@ export class StackMixin extends CoordinateGridMixin {
             return [];
         }
 
-        layers.forEach((l, i) => {
+        layers.forEach(l => {
             const allValues = l.rawData.map((d, i) => ({
                 x: this._conf.keyAccessor(d, i),
                 y: d._value,
@@ -70,7 +70,7 @@ export class StackMixin extends CoordinateGridMixin {
                 name: l.name,
             }));
 
-            l.domainValues = allValues.filter(l => this._domainFilter()(l));
+            l.domainValues = allValues.filter(layer => this._domainFilter()(layer));
             l.values = this._conf.evadeDomainFilter ? allValues : l.domainValues;
         });
 
@@ -188,13 +188,14 @@ export class StackMixin extends CoordinateGridMixin {
     }
 
     public legendables(): LegendItem[] {
-        const stack = this.dataProvider().layers();
-        return stack.map((layer, i) => ({
-            chart: this,
-            name: layer.name,
-            hidden: !this._isLayerVisible(layer.name),
-            color: this.getColor(layer, i),
-        }));
+        return this.dataProvider()
+            .layers()
+            .map((layer, i) => ({
+                chart: this,
+                name: layer.name,
+                hidden: !this._isLayerVisible(layer.name),
+                color: this.getColor(layer, i),
+            }));
     }
 
     public isLegendableHidden(d: LegendItem) {

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -3,7 +3,7 @@ import { max, min } from 'd3-array';
 
 import { add, subtract } from '../core/utils';
 import { CoordinateGridMixin } from './coordinate-grid-mixin';
-import { ChartGroupType, LegendItem, TitleAccessor } from '../core/types';
+import { ChartGroupType, ChartParentType, LegendItem, TitleAccessor } from '../core/types';
 import { IStackMixinConf } from './i-stack-mixin-conf';
 import { CFMultiAdapter } from '../data/c-f-multi-adapter';
 
@@ -20,8 +20,8 @@ export class StackMixin extends CoordinateGridMixin {
 
     protected _dataProvider: CFMultiAdapter;
 
-    constructor(chartGroup: ChartGroupType) {
-        super(chartGroup);
+    constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
+        super(parent, chartGroup);
 
         this.configure({
             colorAccessor: d => d.name,

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -3,7 +3,7 @@ import { max, min } from 'd3-array';
 
 import { add, subtract } from '../core/utils';
 import { CoordinateGridMixin } from './coordinate-grid-mixin';
-import { LegendItem, TitleAccessor } from '../core/types';
+import { ChartGroupType, LegendItem, TitleAccessor } from '../core/types';
 import { IStackMixinConf } from './i-stack-mixin-conf';
 import { CFMultiAdapter } from '../data/c-f-multi-adapter';
 
@@ -20,8 +20,8 @@ export class StackMixin extends CoordinateGridMixin {
 
     protected _dataProvider: CFMultiAdapter;
 
-    constructor() {
-        super();
+    constructor(chartGroup: ChartGroupType) {
+        super(chartGroup);
 
         this.configure({
             colorAccessor: d => d.name,

--- a/src/base/stack-mixin.ts
+++ b/src/base/stack-mixin.ts
@@ -29,7 +29,7 @@ export class StackMixin extends CoordinateGridMixin {
             evadeDomainFilter: false,
         });
 
-        this._dataProvider = new CFMultiAdapter();
+        this.dataProvider(new CFMultiAdapter());
 
         this._stackLayout = stack();
 
@@ -45,8 +45,17 @@ export class StackMixin extends CoordinateGridMixin {
         return this._conf;
     }
 
+    public dataProvider(): CFMultiAdapter;
+    public dataProvider(dataProvider): this;
+    public dataProvider(dataProvider?) {
+        if (!arguments.length) {
+            return super.dataProvider();
+        }
+        return super.dataProvider(dataProvider);
+    }
+
     public data() {
-        let layers: any[] = this._dataProvider.data();
+        let layers: any[] = this.dataProvider().data();
         layers = layers.filter(l => this._isLayerVisible(l.name));
 
         if (!layers.length) {
@@ -179,7 +188,7 @@ export class StackMixin extends CoordinateGridMixin {
     }
 
     public legendables(): LegendItem[] {
-        const stack = this._dataProvider.layers();
+        const stack = this.dataProvider().layers();
         return stack.map((layer, i) => ({
             chart: this,
             name: layer.name,

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -50,7 +50,7 @@ export class BarChart extends StackMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             label: d => printSingleValue(d.y0 + d.y),
@@ -62,8 +62,6 @@ export class BarChart extends StackMixin {
         this._gap = DEFAULT_GAP_BETWEEN_BARS; // TODO: after untangling it with outer/inner paddings try to move to conf
 
         this._barWidth = undefined;
-
-        this.anchor(parent);
     }
 
     public configure(conf: IBarChartConf): this {

--- a/src/charts/bar-chart.ts
+++ b/src/charts/bar-chart.ts
@@ -50,7 +50,7 @@ export class BarChart extends StackMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             label: d => printSingleValue(d.y0 + d.y),
@@ -63,7 +63,7 @@ export class BarChart extends StackMixin {
 
         this._barWidth = undefined;
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IBarChartConf): this {

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -71,7 +71,7 @@ export class BoxPlot extends CoordinateGridMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         const whiskerIqrFactor = 1.5;
         this._whiskers = defaultWhiskersIQR(whiskerIqrFactor);
@@ -104,8 +104,6 @@ export class BoxPlot extends CoordinateGridMixin {
 
         this.boxPadding(0.8);
         this.outerPadding(0.5);
-
-        this.anchor(parent);
     }
 
     public configure(conf: IBoxPlotConf): this {

--- a/src/charts/box-plot.ts
+++ b/src/charts/box-plot.ts
@@ -71,7 +71,7 @@ export class BoxPlot extends CoordinateGridMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         const whiskerIqrFactor = 1.5;
         this._whiskers = defaultWhiskersIQR(whiskerIqrFactor);
@@ -105,7 +105,7 @@ export class BoxPlot extends CoordinateGridMixin {
         this.boxPadding(0.8);
         this.outerPadding(0.5);
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IBoxPlotConf): this {

--- a/src/charts/bubble-chart.ts
+++ b/src/charts/bubble-chart.ts
@@ -42,7 +42,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             // TODO: move following two to Mixin, BubbleOverlay has exactly same setup
@@ -51,8 +51,6 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
         });
 
         this._bubbleLocator = d => `translate(${this._bubbleX(d)},${this._bubbleY(d)})`;
-
-        this.anchor(parent);
     }
 
     public plotData(): void {

--- a/src/charts/bubble-chart.ts
+++ b/src/charts/bubble-chart.ts
@@ -42,7 +42,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             // TODO: move following two to Mixin, BubbleOverlay has exactly same setup
@@ -52,7 +52,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
 
         this._bubbleLocator = d => `translate(${this._bubbleX(d)},${this._bubbleY(d)})`;
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public plotData(): void {

--- a/src/charts/bubble-overlay.ts
+++ b/src/charts/bubble-overlay.ts
@@ -45,7 +45,7 @@ export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             points: [],
@@ -72,7 +72,7 @@ export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
             radiusValueAccessor: d => d.value,
         });
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IBubbleOverlayConf): this {

--- a/src/charts/bubble-overlay.ts
+++ b/src/charts/bubble-overlay.ts
@@ -45,7 +45,7 @@ export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             points: [],
@@ -71,8 +71,6 @@ export class BubbleOverlay extends BubbleMixin(ColorMixin(BaseMixin)) {
             transitionDelay: 0,
             radiusValueAccessor: d => d.value,
         });
-
-        this.anchor(parent);
     }
 
     public configure(conf: IBubbleOverlayConf): this {

--- a/src/charts/cbox-menu.ts
+++ b/src/charts/cbox-menu.ts
@@ -43,7 +43,7 @@ export class CboxMenu extends BaseMixin {
      * Interaction with the widget will only trigger events and redraws within its group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             multiple: false,
@@ -57,7 +57,7 @@ export class CboxMenu extends BaseMixin {
 
         this._uniqueId = uniqueId();
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: ICboxMenuConf): this {

--- a/src/charts/cbox-menu.ts
+++ b/src/charts/cbox-menu.ts
@@ -43,7 +43,7 @@ export class CboxMenu extends BaseMixin {
      * Interaction with the widget will only trigger events and redraws within its group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             multiple: false,
@@ -56,8 +56,6 @@ export class CboxMenu extends BaseMixin {
         this._cbox = undefined;
 
         this._uniqueId = uniqueId();
-
-        this.anchor(parent);
     }
 
     public configure(conf: ICboxMenuConf): this {

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -48,7 +48,7 @@ export class CompositeChart extends CoordinateGridMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             transitionDuration: 500,
@@ -79,8 +79,6 @@ export class CompositeChart extends CoordinateGridMixin {
                 this._children[i].replaceFilter(this.filter());
             }
         });
-
-        this.anchor(parent);
     }
 
     public configure(conf: ICompositeChartConf): this {

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -48,7 +48,7 @@ export class CompositeChart extends CoordinateGridMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             transitionDuration: 500,
@@ -80,7 +80,7 @@ export class CompositeChart extends CoordinateGridMixin {
             }
         });
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: ICompositeChartConf): this {

--- a/src/charts/data-count.ts
+++ b/src/charts/data-count.ts
@@ -51,7 +51,7 @@ export class DataCount extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             formatNumber: format(',d'),
@@ -63,7 +63,7 @@ export class DataCount extends BaseMixin {
 
         this._mandatoryAttributes(['crossfilter', 'groupAll']);
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IDataCountConf): this {

--- a/src/charts/data-count.ts
+++ b/src/charts/data-count.ts
@@ -51,7 +51,7 @@ export class DataCount extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             formatNumber: format(',d'),
@@ -62,8 +62,6 @@ export class DataCount extends BaseMixin {
         this._groupAll = null;
 
         this._mandatoryAttributes(['crossfilter', 'groupAll']);
-
-        this.anchor(parent);
     }
 
     public configure(conf: IDataCountConf): this {

--- a/src/charts/data-grid.ts
+++ b/src/charts/data-grid.ts
@@ -35,7 +35,7 @@ export class DataGrid extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             section: null,
@@ -52,8 +52,6 @@ export class DataGrid extends BaseMixin {
         });
 
         this._mandatoryAttributes(['dimension', 'section']);
-
-        this.anchor(parent);
     }
 
     public configure(conf: IDataGridConf): this {

--- a/src/charts/data-grid.ts
+++ b/src/charts/data-grid.ts
@@ -35,7 +35,7 @@ export class DataGrid extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             section: null,
@@ -53,7 +53,7 @@ export class DataGrid extends BaseMixin {
 
         this._mandatoryAttributes(['dimension', 'section']);
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IDataGridConf): this {

--- a/src/charts/data-table.ts
+++ b/src/charts/data-table.ts
@@ -49,7 +49,7 @@ export class DataTable extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             size: 25,
@@ -63,8 +63,6 @@ export class DataTable extends BaseMixin {
         });
 
         this._mandatoryAttributes(['dimension']);
-
-        this.anchor(parent);
     }
 
     public configure(conf: IDataTableConf): this {

--- a/src/charts/data-table.ts
+++ b/src/charts/data-table.ts
@@ -49,7 +49,7 @@ export class DataTable extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             size: 25,
@@ -64,7 +64,7 @@ export class DataTable extends BaseMixin {
 
         this._mandatoryAttributes(['dimension']);
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IDataTableConf): this {

--- a/src/charts/geo-choropleth-chart.ts
+++ b/src/charts/geo-choropleth-chart.ts
@@ -42,7 +42,7 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             colorAccessor: d => d || 0,
@@ -52,8 +52,6 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
         this._geoPath = geoPath();
         this._projectionFlag = undefined;
         this._projection = undefined;
-
-        this.anchor(parent);
     }
 
     public configure(conf: IGeoChoroplethChartConf): this {

--- a/src/charts/geo-choropleth-chart.ts
+++ b/src/charts/geo-choropleth-chart.ts
@@ -42,7 +42,7 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             colorAccessor: d => d || 0,
@@ -53,7 +53,7 @@ export class GeoChoroplethChart extends ColorMixin(BaseMixin) {
         this._projectionFlag = undefined;
         this._projection = undefined;
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IGeoChoroplethChartConf): this {

--- a/src/charts/heat-map.ts
+++ b/src/charts/heat-map.ts
@@ -42,7 +42,7 @@ export class HeatMap extends ColorMixin(MarginMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             cols: undefined,
@@ -77,7 +77,7 @@ export class HeatMap extends ColorMixin(MarginMixin) {
 
         this._mandatoryAttributes(['group']);
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IHeatMapConf): this {

--- a/src/charts/heat-map.ts
+++ b/src/charts/heat-map.ts
@@ -42,7 +42,7 @@ export class HeatMap extends ColorMixin(MarginMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             cols: undefined,
@@ -76,8 +76,6 @@ export class HeatMap extends ColorMixin(MarginMixin) {
         this._rowScale = scaleBand();
 
         this._mandatoryAttributes(['group']);
-
-        this.anchor(parent);
     }
 
     public configure(conf: IHeatMapConf): this {

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -79,7 +79,7 @@ export class LineChart extends StackMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             transitionDuration: 500,
@@ -101,8 +101,6 @@ export class LineChart extends StackMixin {
         this._xyTipsOn = true;
 
         this._rangeBandPadding(1);
-
-        this.anchor(parent);
     }
 
     public plotData() {

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -79,7 +79,7 @@ export class LineChart extends StackMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             transitionDuration: 500,
@@ -102,7 +102,7 @@ export class LineChart extends StackMixin {
 
         this._rangeBandPadding(1);
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public plotData() {

--- a/src/charts/number-display.ts
+++ b/src/charts/number-display.ts
@@ -44,7 +44,7 @@ export class NumberDisplay extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             transitionDuration: 250, // good default
@@ -62,7 +62,7 @@ export class NumberDisplay extends BaseMixin {
         // dimension not required
         this._mandatoryAttributes(['group']);
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: INumberDisplayConf): this {

--- a/src/charts/number-display.ts
+++ b/src/charts/number-display.ts
@@ -80,7 +80,7 @@ export class NumberDisplay extends BaseMixin {
 
         const valObj = group.value ? group.value() : this._maxBin(group.all());
 
-        return this._dataProvider.conf().valueAccessor(valObj);
+        return this.dataProvider().conf().valueAccessor(valObj);
     }
 
     /**

--- a/src/charts/number-display.ts
+++ b/src/charts/number-display.ts
@@ -44,7 +44,7 @@ export class NumberDisplay extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             transitionDuration: 250, // good default
@@ -61,8 +61,6 @@ export class NumberDisplay extends BaseMixin {
 
         // dimension not required
         this._mandatoryAttributes(['group']);
-
-        this.anchor(parent);
     }
 
     public configure(conf: INumberDisplayConf): this {

--- a/src/charts/pie-chart.ts
+++ b/src/charts/pie-chart.ts
@@ -54,7 +54,7 @@ export class PieChart extends ColorMixin(BaseMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             colorAccessor: d => this._conf.keyAccessor(d),
@@ -85,8 +85,6 @@ export class PieChart extends ColorMixin(BaseMixin) {
         this._g = undefined;
         this._cx = undefined;
         this._cy = undefined;
-
-        this.anchor(parent);
     }
 
     public configure(conf: IPieChartConf): this {

--- a/src/charts/pie-chart.ts
+++ b/src/charts/pie-chart.ts
@@ -54,7 +54,7 @@ export class PieChart extends ColorMixin(BaseMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             colorAccessor: d => this._conf.keyAccessor(d),
@@ -86,7 +86,7 @@ export class PieChart extends ColorMixin(BaseMixin) {
         this._cx = undefined;
         this._cy = undefined;
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IPieChartConf): this {

--- a/src/charts/row-chart.ts
+++ b/src/charts/row-chart.ts
@@ -54,7 +54,7 @@ export class RowChart extends ColorMixin(MarginMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             label: d => this._conf.keyAccessor(d),
@@ -83,7 +83,7 @@ export class RowChart extends ColorMixin(MarginMixin) {
 
         this._rowData = undefined;
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IRowChartConf): this {

--- a/src/charts/row-chart.ts
+++ b/src/charts/row-chart.ts
@@ -54,7 +54,7 @@ export class RowChart extends ColorMixin(MarginMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             label: d => this._conf.keyAccessor(d),
@@ -82,8 +82,6 @@ export class RowChart extends ColorMixin(MarginMixin) {
         this._xAxis = axisBottom(undefined);
 
         this._rowData = undefined;
-
-        this.anchor(parent);
     }
 
     public configure(conf: IRowChartConf): this {

--- a/src/charts/scatter-plot.ts
+++ b/src/charts/scatter-plot.ts
@@ -505,9 +505,7 @@ export class ScatterPlot extends CoordinateGridMixin {
 
         this.redrawBrush(brushSelection, false);
 
-        const ranged2DFilter = brushIsEmpty
-            ? null
-            : new RangedTwoDimensionalFilter(brushSelection);
+        const ranged2DFilter = brushIsEmpty ? null : new RangedTwoDimensionalFilter(brushSelection);
 
         events.trigger(() => {
             this.replaceFilter(ranged2DFilter);

--- a/src/charts/scatter-plot.ts
+++ b/src/charts/scatter-plot.ts
@@ -44,7 +44,7 @@ export class ScatterPlot extends CoordinateGridMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         const originalKeyAccessor = this._conf.keyAccessor;
 
@@ -81,8 +81,6 @@ export class ScatterPlot extends CoordinateGridMixin {
         this.brush(brush());
 
         this._symbol.size((d, i) => this._elementSize(d, i));
-
-        this.anchor(parent);
     }
 
     public configure(conf: IScatterPlotConf): this {

--- a/src/charts/scatter-plot.ts
+++ b/src/charts/scatter-plot.ts
@@ -44,7 +44,7 @@ export class ScatterPlot extends CoordinateGridMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         const originalKeyAccessor = this._conf.keyAccessor;
 
@@ -82,7 +82,7 @@ export class ScatterPlot extends CoordinateGridMixin {
 
         this._symbol.size((d, i) => this._elementSize(d, i));
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: IScatterPlotConf): this {

--- a/src/charts/select-menu.ts
+++ b/src/charts/select-menu.ts
@@ -39,7 +39,7 @@ export class SelectMenu extends BaseMixin {
      * Interaction with the widget will only trigger events and redraws within its group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             multiple: false,
@@ -51,8 +51,6 @@ export class SelectMenu extends BaseMixin {
         });
 
         this._select = undefined;
-
-        this.anchor(parent);
     }
 
     public configure(conf: ISelectMenuConf): this {

--- a/src/charts/select-menu.ts
+++ b/src/charts/select-menu.ts
@@ -39,7 +39,7 @@ export class SelectMenu extends BaseMixin {
      * Interaction with the widget will only trigger events and redraws within its group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             multiple: false,
@@ -52,7 +52,7 @@ export class SelectMenu extends BaseMixin {
 
         this._select = undefined;
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: ISelectMenuConf): this {

--- a/src/charts/sunburst-chart.ts
+++ b/src/charts/sunburst-chart.ts
@@ -59,7 +59,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             colorAccessor: d => this._conf.keyAccessor(d),
@@ -87,7 +87,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
         this._cx = undefined;
         this._cy = undefined;
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: ISunburstChartConf): this {

--- a/src/charts/sunburst-chart.ts
+++ b/src/charts/sunburst-chart.ts
@@ -59,7 +59,7 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             colorAccessor: d => this._conf.keyAccessor(d),
@@ -86,8 +86,6 @@ export class SunburstChart extends ColorMixin(BaseMixin) {
         this._g = undefined;
         this._cx = undefined;
         this._cy = undefined;
-
-        this.anchor(parent);
     }
 
     public configure(conf: ISunburstChartConf): this {

--- a/src/charts/text-filter-widget.ts
+++ b/src/charts/text-filter-widget.ts
@@ -43,7 +43,7 @@ export class TextFilterWidget extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super(chartGroup);
+        super(parent, chartGroup);
 
         this.configure({
             placeHolder: 'search',
@@ -53,8 +53,6 @@ export class TextFilterWidget extends BaseMixin {
                 return d => this._conf.normalize(d).indexOf(query) !== -1;
             },
         });
-
-        this.anchor(parent);
     }
 
     public configure(conf: ITextFilterWidgetConf): this {

--- a/src/charts/text-filter-widget.ts
+++ b/src/charts/text-filter-widget.ts
@@ -43,7 +43,7 @@ export class TextFilterWidget extends BaseMixin {
      * Interaction with a chart will only trigger events and redraws within the chart's group.
      */
     constructor(parent: ChartParentType, chartGroup: ChartGroupType) {
-        super();
+        super(chartGroup);
 
         this.configure({
             placeHolder: 'search',
@@ -54,7 +54,7 @@ export class TextFilterWidget extends BaseMixin {
             },
         });
 
-        this.anchor(parent, chartGroup);
+        this.anchor(parent);
     }
 
     public configure(conf: ITextFilterWidgetConf): this {

--- a/src/compat/base/base-mixin.ts
+++ b/src/compat/base/base-mixin.ts
@@ -398,4 +398,4 @@ export function BaseMixinExt<TBase extends Constructor<BaseMixinNeo>>(Base: TBas
 
 export const BaseMixin = BaseMixinExt(BaseMixinNeo);
 
-export const baseMixin = () => new BaseMixin(undefined);
+export const baseMixin = (parent, chartGroup) => new BaseMixin(parent, chartGroup);

--- a/src/compat/base/base-mixin.ts
+++ b/src/compat/base/base-mixin.ts
@@ -398,4 +398,4 @@ export function BaseMixinExt<TBase extends Constructor<BaseMixinNeo>>(Base: TBas
 
 export const BaseMixin = BaseMixinExt(BaseMixinNeo);
 
-export const baseMixin = () => new BaseMixin();
+export const baseMixin = () => new BaseMixin(undefined);

--- a/src/compat/core/filters.ts
+++ b/src/compat/core/filters.ts
@@ -1,8 +1,8 @@
 import {
-    RangedFilter,
-    TwoDimensionalFilter,
-    RangedTwoDimensionalFilter,
     HierarchyFilter,
+    RangedFilter,
+    RangedTwoDimensionalFilter,
+    TwoDimensionalFilter,
 } from '../../core/filters/index';
 
 /**

--- a/src/core/filters/hierarchy-filter.ts
+++ b/src/core/filters/hierarchy-filter.ts
@@ -3,7 +3,7 @@ import { IFilter } from './i-filter';
 export class HierarchyFilter extends Array implements IFilter {
     public readonly filterType = 'HierarchyFilter';
 
-    constructor (path) {
+    constructor(path) {
         super();
 
         for (let i = 0; i < path.length; i++) {
@@ -11,7 +11,7 @@ export class HierarchyFilter extends Array implements IFilter {
         }
     }
 
-    public isFiltered (value): boolean {
+    public isFiltered(value): boolean {
         const filter = this;
 
         if (!(filter.length && value && value.length && value.length >= filter.length)) {

--- a/src/core/filters/i-filter.ts
+++ b/src/core/filters/i-filter.ts
@@ -1,4 +1,4 @@
 export interface IFilter {
     filterType: string;
-    isFiltered (value): boolean;
+    isFiltered(value): boolean;
 }

--- a/src/core/filters/ranged-filter.ts
+++ b/src/core/filters/ranged-filter.ts
@@ -3,13 +3,13 @@ import { IFilter } from './i-filter';
 export class RangedFilter<T> extends Array<T> implements IFilter {
     readonly filterType = 'RangedFilter';
 
-    constructor (low: T, high: T) {
+    constructor(low: T, high: T) {
         super();
         this[0] = low;
         this[1] = high;
     }
 
-    isFiltered (value: T): boolean {
+    isFiltered(value: T): boolean {
         return value >= this[0] && value < this[1];
     }
 }

--- a/src/core/filters/ranged-two-dimensional-filter.ts
+++ b/src/core/filters/ranged-two-dimensional-filter.ts
@@ -5,7 +5,7 @@ export class RangedTwoDimensionalFilter extends Array implements IFilter {
 
     private fromBottomLeft;
 
-    constructor (filter) {
+    constructor(filter) {
         super();
 
         for (let i = 0; i < filter.length; i++) {
@@ -15,17 +15,17 @@ export class RangedTwoDimensionalFilter extends Array implements IFilter {
         if (filter[0] instanceof Array) {
             this.fromBottomLeft = [
                 [Math.min(filter[0][0], filter[1][0]), Math.min(filter[0][1], filter[1][1])],
-                [Math.max(filter[0][0], filter[1][0]), Math.max(filter[0][1], filter[1][1])]
+                [Math.max(filter[0][0], filter[1][0]), Math.max(filter[0][1], filter[1][1])],
             ];
         } else {
             this.fromBottomLeft = [
                 [filter[0], -Infinity],
-                [filter[1], Infinity]
+                [filter[1], Infinity],
             ];
         }
     }
 
-    public isFiltered (value): boolean {
+    public isFiltered(value): boolean {
         let x;
         let y;
 

--- a/src/core/filters/two-dimensional-filter.ts
+++ b/src/core/filters/two-dimensional-filter.ts
@@ -3,13 +3,13 @@ import { IFilter } from './i-filter';
 export class TwoDimensionalFilter extends Array implements IFilter {
     public readonly filterType = 'TwoDimensionalFilter';
 
-    constructor (filter) {
+    constructor(filter) {
         super();
         this[0] = filter[0];
         this[1] = filter[1];
     }
 
-    public isFiltered (value) {
+    public isFiltered(value) {
         return (
             value.length &&
             value.length === this.length &&

--- a/src/data/c-f-filter-handler.ts
+++ b/src/data/c-f-filter-handler.ts
@@ -1,24 +1,12 @@
 import { MinimalCFDimension } from '../core/types';
+import { FilterHandler } from './filter-handler';
 
 export interface ICFFilterHandlerConf {
     dimension?: MinimalCFDimension;
 }
 
-export class CFFilterHandler {
-    private _filters: any[]; // TODO: find better types
-    get filters (): any[] {
-        return this._filters;
-    }
-
-    set filters (value: any[]) {
-        this._filters = value;
-    }
-
+export class CFFilterHandler extends FilterHandler {
     protected _conf: ICFFilterHandlerConf;
-
-    constructor() {
-        this.filters = [];
-    }
 
     public configure(conf: ICFFilterHandlerConf): this {
         this._conf = { ...this._conf, ...conf };
@@ -27,20 +15,6 @@ export class CFFilterHandler {
 
     public conf(): ICFFilterHandlerConf {
         return this._conf;
-    }
-
-    /**
-     * Check whether any active filter or a specific filter is associated with particular chart instance.
-     * This function is **not chainable**.
-     * @see {@link BaseMixin#hasFilterHandler hasFilterHandler}
-     * @param {*} [filter]
-     * @returns {Boolean}
-     */
-    public hasFilter(filter?): boolean {
-        if (filter === null || typeof filter === 'undefined') {
-            return this.filters.length > 0;
-        }
-        return this.filters.some(f => filter <= f && filter >= f);
     }
 
     public applyFilters() {
@@ -71,100 +45,5 @@ export class CFFilterHandler {
                 return false;
             });
         }
-    }
-
-    /**
-     * Filter the chart by the given parameter, or return the current filter if no input parameter
-     * is given.
-     *
-     * The filter parameter can take one of these forms:
-     * * A single value: the value will be toggled (added if it is not present in the current
-     * filters, removed if it is present)
-     * * An array containing a single array of values (`[[value,value,value]]`): each value is
-     * toggled
-     * * When appropriate for the chart, a {@link filters dc filter object} such as
-     *   * {@link filters.RangedFilter `filters.RangedFilter`} for the
-     * {@link CoordinateGridMixin CoordinateGridMixin} charts
-     *   * {@link filters.TwoDimensionalFilter `filters.TwoDimensionalFilter`} for the
-     * {@link HeatMap heat map}
-     *   * {@link filters.RangedTwoDimensionalFilter `filters.RangedTwoDimensionalFilter`}
-     * for the {@link ScatterPlot scatter plot}
-     * * `null`: the filter will be reset using the
-     * {@link BaseMixin#resetFilterHandler resetFilterHandler}
-     *
-     * Note that this is always a toggle (even when it doesn't make sense for the filter type). If
-     * you wish to replace the current filter, either call `chart.filter(null)` first - or it's more
-     * efficient to call {@link BaseMixin#replaceFilter `chart.replaceFilter(filter)`} instead.
-     *
-     * Each toggle is executed by checking if the value is already present using the
-     * {@link BaseMixin#hasFilterHandler hasFilterHandler}; if it is not present, it is added
-     * using the {@link BaseMixin#addFilterHandler addFilterHandler}; if it is already present,
-     * it is removed using the {@link BaseMixin#removeFilterHandler removeFilterHandler}.
-     *
-     * Once the filters array has been updated, the filters are applied to the
-     * crossfilter dimension, using the {@link BaseMixin#filterHandler filterHandler}.
-     *
-     * Once you have set the filters, call {@link BaseMixin#redrawGroup `chart.redrawGroup()`}
-     * (or {@link redrawAll `redrawAll()`}) to redraw the chart's group.
-     * @see {@link BaseMixin#addFilterHandler addFilterHandler}
-     * @see {@link BaseMixin#removeFilterHandler removeFilterHandler}
-     * @see {@link BaseMixin#resetFilterHandler resetFilterHandler}
-     * @see {@link BaseMixin#filterHandler filterHandler}
-     * @example
-     * // filter by a single string
-     * chart.filter('Sunday');
-     * // filter by a single age
-     * chart.filter(18);
-     * // filter by a set of states
-     * chart.filter([['MA', 'TX', 'ND', 'WA']]);
-     * // filter by range -- note the use of filters.RangedFilter, which is different
-     * // from the syntax for filtering a crossfilter dimension directly, dimension.filter([15,20])
-     * chart.filter(filters.RangedFilter(15,20));
-     * @param {*} [filter]
-     * @returns {BaseMixin}
-     */
-    public filter();
-    public filter(filter): this;
-    public filter(filter?) {
-        if (!arguments.length) {
-            return this.filters.length > 0 ? this.filters[0] : null;
-        }
-
-        if (filter === null) {
-            this.resetFilters();
-        } else if (
-            filter instanceof Array &&
-            filter[0] instanceof Array &&
-            !(filter as any).isFiltered
-        ) {
-            // list of filters
-            filter[0].forEach(f => this.toggleFilter(f));
-        } else {
-            this.toggleFilter(filter);
-        }
-
-        this.applyFilters();
-
-        return this;
-    }
-
-    public toggleFilter(filter) {
-        if (this.hasFilter(filter)) {
-            this.removeFilter(filter);
-        } else {
-            this.addFilter(filter);
-        }
-    }
-
-    public addFilter(f) {
-        this.filters.push(f);
-    }
-
-    public removeFilter(filter) {
-        this.filters = this.filters.filter(f => !(filter <= f && filter >= f));
-    }
-
-    public resetFilters() {
-        this.filters = [];
     }
 }

--- a/src/data/c-f-filter-handler.ts
+++ b/src/data/c-f-filter-handler.ts
@@ -5,11 +5,19 @@ export interface ICFFilterHandlerConf {
 }
 
 export class CFFilterHandler {
+    private _filters: any[]; // TODO: find better types
+    get filters (): any[] {
+        return this._filters;
+    }
+
+    set filters (value: any[]) {
+        this._filters = value;
+    }
+
     protected _conf: ICFFilterHandlerConf;
-    protected _filters: any[]; // TODO: find better types
 
     constructor() {
-        this._filters = [];
+        this.filters = [];
     }
 
     public configure(conf: ICFFilterHandlerConf): this {
@@ -30,9 +38,9 @@ export class CFFilterHandler {
      */
     public hasFilter(filter?): boolean {
         if (filter === null || typeof filter === 'undefined') {
-            return this._filters.length > 0;
+            return this.filters.length > 0;
         }
-        return this._filters.some(f => filter <= f && filter >= f);
+        return this.filters.some(f => filter <= f && filter >= f);
     }
 
     public applyFilters() {
@@ -40,18 +48,18 @@ export class CFFilterHandler {
             return;
         }
 
-        if (this._filters.length === 0) {
+        if (this.filters.length === 0) {
             this._conf.dimension.filter(null);
-        } else if (this._filters.length === 1 && !this._filters[0].isFiltered) {
+        } else if (this.filters.length === 1 && !this.filters[0].isFiltered) {
             // single value and not a function-based filter
-            this._conf.dimension.filterExact(this._filters[0]);
-        } else if (this._filters.length === 1 && this._filters[0].filterType === 'RangedFilter') {
+            this._conf.dimension.filterExact(this.filters[0]);
+        } else if (this.filters.length === 1 && this.filters[0].filterType === 'RangedFilter') {
             // single range-based filter
-            this._conf.dimension.filterRange(this._filters[0]);
+            this._conf.dimension.filterRange(this.filters[0]);
         } else {
             this._conf.dimension.filterFunction(d => {
-                for (let i = 0; i < this._filters.length; i++) {
-                    const filter = this._filters[i];
+                for (let i = 0; i < this.filters.length; i++) {
+                    const filter = this.filters[i];
                     if (filter.isFiltered) {
                         if (filter.isFiltered(d)) {
                             return true;
@@ -119,7 +127,7 @@ export class CFFilterHandler {
     public filter(filter): this;
     public filter(filter?) {
         if (!arguments.length) {
-            return this._filters.length > 0 ? this._filters[0] : null;
+            return this.filters.length > 0 ? this.filters[0] : null;
         }
 
         if (filter === null) {
@@ -149,24 +157,14 @@ export class CFFilterHandler {
     }
 
     public addFilter(f) {
-        this._filters.push(f);
+        this.filters.push(f);
     }
 
     public removeFilter(filter) {
-        this._filters = this._filters.filter(f => !(filter <= f && filter >= f));
+        this.filters = this.filters.filter(f => !(filter <= f && filter >= f));
     }
 
     public resetFilters() {
-        this._filters = [];
-    }
-
-    /**
-     * Returns all current filters. This method does not perform defensive cloning of the internal
-     * filter array before returning, therefore any modification of the returned array will effect the
-     * chart's internal filter storage.
-     * @returns {Array<*>}
-     */
-    public filters() {
-        return this._filters;
+        this.filters = [];
     }
 }

--- a/src/data/c-f-simple-adapter.ts
+++ b/src/data/c-f-simple-adapter.ts
@@ -29,7 +29,7 @@ export class CFSimpleAdapter extends CFFilterHandler {
 
     // TODO: better typing
     public data(): any {
-        let entities = this._conf.group.all();
+        const entities = this._conf.group.all();
 
         // create a two level deep copy defensively
         entities.map(val => ({ ...val }));

--- a/src/data/filter-handler.ts
+++ b/src/data/filter-handler.ts
@@ -1,14 +1,14 @@
 export class FilterHandler {
     private _filters: any[]; // TODO: find better types
-    get filters (): any[] {
+    get filters(): any[] {
         return this._filters;
     }
 
-    set filters (value: any[]) {
+    set filters(value: any[]) {
         this._filters = value;
     }
 
-    constructor () {
+    constructor() {
         this.filters = [];
     }
 
@@ -19,14 +19,14 @@ export class FilterHandler {
      * @param {*} [filter]
      * @returns {Boolean}
      */
-    public hasFilter (filter?): boolean {
+    public hasFilter(filter?): boolean {
         if (filter === null || typeof filter === 'undefined') {
             return this.filters.length > 0;
         }
         return this.filters.some(f => filter <= f && filter >= f);
     }
 
-    public applyFilters () {
+    public applyFilters() {
         // do nothing at this level, derived classes will actually implement it
     }
 
@@ -80,9 +80,9 @@ export class FilterHandler {
      * @param {*} [filter]
      * @returns {BaseMixin}
      */
-    public filter ();
-    public filter (filter): this;
-    public filter (filter?) {
+    public filter();
+    public filter(filter): this;
+    public filter(filter?) {
         if (!arguments.length) {
             return this.filters.length > 0 ? this.filters[0] : null;
         }
@@ -105,7 +105,7 @@ export class FilterHandler {
         return this;
     }
 
-    public toggleFilter (filter) {
+    public toggleFilter(filter) {
         if (this.hasFilter(filter)) {
             this.removeFilter(filter);
         } else {
@@ -113,15 +113,15 @@ export class FilterHandler {
         }
     }
 
-    public addFilter (f) {
+    public addFilter(f) {
         this.filters.push(f);
     }
 
-    public removeFilter (filter) {
+    public removeFilter(filter) {
         this.filters = this.filters.filter(f => !(filter <= f && filter >= f));
     }
 
-    public resetFilters () {
+    public resetFilters() {
         this.filters = [];
     }
 }

--- a/src/data/filter-handler.ts
+++ b/src/data/filter-handler.ts
@@ -1,0 +1,127 @@
+export class FilterHandler {
+    private _filters: any[]; // TODO: find better types
+    get filters (): any[] {
+        return this._filters;
+    }
+
+    set filters (value: any[]) {
+        this._filters = value;
+    }
+
+    constructor () {
+        this.filters = [];
+    }
+
+    /**
+     * Check whether any active filter or a specific filter is associated with particular chart instance.
+     * This function is **not chainable**.
+     * @see {@link BaseMixin#hasFilterHandler hasFilterHandler}
+     * @param {*} [filter]
+     * @returns {Boolean}
+     */
+    public hasFilter (filter?): boolean {
+        if (filter === null || typeof filter === 'undefined') {
+            return this.filters.length > 0;
+        }
+        return this.filters.some(f => filter <= f && filter >= f);
+    }
+
+    public applyFilters () {
+        // do nothing at this level, derived classes will actually implement it
+    }
+
+    /**
+     * Filter the chart by the given parameter, or return the current filter if no input parameter
+     * is given.
+     *
+     * The filter parameter can take one of these forms:
+     * * A single value: the value will be toggled (added if it is not present in the current
+     * filters, removed if it is present)
+     * * An array containing a single array of values (`[[value,value,value]]`): each value is
+     * toggled
+     * * When appropriate for the chart, a {@link filters dc filter object} such as
+     *   * {@link filters.RangedFilter `filters.RangedFilter`} for the
+     * {@link CoordinateGridMixin CoordinateGridMixin} charts
+     *   * {@link filters.TwoDimensionalFilter `filters.TwoDimensionalFilter`} for the
+     * {@link HeatMap heat map}
+     *   * {@link filters.RangedTwoDimensionalFilter `filters.RangedTwoDimensionalFilter`}
+     * for the {@link ScatterPlot scatter plot}
+     * * `null`: the filter will be reset using the
+     * {@link BaseMixin#resetFilterHandler resetFilterHandler}
+     *
+     * Note that this is always a toggle (even when it doesn't make sense for the filter type). If
+     * you wish to replace the current filter, either call `chart.filter(null)` first - or it's more
+     * efficient to call {@link BaseMixin#replaceFilter `chart.replaceFilter(filter)`} instead.
+     *
+     * Each toggle is executed by checking if the value is already present using the
+     * {@link BaseMixin#hasFilterHandler hasFilterHandler}; if it is not present, it is added
+     * using the {@link BaseMixin#addFilterHandler addFilterHandler}; if it is already present,
+     * it is removed using the {@link BaseMixin#removeFilterHandler removeFilterHandler}.
+     *
+     * Once the filters array has been updated, the filters are applied to the
+     * crossfilter dimension, using the {@link BaseMixin#filterHandler filterHandler}.
+     *
+     * Once you have set the filters, call {@link BaseMixin#redrawGroup `chart.redrawGroup()`}
+     * (or {@link redrawAll `redrawAll()`}) to redraw the chart's group.
+     * @see {@link BaseMixin#addFilterHandler addFilterHandler}
+     * @see {@link BaseMixin#removeFilterHandler removeFilterHandler}
+     * @see {@link BaseMixin#resetFilterHandler resetFilterHandler}
+     * @see {@link BaseMixin#filterHandler filterHandler}
+     * @example
+     * // filter by a single string
+     * chart.filter('Sunday');
+     * // filter by a single age
+     * chart.filter(18);
+     * // filter by a set of states
+     * chart.filter([['MA', 'TX', 'ND', 'WA']]);
+     * // filter by range -- note the use of filters.RangedFilter, which is different
+     * // from the syntax for filtering a crossfilter dimension directly, dimension.filter([15,20])
+     * chart.filter(filters.RangedFilter(15,20));
+     * @param {*} [filter]
+     * @returns {BaseMixin}
+     */
+    public filter ();
+    public filter (filter): this;
+    public filter (filter?) {
+        if (!arguments.length) {
+            return this.filters.length > 0 ? this.filters[0] : null;
+        }
+
+        if (filter === null) {
+            this.resetFilters();
+        } else if (
+            filter instanceof Array &&
+            filter[0] instanceof Array &&
+            !(filter as any).isFiltered
+        ) {
+            // list of filters
+            filter[0].forEach(f => this.toggleFilter(f));
+        } else {
+            this.toggleFilter(filter);
+        }
+
+        this.applyFilters();
+
+        return this;
+    }
+
+    public toggleFilter (filter) {
+        if (this.hasFilter(filter)) {
+            this.removeFilter(filter);
+        } else {
+            this.addFilter(filter);
+        }
+    }
+
+    public addFilter (f) {
+        this.filters.push(f);
+    }
+
+    public removeFilter (filter) {
+        this.filters = this.filters.filter(f => !(filter <= f && filter >= f));
+    }
+
+    public resetFilters () {
+        this.filters = [];
+    }
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -2,3 +2,4 @@ export * from './c-f-data-cap-helper';
 export * from './c-f-filter-handler';
 export * from './c-f-multi-adapter';
 export * from './c-f-simple-adapter';
+export * from './filter-handler';


### PR DESCRIPTION
Several housekeeping tasks, mostly mechanical to keep commits needed for #1777 and #1778 small.

- Shift call to anchor towards beginning of the BaseMixin constructor. This will allow chart gorup and anchor name be available sooner.
- Splitting Filter Handler into two layers - one having no dependency on CrossFilter.