### PR TITLE
Fix the cumulative line chart.

### DIFF
--- a/web-src/examples/pareto-chart.html
+++ b/web-src/examples/pareto-chart.html
@@ -86,6 +86,7 @@
         .yAxisLabel("The Y Axis")
         .legend(dc.legend().x(80).y(20).itemHeight(13).gap(5))
         .renderHorizontalGridLines(true)
+        .ordering(kv => -kv.value.value)
         .compose([
             dc.barChart(chart)
                 .dimension(dim_)

--- a/web-src/examples/scatter-series.html
+++ b/web-src/examples/scatter-series.html
@@ -47,7 +47,7 @@ d3.csv("morley.csv").then(function(experiments) {
     .elasticY(true)
     .dimension(runDimension)
     .group(runGroup)
-    .mouseZoomable(true)
+    .mouseZoomable(false)
     .shareTitle(false) // allow default scatter title to work
     .seriesAccessor(function(d) {return "Expt: " + d.key[0];})
     .keyAccessor(function(d) {return +d.key[1];})


### PR DESCRIPTION
It seems the cumulative line in the [Pareto chart example](http://dc-js.github.io/dc.js/examples/pareto-chart.html) is incorrect. Removing the sort in the fake group seems to fix it. Please review.