### PR TITLE
fix: limited crossfilter2 dependecy to 1.4.x (#1862)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1513,9 +1513,9 @@
       }
     },
     "crossfilter2": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/crossfilter2/-/crossfilter2-1.4.6.tgz",
-      "integrity": "sha512-Fdmb6NqdUqreOuQ9qiNvTLOxMFBQRPDeRBBnqM8Zlebdf2i7Bn5hRhE8RlO9YzbGRyYxvYzdDXt6C1muyanolg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/crossfilter2/-/crossfilter2-1.4.8.tgz",
+      "integrity": "sha512-H3D2AyRGpRYK0pKs6kgwALuNb3J6/PuW/sIckPDxPi2wz+TX1Cp/1+BC7sKkMUF12RGPjV/PNANF/W4TQ+4BLg==",
       "requires": {
         "lodash.result": "^4.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/dc-js/dc.js.git"
   },
   "dependencies": {
-    "crossfilter2": "^1.4.6",
+    "crossfilter2": "~1.4.8",
     "d3": "^3"
   },
   "devDependencies": {


### PR DESCRIPTION
Since _crossfilter2 1.5_ breaks compatibility by removing _quicksort_ function, we need to limit dependency to 1.4.x version.
See #1862 for details