### PR TITLE
update legend text y calculation #1855 & #1852

### DIFF
--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -322,7 +322,8 @@ export class Legend {
                 .classed('dc-tabbable', this._keyboardAccessible)
                 .attr('x', self._itemHeight + LABEL_GAP)
                 .attr('y', function () {
-                    return self._itemHeight / 2 + (this.clientHeight ? this.clientHeight : 13) / 2 - 2;
+                    const height = this.getBoundingClientRect ? (this.getBoundingClientRect().height) : this.clientHeight
+                    return self._itemHeight / 2 + (height || 13) / 2 - 2;
                 });
 
             if (this._keyboardAccessible) {


### PR DESCRIPTION
After reading about these two issues, I was investigating the cause of this and found that on chrome the `clientHeight` was returning a much smaller value than `getBoundingClientRect().height` which was returning more consistent results across environments for me.

Please let me know if there are any issues with the code here so I can adjust accordingly.