### PR TITLE
Fix Series Chart examples

### DIFF
--- a/src/base/i-base-mixin-conf.ts
+++ b/src/base/i-base-mixin-conf.ts
@@ -6,7 +6,6 @@ export interface IBaseMixinConf {
     readonly title?: TitleAccessor;
     readonly label?: LabelAccessor;
     readonly renderLabel?: boolean;
-    readonly groupName?: string;
     readonly commitHandler?: (render: boolean, callback: (error: any, result: any) => void) => void;
     readonly controlsUseVisibility?: boolean;
     readonly transitionDelay?: number;

--- a/src/charts/scatter-plot.ts
+++ b/src/charts/scatter-plot.ts
@@ -50,7 +50,7 @@ export class ScatterPlot extends CoordinateGridMixin {
 
         this.configure({
             keyAccessor: d => originalKeyAccessor(d)[0],
-            colorAccessor: () => this._conf.groupName,
+            colorAccessor: () => this.dataProvider().conf().groupName,
             existenceAccessor: d => d.value,
             // see https://github.com/dc-js/dc.js/issues/702
             title: d =>
@@ -410,7 +410,11 @@ export class ScatterPlot extends CoordinateGridMixin {
     public legendables(): LegendItem[] {
         // Argument to getColor is ignored by the default color accessor for this chart
         return [
-            { chart: this, name: this._conf.groupName, color: this.getColor(this._conf.groupName) },
+            {
+                chart: this,
+                name: this.dataProvider().conf().groupName,
+                color: this.getColor(this.dataProvider().conf().groupName),
+            },
         ];
     }
 

--- a/src/charts/series-chart.ts
+++ b/src/charts/series-chart.ts
@@ -98,15 +98,11 @@ export class SeriesChart extends CompositeChart {
             subChart.dataProvider().configure({
                 dimension: this.dataProvider().conf().dimension,
                 valueAccessor: this.dataProvider().conf().valueAccessor,
-                layers: [
-                    {
-                        name: sub.key,
-                        group: {
-                            all: typeof sub.values === 'function' ? sub.values : () => sub.values,
-                        },
-                    },
-                ],
-            } as ICFMultiAdapterConf);
+                groupName: sub.key,
+                group: {
+                    all: typeof sub.values === 'function' ? sub.values : () => sub.values,
+                },
+            });
             subChart.configure({
                 keyAccessor: this._conf.keyAccessor,
             });

--- a/src/compat/base/base-mixin.ts
+++ b/src/compat/base/base-mixin.ts
@@ -133,10 +133,7 @@ export function BaseMixinExt<TBase extends Constructor<BaseMixinNeo>>(Base: TBas
             if (!arguments.length) {
                 return this._dataProvider.conf().group;
             }
-            this._dataProvider.configure({ group });
-            this.configure({
-                groupName: name,
-            });
+            this._dataProvider.configure({ group, groupName: name });
             this.expireCache();
             return this;
         }

--- a/src/compat/base/stack-mixin.ts
+++ b/src/compat/base/stack-mixin.ts
@@ -4,7 +4,7 @@ import { StackMixin as StackMixinNeo } from '../../base/stack-mixin';
 import { MarginMixinExt } from './margin-mixin';
 import { ColorMixinExt } from './color-mixin';
 import { CoordinateGridMixinExt } from './coordinate-grid-mixin';
-import { LayerSpec } from '../../data';
+import { ICFMultiAdapterConf, LayerSpec } from '../../data';
 
 class Intermediate extends CoordinateGridMixinExt(MarginMixinExt(BaseMixinExt(StackMixinNeo))) {}
 
@@ -35,10 +35,11 @@ export function StackMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
         public stack();
         public stack(group, name?, accessor?): this;
         public stack(group?, name?, accessor?) {
-            const stack = this._dataProvider.layers();
             if (!arguments.length) {
-                return stack;
+                return this._dataProvider.layers();
             }
+
+            const stack = (this._dataProvider.conf() as ICFMultiAdapterConf).layers;
 
             if (arguments.length <= 2) {
                 accessor = name;
@@ -49,7 +50,7 @@ export function StackMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
             if (typeof accessor === 'function') {
                 layer.valueAccessor = accessor;
             }
-            // @ts-ignore
+
             stack.push(layer);
 
             return this;
@@ -67,7 +68,6 @@ export function StackMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
             this.configure({
                 titles: {},
             });
-            this.stack(g, n);
             if (f) {
                 this._dataProvider.configure({ valueAccessor: f });
             }

--- a/src/compat/base/stack-mixin.ts
+++ b/src/compat/base/stack-mixin.ts
@@ -102,7 +102,10 @@ export function StackMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
             if (typeof stackName === 'function') {
                 return super.title(stackName);
             }
-            if (stackName === this._conf.groupName && typeof titleAccessor === 'function') {
+            if (
+                stackName === this.dataProvider().conf().groupName &&
+                typeof titleAccessor === 'function'
+            ) {
                 return super.title(titleAccessor);
             }
 

--- a/src/data/c-f-multi-adapter.ts
+++ b/src/data/c-f-multi-adapter.ts
@@ -9,8 +9,6 @@ export interface LayerSpec {
 }
 
 export interface ICFMultiAdapterConf extends ICFSimpleAdapterConf {
-    readonly group?: MinimalCFGroup;
-    readonly valueAccessor?: ValueAccessor;
     readonly layers?: LayerSpec[];
 }
 
@@ -37,7 +35,8 @@ export class CFMultiAdapter extends CFSimpleAdapter {
     // TODO: better typing
     public data(): any {
         // Two level defensive copy
-        const layers: any[] = this._conf.layers.map(l => ({ ...l }));
+        const layers = this.layers().map(l => ({ ...l }));
+
         layers.forEach(layer => {
             const valueAccessor = layer.valueAccessor || this._conf.valueAccessor;
             // Two level defensive copy
@@ -50,11 +49,17 @@ export class CFMultiAdapter extends CFSimpleAdapter {
         return layers;
     }
 
-    public layers() {
+    public layers(): LayerSpec[] {
+        if (this._conf.group) {
+            // if a stack configuration includes a `group` as well, that become the first layer
+            const firstLayer = { name: this._conf.groupName, group: this._conf.group };
+
+            return [firstLayer].concat(this._conf.layers);
+        }
         return this._conf.layers;
     }
 
-    public layerByName(name: string) {
+    public layerByName(name: string): LayerSpec {
         return this._conf.layers.find(l => l.name === name);
     }
 }

--- a/src/data/c-f-simple-adapter.ts
+++ b/src/data/c-f-simple-adapter.ts
@@ -3,6 +3,7 @@ import { CFFilterHandler, ICFFilterHandlerConf } from './c-f-filter-handler';
 
 export interface ICFSimpleAdapterConf extends ICFFilterHandlerConf {
     readonly group?: MinimalCFGroup;
+    readonly groupName?: string;
     readonly valueAccessor?: ValueAccessor;
     readonly ordering?: BaseAccessor<any>;
 }


### PR DESCRIPTION
Before moving deeper into dimension related work, I wanted to ensure that related examples work. While going through these I realized that Series chart can be used in far more ways than what I had considered.

I had assumed, incorrectly, that only Stack based charts can be used as children in Series charts. The final solution that I came up with involves following:

- `groupName` is now part of dataProvider. Very few charts use it and ealier it was tangled with group and stack which is no longer the case.
- Updated CFMultiAdaptor to consider `group` as the first layer if it is set. This in my opinion gives best of the world. If someone wants to initialize just one layer, they can alternatily configure it like most of the other charts by setting the `group`. However if they want more than one layer they need to set `layers`. Unlike earlier, `group` is not mandatory.