### PR TITLE
Expose css files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
     "prepublishOnly": "npm run build && npm run css && npm run karmaChrome"
   },
   "browser": "dist/dc.js",
-  "exports": "./dist/esm6/index.js",
+  "exports": {
+    ".": "./dist/esm6/index.js",
+    "./dist/style/*.css": "./dist/style/*.css"
+  },
   "main": "./dist/esm6/index.js",
   "type": "module",
   "typings": "index.d.ts"


### PR DESCRIPTION
On dc `5.0.0-alpha5`:

```js
import 'dc/dist/style/dc.min.css';
```

raises the following issue:

```
× Package subpath './dist/style/dc.min.css' is not defined by "exports" in node_modules/dc/package.json
```