### PR TITLE
Concept of `autoFocus`, range/focus moved to the compat layer

### DIFF
--- a/web-src/examples/focus-dynamic-interval.html
+++ b/web-src/examples/focus-dynamic-interval.html
@@ -95,7 +95,7 @@
                 .group(choose_group(fullDomain))
                 .yAxisPadding(0.1)
                 .valueAccessor(kv => kv.value.total / kv.value.count)
-                .rangeChart(rangeChart)
+                .configure({autoFocus: true})
                 .x(d3.scaleTime().domain(fullDomain))
                 .xUnits(d3.timeDay)
                 .brushOn(false)

--- a/web-src/examples/range-series.html
+++ b/web-src/examples/range-series.html
@@ -49,7 +49,7 @@ d3.csv("morley.csv").then(function(experiments) {
     .dimension(runDimension)
     .group(runGroup)
     .mouseZoomable(true)
-    .rangeChart(overviewChart)
+    .configure({autoFocus: true})
     .seriesAccessor(function(d) {return "Expt: " + d.key[0];})
     .keyAccessor(function(d) {return +d.key[1];})
     .valueAccessor(function(d) {return +d.value - 500;})

--- a/web-src/stock.js
+++ b/web-src/stock.js
@@ -384,7 +384,7 @@ d3.csv('ndx.csv').then(data => {
         .dimension(moveMonths)
         .mouseZoomable(true)
     // Specify a "range chart" to link its brush extent with the zoom of the current "focus chart".
-        .rangeChart(volumeChart)
+        .configure({autoFocus: true})
         .x(d3.scaleTime().domain([new Date(1985, 0, 1), new Date(2012, 11, 31)]))
         .round(d3.timeMonth.round)
         .xUnits(d3.timeMonths)


### PR DESCRIPTION
After #1785, the code specific to range/focus charts had reduced drastically. It is actually possible to create a conf flag `autoFocus` that will cause the chart to focus if a filter is specified.

This is not exact earlier functionality, however, quite close - the earlier code was also checking the domain of the other chart and constraining based on that.

The multi-focus example now works without custom code.

I will not commit other examples as of now - those are just to test.