### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/api-latest.md
+++ b/docs/api-latest.md
@@ -2982,7 +2982,7 @@ Turn on/off Title label rendering (values) using SVG style of text-anchor 'end'.
 ### rowChart.xAxis([xAxis]) ⇒ <code>d3.axis</code> \| [<code>RowChart</code>](#RowChart)
 Get or sets the x axis for the row chart instance.
 See the [d3.axis](https://github.com/d3/d3-axis/blob/master/README.md)
-documention for more information.
+documentation for more information.
 
 **Kind**: instance method of [<code>RowChart</code>](#RowChart)  
 

--- a/docs/old-api-docs/api-2.0.0.md
+++ b/docs/old-api-docs/api-2.0.0.md
@@ -1872,7 +1872,7 @@ Turn on/off Title label rendering (values) using SVG style of text-anchor 'end'.
 #### rowChart.xAxis() ⇒ <code>d3.svg.axis</code>
 Get the x axis for the row chart instance.  Note: not settable for row charts.
 See the [d3 axis object](https://github.com/d3/d3-3.x-api-reference/blob/master/SVG-Axes.md#axis)
-documention for more information.
+documentation for more information.
 
 **Kind**: instance method of <code>[rowChart](#dc.rowChart)</code>  
 **See**: [d3.svg.axis](https://github.com/d3/d3-3.x-api-reference/blob/master/SVG-Axes.md#axis)  

--- a/docs/old-api-docs/api-2.1.0.md
+++ b/docs/old-api-docs/api-2.1.0.md
@@ -1884,7 +1884,7 @@ Turn on/off Title label rendering (values) using SVG style of text-anchor 'end'.
 #### rowChart.xAxis() ⇒ <code>d3.svg.axis</code>
 Get the x axis for the row chart instance.  Note: not settable for row charts.
 See the [d3 axis object](https://github.com/d3/d3-3.x-api-reference/blob/master/SVG-Axes.md#axis)
-documention for more information.
+documentation for more information.
 
 **Kind**: instance method of [<code>rowChart</code>](#dc.rowChart)  
 **See**: [d3.svg.axis](https://github.com/d3/d3-3.x-api-reference/blob/master/SVG-Axes.md#axis)  

--- a/docs/old-api-docs/api-3.1.9.md
+++ b/docs/old-api-docs/api-3.1.9.md
@@ -2332,7 +2332,7 @@ Turn on/off Title label rendering (values) using SVG style of text-anchor 'end'.
 #### rowChart.xAxis([xAxis]) ⇒ <code>d3.axis</code> \| [<code>rowChart</code>](#dc.rowChart)
 Get or sets the x axis for the row chart instance.
 See the [d3.axis](https://github.com/d3/d3-axis/blob/master/README.md)
-documention for more information.
+documentation for more information.
 
 **Kind**: instance method of [<code>rowChart</code>](#dc.rowChart)  
 

--- a/src/base/base-mixin.js
+++ b/src/base/base-mixin.js
@@ -724,7 +724,7 @@ export class BaseMixin {
                 
         if (onClickFunction) {
             tabElements.on('keydown', d3compat.eventHandler((d, event) => {
-                // trigger only if d is an object undestood by KeyAccessor()
+                // trigger only if d is an object understood by KeyAccessor()
                 if (event.keyCode === 13 && typeof d === 'object') {
                     onClickFunction.call(this, d, ...onClickArgs)
                 } 

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -285,7 +285,7 @@ export class RowChart extends CapMixin(ColorMixin(MarginMixin)) {
     /**
      * Get or sets the x axis for the row chart instance.
      * See the {@link https://github.com/d3/d3-axis/blob/master/README.md d3.axis}
-     * documention for more information.
+     * documentation for more information.
      * @param {d3.axis} [xAxis]
      * @example
      * // customize x axis tick format

--- a/web-src/stock.js
+++ b/web-src/stock.js
@@ -395,7 +395,7 @@ d3.csv('ndx.csv').then(data => {
         // The `.valueAccessor` will be used for the base layer
         .group(indexAvgByMonthGroup, 'Monthly Index Average')
         .valueAccessor(d => d.value.avg)
-        // Stack additional layers with `.stack`. The first paramenter is a new group.
+        // Stack additional layers with `.stack`. The first parameter is a new group.
         // The second parameter is the series name. The third is a value accessor.
         .stack(monthlyMoveGroup, 'Monthly Index Move', d => d.value)
         // Title can be called by any stack layer.


### PR DESCRIPTION
There are small typos in:
- docs/api-latest.md
- docs/old-api-docs/api-2.0.0.md
- docs/old-api-docs/api-2.1.0.md
- docs/old-api-docs/api-3.1.9.md
- src/base/base-mixin.js
- src/charts/row-chart.js
- web-src/stock.js

Fixes:
- Should read `documentation` rather than `documention`.
- Should read `understood` rather than `undestood`.
- Should read `parameter` rather than `paramenter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md