### PR TITLE
Stocks examples

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,7 +114,7 @@ module.exports = function (grunt) {
                     outfile: 'spec/index.html',
                     keepRunner: true,
                 },
-                src: ['dist/dc.js'],
+                src: ['dist/dc-compat.js'],
             },
         },
         karma: {
@@ -428,7 +428,7 @@ module.exports = function (grunt) {
     grunt.registerTask('build', [
         'shell:dist-clean',
         'shell:tsc',
-        'shell:rollup',
+        'shell:rollup-full',
         'sass',
         'cssmin',
     ]);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
             // JS code dependencies
             'spec/3rd-party/*.js',
             // Code to be tested
-            'dist/dc.js',
+            'dist/dc-compat.js',
             // Jasmine spec files
             'spec/*spec.js'
         ],

--- a/rollup-full.config.js
+++ b/rollup-full.config.js
@@ -8,18 +8,18 @@ const umdMinConf = Object.assign({}, umdConf, {
 
 export default [
     {
-        input: 'src/compat/index-compat.ts',
+        input: 'src/index-with-version.ts',
         external: Object.keys(d3Modules),
         plugins: plugins,
         output: [umdConf, umdMinConf],
     },
     {
-        input: 'src/index-with-version.ts',
+        input: 'src/compat/index-compat.ts',
         external: Object.keys(d3Modules),
         plugins: plugins,
         output: [
-            Object.assign({}, umdConf, { file: 'dist/dc-neo.js' }),
-            Object.assign({}, umdMinConf, { file: 'dist/dc-neo.min.js' }),
+            Object.assign({}, umdConf, { file: 'dist/dc-compat.js' }),
+            Object.assign({}, umdMinConf, { file: 'dist/dc-compat.min.js' }),
         ],
     },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,7 +58,7 @@ export const plugins = [
 
 export default [
     {
-        input: 'src/compat/index-compat.ts',
+        input: 'src/index-with-version.ts',
         external: Object.keys(d3Modules),
         plugins: plugins,
         output: [umdConf],

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -117,7 +117,7 @@ export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) 
          * @see {@link ColorScaleHelper}
          * @see {@link https://github.com/d3/d3-scale/}
          */
-        public scaledColors(scale: BaseAccessor<string>): this {
+        public colorScale(scale: BaseAccessor<string>): this {
             return this.colorHelper(new ColorScaleHelper(scale));
         }
 

--- a/src/base/color-mixin.ts
+++ b/src/base/color-mixin.ts
@@ -1,15 +1,18 @@
 import { extent } from 'd3-array';
 
 import { config } from '../core/config';
-import { Constructor, MinimalColorScale } from '../core/types';
+import { BaseAccessor, ColorAccessor, Constructor, MinimalColorScale } from '../core/types';
 import { IColorMixinConf } from './i-color-mixin-conf';
 import { AbstractColorHelper } from './colors/abstract-color-helper';
 import { ColorScaleHelper } from './colors/color-scale-helper';
 import { OrdinalColors } from './colors/ordinal-colors';
 import { IBaseMixinConf } from './i-base-mixin-conf';
+import { LinearColors } from './colors/linear-colors';
+import { ColorCalculator } from './colors/color-calculator';
 
 interface MinimalBase {
     configure(conf: IBaseMixinConf);
+
     data();
 }
 
@@ -58,6 +61,8 @@ export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) 
          * the underlying data element will be used to determine the color.
          * In most of the cases output of {@linkcode colorAccessor | colorAccessor(d, i)} will be used to determine the color.
          *
+         * Usually charts would used use one of
+         *
          * Different implementations of ColorAccessors provide different functionality:
          *
          * * {@link OrdinalColors} - this is the default. It needs fixed list of colors.
@@ -65,7 +70,7 @@ export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) 
          * * {@link ColorScaleHelper} - it allows any of {@link https://github.com/d3/d3-scale | d3-scales} to be used.
          *   {@link OrdinalColors} and {@link LinearColors} are specialization of this.
          * * {@link ColorCalculator} - It allows skipping {@link colorAccessor} while computing the color.
-         *   It ignores even if a {@link colorAccessor} is provided.
+         *   Even if a {@link colorAccessor} is provided, it will be ignored.
          *
          * ```
          * // TODO example
@@ -96,6 +101,68 @@ export function ColorMixin<TBase extends Constructor<MinimalBase>>(Base: TBase) 
          */
         public ordinalColors(colorList: string[]): this {
             this.colorHelper(new OrdinalColors(colorList));
+            return this;
+        }
+
+        /**
+         * Use any of d3 scales for color. This method is a shorthand for the following:
+         *
+         * ```
+         * chart.scaledColors(scale); // same as chart.colorHelper(new ColorScaleHelper(scale));
+         * ```
+         *
+         * Depending on type of scale, it will need eaither setting domain for the scale or
+         * compute it se per your data using {@linkcode calculateColorDomain}.
+         *
+         * @see {@link ColorScaleHelper}
+         * @see {@link https://github.com/d3/d3-scale/}
+         */
+        public scaledColors(scale: BaseAccessor<string>): this {
+            return this.colorHelper(new ColorScaleHelper(scale));
+        }
+
+        /**
+         * Convenience method to set the color scale to an Hcl interpolated linear scale with range `r`.
+         */
+        public linearColors(r: [string, string]): this {
+            this.colorHelper(new LinearColors(r));
+            return this;
+        }
+
+        /**
+         * Overrides the color selection algorithm, replacing it with a simple function.
+         *
+         * Normally colors will be determined by calling the `colorAccessor` to get a value, and then passing that
+         * value through the `colorScale`.
+         *
+         * But sometimes it is difficult to get a color scale to produce the desired effect. The `colorCalculator`
+         * takes the datum and index and returns a color directly.
+         */
+        public colorCalculator(): ColorAccessor;
+        public colorCalculator(colorCalculator: ColorAccessor): this;
+        public colorCalculator(colorCalculator?) {
+            if (!arguments.length) {
+                return this.colorHelper().getColor;
+            }
+            this.colorHelper(new ColorCalculator(colorCalculator));
+            return this;
+        }
+
+        /**
+         * Set or get the current domain for the color mapping function. The domain must be supplied as an
+         * array.
+         *
+         * Note: previously this method accepted a callback function. Instead you may use a custom scale
+         * set by {@link ColorMixin.colors .colors}.
+         */
+        public colorDomain(): string[];
+        public colorDomain(domain: string[]): this;
+        public colorDomain(domain?) {
+            const scale = (this.colorHelper() as ColorScaleHelper).colorScale as MinimalColorScale;
+            if (!arguments.length) {
+                return scale.domain();
+            }
+            scale.domain(domain);
             return this;
         }
 

--- a/src/charts/bubble-chart.ts
+++ b/src/charts/bubble-chart.ts
@@ -45,6 +45,7 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
             // TODO: move following two to Mixin, BubbleOverlay has exactly same setup
             transitionDuration: 750,
             transitionDelay: 0,
+            brushOn: false,
         });
 
         this._bubbleLocator = d => `translate(${this._bubbleX(d)},${this._bubbleY(d)})`;
@@ -134,20 +135,5 @@ export class BubbleChart extends BubbleMixin(CoordinateGridMixin) {
             y = 0;
         }
         return y;
-    }
-
-    /**
-     * @hidden
-     */
-    public renderBrush(): void {
-        // override default x axis brush from parent chart
-    }
-
-    /**
-     * @hidden
-     */
-    public redrawBrush(brushSelection: DCBrushSelection, doTransition: boolean): void {
-        // override default x axis brush from parent chart
-        this.fadeDeselectedArea(brushSelection);
     }
 }

--- a/src/charts/bubble-chart.ts
+++ b/src/charts/bubble-chart.ts
@@ -1,13 +1,7 @@
 import { BubbleMixin } from '../base/bubble-mixin';
 import { CoordinateGridMixin } from '../base/coordinate-grid-mixin';
 import { transition } from '../core/core';
-import {
-    BaseAccessor,
-    ChartGroupType,
-    ChartParentType,
-    DCBrushSelection,
-    SVGGElementSelection,
-} from '../core/types';
+import { BaseAccessor, ChartGroupType, ChartParentType, SVGGElementSelection } from '../core/types';
 import { adaptHandler } from '../core/d3compat';
 
 /**

--- a/src/charts/i-line-chart-conf.ts
+++ b/src/charts/i-line-chart-conf.ts
@@ -1,0 +1,6 @@
+import { IStackMixinConf } from '../base/i-stack-mixin-conf';
+
+export interface ILineChartConf extends IStackMixinConf {
+    readonly renderArea?: boolean;
+}
+

--- a/src/charts/i-line-chart-conf.ts
+++ b/src/charts/i-line-chart-conf.ts
@@ -3,4 +3,3 @@ import { IStackMixinConf } from '../base/i-stack-mixin-conf';
 export interface ILineChartConf extends IStackMixinConf {
     readonly renderArea?: boolean;
 }
-

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -100,7 +100,7 @@ export class LineChart extends StackMixin {
 
         this._rangeBandPadding(1);
     }
-    
+
     public configure(conf: ILineChartConf): this {
         super.configure(conf);
         return this;
@@ -109,7 +109,7 @@ export class LineChart extends StackMixin {
     public conf(): ILineChartConf {
         return this._conf;
     }
-    
+
     public plotData() {
         const chartBody: SVGGElementSelection = this.chartBodyG();
         let layersList = chartBody.select<SVGGElement>('g.stack-list');
@@ -287,7 +287,7 @@ export class LineChart extends StackMixin {
         if (!arguments.length) {
             return this._conf.renderArea;
         }
-        this.configure({renderArea: renderArea});
+        this.configure({ renderArea: renderArea });
         return this;
     }
 

--- a/src/charts/line-chart.ts
+++ b/src/charts/line-chart.ts
@@ -30,6 +30,7 @@ import {
     LegendItem,
     SVGGElementSelection,
 } from '../core/types';
+import { ILineChartConf } from './i-line-chart-conf';
 
 const DEFAULT_DOT_RADIUS = 5;
 const TOOLTIP_G_CLASS = 'dc-tooltip';
@@ -47,6 +48,8 @@ const LABEL_PADDING = 3;
  * - {@link http://dc-js.github.com/dc.js/crime/index.html | Canadian City Crime Stats}
  */
 export class LineChart extends StackMixin {
+    public _conf: ILineChartConf;
+
     private _renderArea: boolean;
     private _dotRadius: number;
     private _dataPointRadius: number;
@@ -81,9 +84,9 @@ export class LineChart extends StackMixin {
             transitionDelay: 0,
             label: d => printSingleValue(d.y0 + d.y),
             renderLabel: false,
+            renderArea: false,
         });
 
-        this._renderArea = false;
         this._dotRadius = DEFAULT_DOT_RADIUS;
         this._dataPointRadius = null;
         this._dataPointFillOpacity = DEFAULT_DOT_OPACITY;
@@ -97,7 +100,16 @@ export class LineChart extends StackMixin {
 
         this._rangeBandPadding(1);
     }
+    
+    public configure(conf: ILineChartConf): this {
+        super.configure(conf);
+        return this;
+    }
 
+    public conf(): ILineChartConf {
+        return this._conf;
+    }
+    
     public plotData() {
         const chartBody: SVGGElementSelection = this.chartBodyG();
         let layersList = chartBody.select<SVGGElement>('g.stack-list');
@@ -273,9 +285,9 @@ export class LineChart extends StackMixin {
     public renderArea(renderArea: boolean): this;
     public renderArea(renderArea?) {
         if (!arguments.length) {
-            return this._renderArea;
+            return this._conf.renderArea;
         }
-        this._renderArea = renderArea;
+        this.configure({renderArea: renderArea});
         return this;
     }
 
@@ -360,7 +372,7 @@ export class LineChart extends StackMixin {
     }
 
     private _drawArea(layersEnter: SVGGElementSelection, layers: SVGGElementSelection): void {
-        if (this._renderArea) {
+        if (this._conf.renderArea) {
             const _area = area()
                 .x((d: any) => this.x()(d.x)) // TODO: revisit later to put proper type
                 .y1((d: any) => this.y()(d.y + d.y0)) // TODO: revisit later to put proper type

--- a/src/charts/pie-chart.ts
+++ b/src/charts/pie-chart.ts
@@ -307,9 +307,7 @@ export class PieChart extends ColorMixin(BaseMixin) {
 
         const arc2 = arc()
             .outerRadius(
-                this._computedRadius -
-                    this._conf.externalRadiusPadding +
-                    this._conf.externalLabels
+                this._computedRadius - this._conf.externalRadiusPadding + this._conf.externalLabels
             )
             .innerRadius(this._computedRadius - this._conf.externalRadiusPadding);
         const tranNodes = transition(

--- a/src/compat/base/color-mixin.ts
+++ b/src/compat/base/color-mixin.ts
@@ -1,12 +1,9 @@
-import { BaseAccessor, ColorAccessor, Constructor, MinimalColorScale } from '../../core/types';
+import { BaseAccessor, ColorAccessor, Constructor } from '../../core/types';
 import { BaseMixinExt } from './base-mixin';
 import { ColorMixin as ColorMixinNeo } from '../../base/color-mixin';
 import { BaseMixin as BaseMixinNeo } from '../../base/base-mixin';
-import { ColorCalculator } from '../../base/colors/color-calculator';
 import { ColorScaleHelper } from '../../base/colors/color-scale-helper';
 import { scaleQuantize } from 'd3-scale';
-import { OrdinalColors } from '../../base/colors/ordinal-colors';
-import { LinearColors } from '../../base/colors/linear-colors';
 
 class Intermediate extends BaseMixinExt(ColorMixinNeo(BaseMixinNeo)) {}
 
@@ -33,25 +30,6 @@ export function ColorMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
                 return this._conf.colorAccessor;
             }
             this.configure({ colorAccessor: colorAccessor });
-            return this;
-        }
-
-        /**
-         * Overrides the color selection algorithm, replacing it with a simple function.
-         *
-         * Normally colors will be determined by calling the `colorAccessor` to get a value, and then passing that
-         * value through the `colorScale`.
-         *
-         * But sometimes it is difficult to get a color scale to produce the desired effect. The `colorCalculator`
-         * takes the datum and index and returns a color directly.
-         */
-        public colorCalculator(): ColorAccessor;
-        public colorCalculator(colorCalculator: ColorAccessor): this;
-        public colorCalculator(colorCalculator?) {
-            if (!arguments.length) {
-                return this.colorHelper().getColor;
-            }
-            this.colorHelper(new ColorCalculator(colorCalculator));
             return this;
         }
 
@@ -83,32 +61,6 @@ export function ColorMixinExt<TBase extends Constructor<Intermediate>>(Base: TBa
             }
 
             this.colorHelper(new ColorScaleHelper(newScale));
-            return this;
-        }
-
-        /**
-         * Convenience method to set the color scale to an Hcl interpolated linear scale with range `r`.
-         */
-        public linearColors(r: [string, string]): this {
-            this.colorHelper(new LinearColors(r));
-            return this;
-        }
-
-        /**
-         * Set or get the current domain for the color mapping function. The domain must be supplied as an
-         * array.
-         *
-         * Note: previously this method accepted a callback function. Instead you may use a custom scale
-         * set by {@link ColorMixin.colors .colors}.
-         */
-        public colorDomain(): string[];
-        public colorDomain(domain: string[]): this;
-        public colorDomain(domain?) {
-            const scale = (this.colorHelper() as ColorScaleHelper).colorScale as MinimalColorScale;
-            if (!arguments.length) {
-                return scale.domain();
-            }
-            scale.domain(domain);
             return this;
         }
     };

--- a/src/compat/base/colors/index.ts
+++ b/src/compat/base/colors/index.ts
@@ -1,0 +1,1 @@
+export * from '../../../base/colors/index';

--- a/src/compat/base/index.ts
+++ b/src/compat/base/index.ts
@@ -1,4 +1,5 @@
 export * from './d3.box';
+export * from './colors/index'
 
 export * from './base-mixin';
 export * from './bubble-mixin';

--- a/src/compat/base/index.ts
+++ b/src/compat/base/index.ts
@@ -1,5 +1,5 @@
 export * from './d3.box';
-export * from './colors/index'
+export * from './colors/index';
 
 export * from './base-mixin';
 export * from './bubble-mixin';

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,4 @@
 import { timeDay, timeHour, timeMinute, timeMonth, timeSecond, timeWeek, timeYear } from 'd3-time';
-import { format } from 'd3-format';
 
 import { constants } from './constants';
 import { config } from './config';

--- a/web-src/stock.js
+++ b/web-src/stock.js
@@ -253,7 +253,7 @@ d3.csv('ndx.csv').then(data => {
         .margins({ top: 10, right: 50, bottom: 30, left: 40 })
         // (_optional_) define color function or array for bubbles: [ColorBrewer](http://colorbrewer2.org/)
         // (optional) define color domain to match your data domain if you want to bind data or color
-        .scaledColors(new d3.scaleQuantize(d3.schemeRdYlGn[9]).domain([-500, 500]))
+        .colorScale(new d3.scaleQuantize(d3.schemeRdYlGn[9]).domain([-500, 500]))
 
         //Accessor functions are applied to each value returned by the grouping
         .x(d3.scaleLinear().domain([-2500, 2500]))

--- a/web-src/stock.js
+++ b/web-src/stock.js
@@ -194,6 +194,9 @@ d3.csv('ndx.csv').then(data => {
         .configure({
             // (_optional_) define chart transition duration, `default = 750`
             transitionDuration: 1500,
+
+            //##### Accessors
+
             // `.colorAccessor` - the returned value will be passed to the `.colors()` scale to determine a fill color
             colorAccessor: d => d.value.absGain,
             // `.keyAccessor` - the `X` value will be passed to the `.x()` scale to determine pixel location
@@ -201,22 +204,26 @@ d3.csv('ndx.csv').then(data => {
             // `.radiusValueAccessor` - the value will be passed to the `.r()` scale to determine radius size;
             //   by default this maps linearly to [0,100]
             radiusValueAccessor: p => p.value.fluctuationPercentage,
+
             maxBubbleRelativeSize: 0.3,
+
             //`.elasticY` and `.elasticX` determine whether the chart should rescale each axis to fit the data.
             elasticY: true,
             elasticX: true,
+
             //`.yAxisPadding` and `.xAxisPadding` add padding to data above and below their max values in the same unit
             //domains as the Accessors.
             yAxisPadding: 100,
             xAxisPadding: 500,
+
             // (_optional_) render horizontal grid lines, `default=false`
             renderHorizontalGridLines: true,
             // (_optional_) render vertical grid lines, `default=false`
             renderVerticalGridLines: true,
-            //Labels are displayed on the chart for each bubble. Titles displayed on mouseover.
-            // (_optional_) whether chart should render labels, `default = true`
 
             //##### Labels and  Titles
+            //Labels are displayed on the chart for each bubble. Titles displayed on mouseover.
+            // (_optional_) whether chart should render labels, `default = true`
             renderLabel: true,
             label: p => p.key,
             // (_optional_) whether chart should render titles, `default = false`
@@ -246,10 +253,7 @@ d3.csv('ndx.csv').then(data => {
         .margins({ top: 10, right: 50, bottom: 30, left: 40 })
         // (_optional_) define color function or array for bubbles: [ColorBrewer](http://colorbrewer2.org/)
         // (optional) define color domain to match your data domain if you want to bind data or color
-        .colorHelper(
-            new dc.ColorScaleHelper(new d3.scaleQuantize(d3.schemeRdYlGn[9]).domain([-500, 500]))
-        )
-        //##### Accessors
+        .scaledColors(new d3.scaleQuantize(d3.schemeRdYlGn[9]).domain([-500, 500]))
 
         //Accessor functions are applied to each value returned by the grouping
         .x(d3.scaleLinear().domain([-2500, 2500]))
@@ -262,12 +266,11 @@ d3.csv('ndx.csv').then(data => {
         // (_optional_) render a vertical axis lable left of the y axis
         .yAxisLabel('Index Gain %');
 
-        //#### Customize Axes
+    //#### Customize Axes
 
-        // Set a custom tick format. Both `.yAxis()` and `.xAxis()` return an axis object,
-        // so any additional method chaining applies to the axis, not the chart.
-    yearlyBubbleChart        .yAxis()
-        .tickFormat(v => `${v}%`);
+    // Set a custom tick format. Both `.yAxis()` and `.xAxis()` return an axis object,
+    // so any additional method chaining applies to the axis, not the chart.
+    yearlyBubbleChart.yAxis().tickFormat(v => `${v}%`);
 
     // #### Pie/Donut Charts
 
@@ -417,11 +420,11 @@ d3.csv('ndx.csv').then(data => {
             renderHorizontalGridLines: true,
             xUnits: d3.timeMonths,
 
-            // Switching off brush, switching on autoFocus, and making mouseZoomable makes it a Focus chart 
+            // Switching off brush, switching on autoFocus, and making mouseZoomable makes it a Focus chart
             mouseZoomable: true,
             autoFocus: true,
             brushOn: false,
-            
+
             // Title can be called by any stack layer.
             title: d => {
                 let value = d.value.avg ? d.value.avg : d.value;


### PR DESCRIPTION
Following are the changes:

- The default dc.js is without compact code, the other one is named dc-compat.js
- The test cases use dc-compat.js
- The stocks example is updated to use the newer syntax
- Some missing items were realized during this conversion (as separate commits).

In general, the newer syntax looks alright. The color scale setting in the case of Bubble Chart seems quite clumsy, I guess I will add suitable methods to the color mixin.

Based on your feedback, I will update other samples.