### PR TITLE
Fixed undefined this on SeriesChart redraw

### DIFF
--- a/src/charts/series-chart.js
+++ b/src/charts/series-chart.js
@@ -102,7 +102,7 @@ export class SeriesChart extends CompositeChart {
     }
 
     _resetChildren () {
-        Object.keys(this._charts).map(this._clearChart);
+        Object.keys(this._charts).map(this._clearChart.bind(this));
         this._charts = {};
     }
 


### PR DESCRIPTION
I had the following bug when redrawing a SeriesChart:
```
dc.js:12456 Uncaught TypeError: Cannot read property '_charts' of undefined
    at _clearChart (dc.js:12456)
    at Array.map (<anonymous>)
    at SeriesChart._resetChildren (dc.js:12463)
    at SeriesChart.chart (dc.js:12482)
    at showUpdatedChart (panel.js:35)
```
The issue is that passing `this._clearChart` to `map` like that makes it unbound, thus the need to bind it again to `this` to clear the issue.
I spent a good time looking for this issue online and have found nothing, so if I'm misguided in any way, let me know, thanks!
Nonetheless, this fix solves correctly my use case.