### PR TITLE
Share Filters

### DIFF
--- a/spec/composite-chart-spec.js
+++ b/spec/composite-chart-spec.js
@@ -714,6 +714,8 @@ describe('dc.compositeChart', () => {
             lineDimension = data.dimension(d => +d.value);
             lineGroup = lineDimension.group();
 
+            chart.dataProvider().configure({ shareFilters: false });
+
             chart
                 .dimension(scatterDimension)
                 .group(scatterGroup)

--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -839,7 +839,6 @@ describe('dc.coordinateGridChart', () => {
         });
 
         it('range filter should execute filtered listener and zoom focus chart', () => {
-            spyOn(chart, 'focus').and.callThrough();
             const expectedCallbackSignature = function (callbackChart, callbackFilter) {
                 expect(callbackChart).toBe(rangeChart);
                 expect(callbackFilter).toEqual(selectedRange);
@@ -851,17 +850,13 @@ describe('dc.coordinateGridChart', () => {
             rangeChart.filter(selectedRange);
             expect(filteredCallback).toHaveBeenCalled();
 
-            expect(chart.focus).toHaveBeenCalled();
-            const focus = cleanDateRange(chart.focus.calls.argsFor(0)[0]);
-            expect(focus).toEqual(selectedRange);
+            expect(chart.x().domain()).toEqual(selectedRange);
         });
 
         it('should zoom the focus chart when range chart is brushed', () => {
-            spyOn(chart, 'focus').and.callThrough();
             simulateChartBrushing(rangeChart, selectedRange);
             jasmine.clock().tick(100);
-            const focus = cleanDateRange(chart.focus.calls.argsFor(0)[0]);
-            expect(focus).toEqual(selectedRange);
+            expect(chart.x().domain()).toEqual(selectedRange);
         });
 
         it('should zoom the focus chart back out when range chart is un-brushed', () => {

--- a/spec/coordinate-grid-chart-spec.js
+++ b/spec/coordinate-grid-chart-spec.js
@@ -790,10 +790,6 @@ describe('dc.coordinateGridChart', () => {
                     expect(dc.utils.arraysEqual(_chart.rangeChart().filter(), _chart.filter())).toEqual(true);
                 });
 
-                it('should trigger redraw on its range chart', () => {
-                    expect(_chart.rangeChart().redraw).toHaveBeenCalled();
-                });
-
                 it('should fire custom zoom listeners', () => {
                     expect(_zoomCallback).toHaveBeenCalled();
                 });
@@ -879,10 +875,9 @@ describe('dc.coordinateGridChart', () => {
         });
 
         it('should update the range chart brush to match zoomed domain of focus chart', () => {
-            spyOn(rangeChart, 'replaceFilter');
             chart.focus(selectedRange);
-            const replaceFilter = cleanDateRange(rangeChart.replaceFilter.calls.argsFor(0)[0]);
-            expect(replaceFilter).toEqual(selectedRange);
+            const filter = cleanDateRange(rangeChart.filter());
+            expect(filter).toEqual(selectedRange);
         });
     });
 

--- a/src/base/base-mixin.ts
+++ b/src/base/base-mixin.ts
@@ -136,7 +136,6 @@ export class BaseMixin {
             anchorName: this.anchorName(),
             filterStorage: this.chartGroup().filterStorage,
             onFiltersChanged: filter => this._filtersChanged(filter),
-            shareFilters: false,
         });
 
         return this;

--- a/src/charts/composite-chart.ts
+++ b/src/charts/composite-chart.ts
@@ -75,9 +75,12 @@ export class CompositeChart extends CoordinateGridMixin {
             // Propagate the filters onto the children
             // Notice that on children the call is .replaceFilter and not .filter
             //   the reason is that _chart.filter() returns the entire current set of filters not just the last added one
-            for (let i = 0; i < this._children.length; ++i) {
-                this._children[i].replaceFilter(this.filter());
-            }
+            this._children.forEach(child => {
+                // Go defensive - the shareFilter option may have already set the correct filters
+                if (child.filter() !== this.filter()) {
+                    child.replaceFilter(this.filter());
+                }
+            });
         });
     }
 
@@ -104,6 +107,7 @@ export class CompositeChart extends CoordinateGridMixin {
             if (!child.dataProvider().conf().group) {
                 child.dataProvider().configure({ group: this.dataProvider().conf().group });
             }
+            child.dataProvider().configure({ shareFilters: this.dataProvider().conf().shareFilters });
 
             child.configure({
                 xUnits: this._conf.xUnits,

--- a/src/compat/core/chart-registry.ts
+++ b/src/compat/core/chart-registry.ts
@@ -1,2 +1,3 @@
 export * from '../../core/chart-registry';
 export * from '../../core/chart-group';
+export * from '../../core/filter-storage';

--- a/src/core/chart-group-types.ts
+++ b/src/core/chart-group-types.ts
@@ -3,6 +3,7 @@ export interface IMinimalChart {
     redraw(): void;
     filterAll(): void;
     focus?(): void;
+    dispose?(): void;
 }
 
 export interface IChartGroup {
@@ -12,4 +13,14 @@ export interface IChartGroup {
     redrawAll(): void;
     filterAll(): void;
     refocusAll(): void;
+    filterStorage: IFilterStorage;
+}
+
+export interface IFilterStorage {
+    setFiltersFor(storageKey: any, filters);
+    getFiltersFor(storageKey: any);
+    registerFilterListener(storageKey: any, onFiltersChanged: (filters) => void): any;
+    deRegisterFilterListener(storageKey: any, listner: any): void;
+    notifyListeners(storageKey: any, filters): void;
+    deRegisterAll(): void;
 }

--- a/src/core/chart-group.ts
+++ b/src/core/chart-group.ts
@@ -1,10 +1,13 @@
-import { IChartGroup, IMinimalChart } from './chart-group-types';
+import { IChartGroup, IFilterStorage, IMinimalChart } from './chart-group-types';
+import { FilterStorage } from './filter-storage';
 
 export class ChartGroup implements IChartGroup {
     private _charts: IMinimalChart[];
+    public filterStorage: IFilterStorage;
 
     constructor() {
         this._charts = [];
+        this.filterStorage = new FilterStorage();
     }
 
     public list(): IMinimalChart[] {
@@ -20,6 +23,10 @@ export class ChartGroup implements IChartGroup {
     }
 
     public deregister(chart: IMinimalChart): void {
+        if (typeof chart.dispose === 'function') {
+            chart.dispose();
+        }
+
         this._charts = this._charts.filter(ch => ch !== chart);
     }
 

--- a/src/core/filter-storage.ts
+++ b/src/core/filter-storage.ts
@@ -1,0 +1,59 @@
+import { IFilterStorage } from './chart-group-types';
+
+export class FilterStorage implements IFilterStorage {
+    // Current filters
+    private _filters;
+
+    // List of listeners for each storage key
+    // Storage key will be dimension (id shareFilters is true) or the chart itself
+    private _listeners: Map<any, { onFiltersChanged: (filters) => void }[]>;
+
+    constructor() {
+        this._filters = new Map();
+        this._listeners = new Map();
+    }
+
+    public registerFilterListener(storageKey: any, onFiltersChanged: (filters) => void): any {
+        if (!(this._listeners.get(storageKey) && this._listeners.get(storageKey).length >= 0)) {
+            this._listeners.set(storageKey, []);
+        }
+        const listener = {
+            onFiltersChanged,
+            storageKey,
+        };
+        this._listeners.get(storageKey).push(listener);
+        return listener;
+    }
+
+    public deRegisterFilterListener(storageKey: any, listener: any): void {
+        // exclude this listener and retain the rest
+        let listeners = this._listeners.get(storageKey);
+        listeners = listeners.filter(l => l !== listener);
+        this._listeners.set(storageKey, listeners);
+    }
+
+    public deRegisterAll(): void {
+        this._filters = new Map();
+        this._listeners = new Map();
+    }
+
+    public notifyListeners(storageKey: any, filters) {
+        const listeners = this._listeners.get(storageKey);
+        listeners
+            .filter(l => typeof l.onFiltersChanged === 'function')
+            .forEach(l => {
+                l.onFiltersChanged(filters);
+            });
+    }
+
+    public setFiltersFor(storageKey: any, filters) {
+        this._filters.set(storageKey, filters);
+    }
+
+    public getFiltersFor(storageKey: any) {
+        if (!this._filters.get(storageKey)) {
+            this._filters.set(storageKey, []);
+        }
+        return this._filters.get(storageKey);
+    }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,6 +9,7 @@ export * from './constants';
 export * from './core';
 export * from './d3compat';
 export * from './events';
+export * from './filter-storage';
 export * from './invalid-state-exception';
 export * from './logger';
 export * from './printers';

--- a/src/data/c-f-simple-adapter.ts
+++ b/src/data/c-f-simple-adapter.ts
@@ -1,14 +1,14 @@
 import { BaseAccessor, MinimalCFGroup, ValueAccessor } from '../core/types';
-import { CFFilterHandler, ICFFilterHandlerConf } from './c-f-filter-handler';
+import { FilterStorageHelper, IFilterStorageConf } from './filter-storage-helper';
 
-export interface ICFSimpleAdapterConf extends ICFFilterHandlerConf {
+export interface ICFSimpleAdapterConf extends IFilterStorageConf {
     readonly group?: MinimalCFGroup;
     readonly groupName?: string;
     readonly valueAccessor?: ValueAccessor;
     readonly ordering?: BaseAccessor<any>;
 }
 
-export class CFSimpleAdapter extends CFFilterHandler {
+export class CFSimpleAdapter extends FilterStorageHelper {
     protected _conf: ICFSimpleAdapterConf;
 
     constructor() {

--- a/src/data/filter-handler.ts
+++ b/src/data/filter-handler.ts
@@ -1,15 +1,11 @@
 export class FilterHandler {
-    private _filters: any[]; // TODO: find better types
+    private _filters: any[] = []; // TODO: find better types
     get filters(): any[] {
         return this._filters;
     }
 
     set filters(value: any[]) {
         this._filters = value;
-    }
-
-    constructor() {
-        this.filters = [];
     }
 
     /**
@@ -102,8 +98,13 @@ export class FilterHandler {
 
         this.applyFilters();
 
+        this.notifyListeners(filter);
+
         return this;
     }
+
+    // Will be implemented in derived class
+    public notifyListeners(filter) {}
 
     public toggleFilter(filter) {
         if (this.hasFilter(filter)) {
@@ -123,5 +124,9 @@ export class FilterHandler {
 
     public resetFilters() {
         this.filters = [];
+    }
+
+    public dispose() {
+        // use this to cleanup before discarding
     }
 }

--- a/src/data/filter-storage-helper.ts
+++ b/src/data/filter-storage-helper.ts
@@ -12,6 +12,13 @@ export class FilterStorageHelper extends CFFilterHandler {
     private _listenerRegToken: any;
     protected _conf: IFilterStorageConf;
 
+    constructor() {
+        super();
+        this.configure({
+            shareFilters: true,
+        });
+    }
+
     public conf(): IFilterStorageConf {
         return super.conf();
     }

--- a/src/data/filter-storage-helper.ts
+++ b/src/data/filter-storage-helper.ts
@@ -1,0 +1,84 @@
+import { IFilterStorage } from '../core/chart-group-types';
+import { CFFilterHandler, ICFFilterHandlerConf } from './c-f-filter-handler';
+
+export interface IFilterStorageConf extends ICFFilterHandlerConf {
+    readonly filterStorage?: IFilterStorage;
+    readonly anchorName?: string;
+    readonly shareFilters?: boolean;
+    readonly onFiltersChanged?: (filters) => void;
+}
+
+export class FilterStorageHelper extends CFFilterHandler {
+    private _listenerRegToken: any;
+    protected _conf: IFilterStorageConf;
+
+    public conf(): IFilterStorageConf {
+        return super.conf();
+    }
+
+    public configure(conf: IFilterStorageConf): this {
+        super.configure(conf);
+        this._ensureListenerRegistered();
+        return this;
+    }
+
+    private _ensureListenerRegistered() {
+        if (!this._conf.filterStorage) {
+            return;
+        }
+
+        // If it was already registered, we check if the storage ky is still same
+        // in case that has changed we need to de-register and register afresh
+
+        const storageKey = this._storageKey();
+
+        if (this._listenerRegToken) {
+            if (this._listenerRegToken['storageKey'] === storageKey) {
+                // all good, storageKey has not changed
+                return;
+            }
+            // storageKey changed, de-register first
+            this._deRegisterListener();
+        }
+
+        this._listenerRegToken = this._conf.filterStorage.registerFilterListener(
+            storageKey,
+            this._conf.onFiltersChanged
+        );
+    }
+
+    private _deRegisterListener() {
+        this._conf.filterStorage.deRegisterFilterListener(
+            this._listenerRegToken['storageKey'],
+            this._listenerRegToken
+        );
+        this._listenerRegToken = undefined;
+    }
+
+    private _storageKey() {
+        if (this._conf.shareFilters) {
+            return this._conf.dimension;
+        } else {
+            return this;
+        }
+    }
+
+    get filters(): any[] {
+        return this._conf.filterStorage.getFiltersFor(this._storageKey());
+    }
+
+    set filters(value: any[]) {
+        this._conf.filterStorage.setFiltersFor(this._storageKey(), value);
+    }
+
+    public notifyListeners(filters) {
+        this._conf.filterStorage.notifyListeners(this._storageKey(), filters);
+    }
+
+    public dispose() {
+        super.dispose();
+        if (this._listenerRegToken) {
+            this._deRegisterListener();
+        }
+    }
+}


### PR DESCRIPTION
*This is still a preview.*

There is a structure to hold filter information by dimension. It is controlled by a flag `shareFilters`.

First round of work on Coordinate chart makes Range/Focus charts simpler. The filter information is already propagated, so, only the UI need to be updated. The current code in not final - I would do additional refactoring and cleanup.

Interesting observation - there is no special handling needed for Focus/Range. If we introduce a flag - say `autoFocus` - which causes the chart to focus when a filter is applied, we would not need to mark range/focus charts at all.

During this phase I realized that zoom acitivity on Focus chart need not cause a redraw on Range chart - just brush needs to be updated. This happens now and test cases have accordingly been updated.

I have checked with stocks example, which seem to be fine.

Tests in Composite charts are currently failing.