### PR TITLE
Two rollup configurations, speeds up build/test cycles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -345,6 +345,9 @@ module.exports = function (grunt) {
             rollup: {
                 command: 'rollup --config',
             },
+            'rollup-full': {
+                command: 'rollup --config rollup-full.config.js',
+            },
             typedoc: {
                 command: 'typedoc src/index.ts',
             },

--- a/rollup-full.config.js
+++ b/rollup-full.config.js
@@ -1,0 +1,25 @@
+import { d3Modules, plugins, umdConf } from './rollup.config';
+import { terser } from 'rollup-plugin-terser';
+
+const umdMinConf = Object.assign({}, umdConf, {
+    file: 'dist/dc.min.js',
+    plugins: [terser()],
+});
+
+export default [
+    {
+        input: 'src/compat/index-compat.ts',
+        external: Object.keys(d3Modules),
+        plugins: plugins,
+        output: [umdConf, umdMinConf],
+    },
+    {
+        input: 'src/index-with-version.ts',
+        external: Object.keys(d3Modules),
+        plugins: plugins,
+        output: [
+            Object.assign({}, umdConf, { file: 'dist/dc-neo.js' }),
+            Object.assign({}, umdMinConf, { file: 'dist/dc-neo.min.js' }),
+        ],
+    },
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,3 @@
-import { terser } from 'rollup-plugin-terser';
 import json from '@rollup/plugin-json';
 import license from 'rollup-plugin-license';
 import typescript from 'rollup-plugin-typescript2';
@@ -13,7 +12,7 @@ const licensePlugin = license({
     },
 });
 
-const d3Modules = {
+export const d3Modules = {
     'd3-array': 'd3',
     'd3-axis': 'd3',
     'd3-brush': 'd3',
@@ -34,7 +33,7 @@ const d3Modules = {
     'd3-zoom': 'd3',
 };
 
-const umdConf = {
+export const umdConf = {
     file: 'dist/dc.js',
     format: 'umd',
     name: 'dc',
@@ -43,12 +42,7 @@ const umdConf = {
     paths: d3Modules,
 };
 
-const umdMinConf = Object.assign({}, umdConf, {
-    file: 'dist/dc.min.js',
-    plugins: [terser()],
-});
-
-const plugins = [
+export const plugins = [
     jsonPlugin,
     licensePlugin,
     typescript({
@@ -67,15 +61,6 @@ export default [
         input: 'src/compat/index-compat.ts',
         external: Object.keys(d3Modules),
         plugins: plugins,
-        output: [umdConf, umdMinConf],
-    },
-    {
-        input: 'src/index-with-version.ts',
-        external: Object.keys(d3Modules),
-        plugins: plugins,
-        output: [
-            Object.assign({}, umdConf, { file: 'dist/dc-neo.js' }),
-            Object.assign({}, umdMinConf, { file: 'dist/dc-neo.min.js' }),
-        ],
+        output: [umdConf],
     },
 ];


### PR DESCRIPTION
The current setup generates 2 x 2 outputs - compat/neo, full/terse. Out of these only one of those is needed for build/test and server tasks.

Separating this speeds up regulr build/test cycles. One more gurnt shell task has been added that would generate all the four outouts. This new tsak would need to be run as part of the release process.