### PR TITLE
Update row-chart row class to '_row'

### DIFF
--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -46,7 +46,7 @@ export class RowChart extends CapMixin(ColorMixin(MarginMixin)) {
         this._gap = 5;
 
         this._fixedBarHeight = false;
-        this._rowCssClass = 'row';
+        this._rowCssClass = '_row';
         this._titleRowCssClass = 'titlerow';
         this._renderTitleLabel = false;
 


### PR DESCRIPTION
Changing the row identifier class to '_row' in order not to collide with bootstrap's 'row'